### PR TITLE
Make demo self-contained and replicable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,43 @@
+# Shared Langfuse environment variables (used by both worker and web)
+x-langfuse-common-env: &langfuse-common-env
+  NODE_ENV: production
+  DATABASE_URL: postgresql://langfuse:langfuse@langfuse-postgres:5432/langfuse
+  REDIS_CONNECTION_STRING: redis://langfuse-redis:6379
+  # ClickHouse configuration (required for v3)
+  CLICKHOUSE_URL: http://langfuse-clickhouse:8123
+  CLICKHOUSE_MIGRATION_URL: clickhouse://langfuse-clickhouse:9000
+  CLICKHOUSE_USER: langfuse
+  CLICKHOUSE_PASSWORD: langfuse123
+  CLICKHOUSE_CLUSTER_ENABLED: "false"
+  # S3/MinIO configuration
+  LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse-events
+  LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse-media
+  LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+  LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+  LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: langfuse
+  LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: langfuse123
+  LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: langfuse
+  LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: langfuse123
+  LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+  LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+  LANGFUSE_S3_EVENT_UPLOAD_REGION: us-east-1
+  LANGFUSE_S3_MEDIA_UPLOAD_REGION: us-east-1
+  # Auth secrets (change in production!)
+  NEXTAUTH_URL: http://localhost:${LANGFUSE_PORT:-3001}
+  NEXTAUTH_SECRET: langfuse-nextauth-secret-min-32-chars
+  SALT: langfuse-salt-min-32-characters-here
+  ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+  # Headless initialization (idempotent - only creates if not exists)
+  LANGFUSE_INIT_ORG_ID: demo-org
+  LANGFUSE_INIT_ORG_NAME: Demo Organization
+  LANGFUSE_INIT_PROJECT_ID: demo-project
+  LANGFUSE_INIT_PROJECT_NAME: LLM Observability Demo
+  LANGFUSE_INIT_PROJECT_PUBLIC_KEY: pk-lf-1234567890
+  LANGFUSE_INIT_PROJECT_SECRET_KEY: sk-lf-1234567890
+  LANGFUSE_INIT_USER_EMAIL: demo@localhost
+  LANGFUSE_INIT_USER_NAME: Demo User
+  LANGFUSE_INIT_USER_PASSWORD: demodemo1!
+
 services:
   # LibreChat API
   api:
@@ -51,7 +91,7 @@ services:
 
   # MongoDB database
   mongodb:
-    image: mongo:latest
+    image: mongo:7
     container_name: librechat-mongodb
     restart: always
     volumes:
@@ -143,6 +183,7 @@ services:
       - demo
     volumes:
       - ./vector-rag:/app
+      - vector-rag-models:/root/.cache
 
   # =============================================================================
   # Test Scenarios - Export synthetic conversations for evaluation demos
@@ -214,7 +255,7 @@ services:
 
   # MinIO for S3-compatible blob storage
   langfuse-minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2024-12-18T13-15-44Z
     container_name: langfuse-minio
     restart: unless-stopped
     profiles:
@@ -250,7 +291,7 @@ services:
 
   # ClickHouse for Langfuse v3 OLAP storage
   langfuse-clickhouse:
-    image: clickhouse/clickhouse-server:latest
+    image: clickhouse/clickhouse-server:24.8
     container_name: langfuse-clickhouse
     restart: unless-stopped
     profiles:
@@ -288,43 +329,7 @@ services:
       langfuse-minio-init:
         condition: service_completed_successfully
     environment:
-      - NODE_ENV=production
-      - DATABASE_URL=postgresql://langfuse:langfuse@langfuse-postgres:5432/langfuse
-      - REDIS_CONNECTION_STRING=redis://langfuse-redis:6379
-      # ClickHouse configuration (required for v3)
-      - CLICKHOUSE_URL=http://langfuse-clickhouse:8123
-      - CLICKHOUSE_MIGRATION_URL=clickhouse://langfuse-clickhouse:9000
-      - CLICKHOUSE_USER=langfuse
-      - CLICKHOUSE_PASSWORD=langfuse123
-      - CLICKHOUSE_CLUSTER_ENABLED=false
-      # S3/MinIO configuration
-      - LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse-events
-      - LANGFUSE_S3_MEDIA_UPLOAD_BUCKET=langfuse-media
-      - LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://langfuse-minio:9000
-      - LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT=http://langfuse-minio:9000
-      - LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID=langfuse
-      - LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=langfuse123
-      - LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID=langfuse
-      - LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY=langfuse123
-      - LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE=true
-      - LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE=true
-      - LANGFUSE_S3_EVENT_UPLOAD_REGION=us-east-1
-      - LANGFUSE_S3_MEDIA_UPLOAD_REGION=us-east-1
-      # Auth secrets (change in production!)
-      - NEXTAUTH_URL=http://localhost:${LANGFUSE_PORT:-3001}
-      - NEXTAUTH_SECRET=langfuse-nextauth-secret-min-32-chars
-      - SALT=langfuse-salt-min-32-characters-here
-      - ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
-      # Headless initialization (idempotent - only creates if not exists)
-      - LANGFUSE_INIT_ORG_ID=demo-org
-      - LANGFUSE_INIT_ORG_NAME=Demo Organization
-      - LANGFUSE_INIT_PROJECT_ID=demo-project
-      - LANGFUSE_INIT_PROJECT_NAME=LLM Observability Demo
-      - LANGFUSE_INIT_PROJECT_PUBLIC_KEY=pk-lf-1234567890
-      - LANGFUSE_INIT_PROJECT_SECRET_KEY=sk-lf-1234567890
-      - LANGFUSE_INIT_USER_EMAIL=demo@localhost
-      - LANGFUSE_INIT_USER_NAME=Demo User
-      - LANGFUSE_INIT_USER_PASSWORD=demodemo1!
+      <<: *langfuse-common-env
 
   # Langfuse Web (UI and API)
   langfuse-web:
@@ -338,47 +343,19 @@ services:
     depends_on:
       langfuse-worker:
         condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/api/public/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
     environment:
-      - NODE_ENV=production
-      - DATABASE_URL=postgresql://langfuse:langfuse@langfuse-postgres:5432/langfuse
-      - REDIS_CONNECTION_STRING=redis://langfuse-redis:6379
-      # ClickHouse configuration (required for v3)
-      - CLICKHOUSE_URL=http://langfuse-clickhouse:8123
-      - CLICKHOUSE_MIGRATION_URL=clickhouse://langfuse-clickhouse:9000
-      - CLICKHOUSE_USER=langfuse
-      - CLICKHOUSE_PASSWORD=langfuse123
-      - CLICKHOUSE_CLUSTER_ENABLED=false
-      # S3/MinIO configuration
-      - LANGFUSE_S3_EVENT_UPLOAD_BUCKET=langfuse-events
-      - LANGFUSE_S3_MEDIA_UPLOAD_BUCKET=langfuse-media
-      - LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT=http://langfuse-minio:9000
-      - LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT=http://langfuse-minio:9000
-      - LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID=langfuse
-      - LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY=langfuse123
-      - LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID=langfuse
-      - LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY=langfuse123
-      - LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE=true
-      - LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE=true
-      - LANGFUSE_S3_EVENT_UPLOAD_REGION=us-east-1
-      - LANGFUSE_S3_MEDIA_UPLOAD_REGION=us-east-1
-      # Auth secrets (change in production!)
-      - NEXTAUTH_URL=http://localhost:${LANGFUSE_PORT:-3001}
-      - NEXTAUTH_SECRET=langfuse-nextauth-secret-min-32-chars
-      - SALT=langfuse-salt-min-32-characters-here
-      - ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
-      # Headless initialization (idempotent - only creates if not exists)
-      - LANGFUSE_INIT_ORG_ID=demo-org
-      - LANGFUSE_INIT_ORG_NAME=Demo Organization
-      - LANGFUSE_INIT_PROJECT_ID=demo-project
-      - LANGFUSE_INIT_PROJECT_NAME=LLM Observability Demo
-      - LANGFUSE_INIT_PROJECT_PUBLIC_KEY=pk-lf-1234567890
-      - LANGFUSE_INIT_PROJECT_SECRET_KEY=sk-lf-1234567890
-      - LANGFUSE_INIT_USER_EMAIL=demo@localhost
-      - LANGFUSE_INIT_USER_NAME=Demo User
-      - LANGFUSE_INIT_USER_PASSWORD=demodemo1!
+      <<: *langfuse-common-env
 
 volumes:
   # Langfuse volumes
   langfuse-postgres-data:
   langfuse-minio-data:
   langfuse-clickhouse-data:
+  # Model cache for vector-rag (persists sentence-transformers downloads)
+  vector-rag-models:

--- a/librechat.yaml
+++ b/librechat.yaml
@@ -10,7 +10,7 @@ cache: true
 mcpServers:
   clickhouse-playground:
     type: sse
-    url: http://host.docker.internal:8001/sse
+    url: http://mcp-clickhouse:8000/sse
 
   # Langfuse Prompt Management (MCP Server)
   # Enables agents to manage Langfuse prompts directly from chat

--- a/librechat/Dockerfile.api
+++ b/librechat/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM ghcr.io/danny-avila/librechat-dev:latest
+FROM ghcr.io/danny-avila/librechat-dev:v0.8.2
 
 USER root
 

--- a/mcp-clickhouse/Dockerfile
+++ b/mcp-clickhouse/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcp/clickhouse
+# Note: mcp/clickhouse only publishes a `latest` tag on Docker Hub.
+# Pin to a specific version when one becomes available.
+FROM mcp/clickhouse:latest
 
 RUN mkdir -p /app/logs
 

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -82,6 +82,8 @@ VOLUME_SUFFIXES=(
     "langfuse-postgres-data"
     "langfuse-minio-data"
     "langfuse-clickhouse-data"
+    # Model cache
+    "vector-rag-models"
 )
 
 for suffix in "${VOLUME_SUFFIXES[@]}"; do
@@ -145,7 +147,8 @@ if [ -f ".env" ]; then
     grep -v "^CREDS_KEY=" | \
     grep -v "^CREDS_IV=" | \
     grep -v "^JWT_SECRET=" | \
-    grep -v "^JWT_REFRESH_SECRET=" > .env.tmp
+    grep -v "^JWT_REFRESH_SECRET=" | \
+    grep -v "^CLICKSTACK_API_KEY=" > .env.tmp
 
     mv .env.tmp .env
 

--- a/scripts/seed-demo-data.sh
+++ b/scripts/seed-demo-data.sh
@@ -60,18 +60,30 @@ echo -e "${GREEN}✓${NC} Required services are running"
 echo ""
 
 # ------------------------------------------------------------------------------
+# Build Demo Images
+# ------------------------------------------------------------------------------
+echo "Building demo images (using cache if available)..."
+docker compose --profile demo --profile tools build --quiet 2>&1
+echo -e "${GREEN}✓${NC} Demo images ready"
+echo ""
+
+# ------------------------------------------------------------------------------
 # Run Text-to-SQL Demo
 # ------------------------------------------------------------------------------
 echo -e "${BLUE}[1/4] Running Text-to-SQL demo queries...${NC}"
 echo ""
 
-docker compose run --rm text-to-sql python main.py 2>&1 | while read line; do
+if ! docker compose run --rm text-to-sql python main.py 2>&1 | while read line; do
     echo "  $line"
-done
-
-echo ""
-echo -e "${GREEN}✓${NC} Text-to-SQL traces generated"
-echo ""
+done; then
+    echo -e "${RED}✗${NC} Text-to-SQL demo failed. Check your ANTHROPIC_API_KEY in .env"
+    echo "  Run manually: docker compose run --rm text-to-sql python main.py"
+    echo ""
+else
+    echo ""
+    echo -e "${GREEN}✓${NC} Text-to-SQL traces generated"
+    echo ""
+fi
 
 # ------------------------------------------------------------------------------
 # Run Vector RAG Demo
@@ -79,13 +91,17 @@ echo ""
 echo -e "${BLUE}[2/4] Running Vector RAG demo queries...${NC}"
 echo ""
 
-docker compose run --rm vector-rag python main.py 2>&1 | while read line; do
+if ! docker compose run --rm vector-rag python main.py 2>&1 | while read line; do
     echo "  $line"
-done
-
-echo ""
-echo -e "${GREEN}✓${NC} Vector RAG traces generated"
-echo ""
+done; then
+    echo -e "${RED}✗${NC} Vector RAG demo failed. Check your ANTHROPIC_API_KEY in .env"
+    echo "  Run manually: docker compose run --rm vector-rag python main.py"
+    echo ""
+else
+    echo ""
+    echo -e "${GREEN}✓${NC} Vector RAG traces generated"
+    echo ""
+fi
 
 # ------------------------------------------------------------------------------
 # Run Test Scenarios (unless --quick)
@@ -96,11 +112,16 @@ if [[ "$1" != "--quick" ]]; then
 
     # Check if test-scenarios service exists and can run
     if docker compose --profile tools run --rm test-scenarios --help > /dev/null 2>&1; then
-        docker compose --profile tools run --rm test-scenarios 2>&1 | while read line; do
+        if ! docker compose --profile tools run --rm test-scenarios 2>&1 | while read line; do
             echo "  $line"
-        done
-        echo ""
-        echo -e "${GREEN}✓${NC} Test scenarios completed"
+        done; then
+            echo -e "${RED}✗${NC} Test scenarios failed."
+            echo "  Run manually: docker compose --profile tools run --rm test-scenarios"
+            echo ""
+        else
+            echo ""
+            echo -e "${GREEN}✓${NC} Test scenarios completed"
+        fi
     else
         echo -e "${YELLOW}⚠${NC} Test scenarios service not available, skipping"
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@
 #
 # Usage:
 #   ./setup.sh                    # Interactive setup
+#   ./setup.sh --seed             # Setup + seed demo data
 #   ./setup.sh --status           # Show status of all services
 #   ./setup.sh --cleanup          # Stop all containers (preserves data)
 #   ./setup.sh --help             # Show help
@@ -98,6 +99,22 @@ ensure_env_file() {
     set -a
     source .env
     set +a
+
+    # Clean up deprecated variables
+    if grep -q "^CLICKSTACK_API_KEY=" .env 2>/dev/null; then
+        sed -i.bak '/^CLICKSTACK_API_KEY=/d' .env && rm -f .env.bak
+        warn "Removed deprecated CLICKSTACK_API_KEY from .env"
+    fi
+}
+
+#######################################
+# Validate critical .env variables
+#######################################
+validate_env() {
+    if [ -z "$LANGFUSE_PUBLIC_KEY" ] || [ -z "$LANGFUSE_SECRET_KEY" ]; then
+        warn "LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY not set in .env"
+        warn "Langfuse tracing will use default demo keys (pk-lf-1234567890 / sk-lf-1234567890)"
+    fi
 }
 
 #######################################
@@ -250,6 +267,10 @@ start_services() {
     docker compose --profile langfuse up -d
 
     success "Docker Compose services started"
+
+    info "Pre-building demo images (cached if unchanged)..."
+    docker compose --profile demo --profile tools build --quiet 2>&1 || true
+    success "Demo images ready"
 }
 
 #######################################
@@ -296,13 +317,14 @@ wait_for_services() {
 show_status() {
     header "Service Status"
 
-    docker compose --profile langfuse ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || \
+    docker compose --profile langfuse --profile demo --profile tools ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || \
         docker compose ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || true
 
     header "Access URLs"
 
     echo ""
     echo -e "  ${GREEN}LibreChat (Chat UI):${NC}        http://localhost:3080"
+    echo -e "    First time? Register at http://localhost:3080 (any email/password)"
     echo -e "  ${GREEN}Langfuse (LLM Traces):${NC}      http://localhost:${LANGFUSE_PORT:-3001}"
     echo -e "    Email: demo@localhost  |  Password: demodemo1!"
     echo ""
@@ -362,6 +384,8 @@ main() {
     echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
     echo ""
 
+    local run_seed=false
+
     case "${1:-}" in
         --cleanup|-c)
             cleanup
@@ -375,11 +399,15 @@ main() {
             show_status
             exit 0
             ;;
+        --seed)
+            run_seed=true
+            ;;
         --help|-h)
             echo "Usage: ./setup.sh [OPTIONS]"
             echo ""
             echo "Options:"
             echo "  (none)      Interactive setup (idempotent - safe to re-run)"
+            echo "  --seed      Setup + seed demo data (single-command experience)"
             echo "  --status    Show status of all services and URLs"
             echo "  --cleanup   Stop all containers (preserves data)"
             echo "  --help      Show this help message"
@@ -396,6 +424,7 @@ main() {
 
     check_prerequisites
     ensure_env_file
+    validate_env
     ensure_anthropic_key
     ensure_librechat_secrets
     ensure_langfuse_mcp_token
@@ -408,8 +437,16 @@ main() {
     echo ""
     echo -e "${GREEN}Your LLM observability demo is ready!${NC}"
     echo ""
-    echo "  Run ./scripts/seed-demo-data.sh to populate sample traces."
-    echo ""
+
+    if [ "$run_seed" = true ]; then
+        echo "  Running demo data seeding..."
+        echo ""
+        "$SCRIPT_DIR/scripts/seed-demo-data.sh"
+    else
+        echo "  Run ./scripts/seed-demo-data.sh to populate sample traces."
+        echo "  Or re-run with: ./setup.sh --seed"
+        echo ""
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- **Fix cross-platform MCP networking**: Use Docker service name (`mcp-clickhouse:8000`) instead of `host.docker.internal:8001` so it works on Linux
- **Pin Docker image versions**: `mongo:7`, `clickhouse-server:24.8`, `minio:RELEASE.2024-12-18T13-15-44Z`, `librechat-dev:v0.8.2`
- **DRY up Langfuse env config**: Extract ~30 duplicated env vars into `x-langfuse-common-env` YAML anchor
- **Add `langfuse-web` healthcheck**: `wget`-based check on `/api/public/health` with 60s start period
- **Pre-build demo images**: `setup.sh` and `seed-demo-data.sh` now build demo/tools images before running them
- **Add `--seed` flag**: `./setup.sh --seed` gives new users a single-command experience
- **Add model cache volume**: `vector-rag-models` volume persists sentence-transformers downloads across runs
- **Clean up CLICKSTACK remnants**: Remove deprecated `CLICKSTACK_API_KEY` from `.env` in setup and reset
- **Improve UX**: `.env` validation warnings, LibreChat registration hint, `--status` shows all profiles

## Test plan

- [ ] `./setup.sh --seed` on a clean clone starts all services, builds images, seeds data
- [ ] `./setup.sh` re-run detects existing services and skips gracefully
- [ ] `./setup.sh --status` shows all profiles (langfuse, demo, tools)
- [ ] `docker compose config --quiet` validates compose syntax
- [ ] MCP URL works on Linux (uses Docker internal networking)
- [ ] `./scripts/reset.sh --force` cleans up `vector-rag-models` volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)