### PR TITLE
Add LLM Observatory analytics dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,10 @@ TEMPERATURE=0.7
 TEXT_TO_SQL_PORT=8002
 VECTOR_RAG_PORT=8003
 LANGFUSE_PORT=3001
+DASHBOARD_PORT=8005
+
+# Dashboard Settings
+DASHBOARD_CACHE_TTL=60
 
 # ==============================================================================
 # INTERNAL - Usually don't need to change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,13 @@ LLM apps (Text-to-SQL, Vector RAG, LibreChat) instrument with the Langfuse SDK. 
 ./scripts/langfuse-cli.sh traces list   # Langfuse CLI (requires Node.js 18+)
 ```
 
+## Running the Dashboard
+
+```bash
+docker compose --profile langfuse --profile dashboard up -d   # Start with dashboard
+# Open http://localhost:8005
+```
+
 ## Running Demo Apps
 
 ```bash
@@ -33,7 +40,7 @@ docker compose --profile tools run --rm test-scenarios           # 40 test scena
 ## Code Conventions
 
 - **Langfuse SDK**: v3 patterns — `langfuse.trace()`, `trace.span()`, `trace.generation()`. See `text-to-sql/langfuse_config.py` for setup.
-- **Docker profiles**: `langfuse` (Langfuse stack), `demo` (text-to-sql, vector-rag), `tools` (test-scenarios)
+- **Docker profiles**: `langfuse` (Langfuse stack), `demo` (text-to-sql, vector-rag), `tools` (test-scenarios), `dashboard` (LLM Observatory)
 - **Environment**: `.env` file sourced by setup.sh. Never commit `.env`. Template is `.env.example`.
 - **LANGFUSE_INTERNAL_URL**: Docker-internal Langfuse URL. Unset in self-hosted (falls back to `http://langfuse-web:3000`), set to cloud URL in cloud mode.
 - **Scripts**: All scripts `cd` to project root and `source .env`. Check `DEPLOY_MODE` before assuming local services.
@@ -46,6 +53,7 @@ docker compose --profile tools run --rm test-scenarios           # 40 test scena
 | Langfuse | http://localhost:3001 (demo@example.com / demodemo1!) |
 | Text-to-SQL API | http://localhost:8002 |
 | Vector RAG API | http://localhost:8003 |
+| LLM Observatory | http://localhost:8005 |
 
 ## Project Layout
 
@@ -57,6 +65,7 @@ text-to-sql/                # Text-to-SQL demo (Python, Langfuse SDK)
 vector-rag/                 # Vector RAG demo (Python, Langfuse SDK, ChromaDB)
 librechat/                  # LibreChat customizations (Dockerfile.api, nginx.conf)
 test-scenarios/             # 40 synthetic traces for evaluation testing
+dashboard/                  # LLM Observatory analytics dashboard (FastAPI + Alpine.js)
 mcp-clickhouse/             # ClickHouse MCP Server
 scripts/                    # Utility scripts (seed, reset, validate, CLI)
 docs/                       # Documentation

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8005
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8005"]

--- a/dashboard/clickhouse_client.py
+++ b/dashboard/clickhouse_client.py
@@ -1,0 +1,472 @@
+"""Direct ClickHouse client for fast analytics queries."""
+
+import os
+import hashlib
+import time
+from datetime import datetime
+
+import httpx
+
+_cache: dict[str, tuple[object, float]] = {}
+_CACHE_TTL = int(os.environ.get("DASHBOARD_CACHE_TTL", "60"))
+
+
+def _cache_key(query: str, params: dict | None) -> str:
+    raw = f"{query}:{sorted((params or {}).items())}"
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+def _cache_get(key: str) -> object | None:
+    if key in _cache:
+        data, expires = _cache[key]
+        if time.time() < expires:
+            return data
+        del _cache[key]
+    return None
+
+
+def _cache_set(key: str, data: object) -> None:
+    _cache[key] = (data, time.time() + _CACHE_TTL)
+
+
+def _get_ch_url() -> str:
+    host = os.environ.get("CLICKHOUSE_HOST", "langfuse-clickhouse")
+    port = os.environ.get("CLICKHOUSE_HTTP_PORT", "8123")
+    return f"http://{host}:{port}"
+
+
+def _get_ch_auth() -> tuple[str, str]:
+    user = os.environ.get("CLICKHOUSE_USER", "langfuse")
+    password = os.environ.get("CLICKHOUSE_PASSWORD", "langfuse123")
+    return user, password
+
+
+def _where_clause(from_ts: str | None, to_ts: str | None, project: str | None,
+                  table_alias: str = "", ts_col: str = "timestamp") -> tuple[str, dict]:
+    """Build WHERE conditions and params for time range + project filter."""
+    prefix = f"{table_alias}." if table_alias else ""
+    conditions = [f"{prefix}is_deleted = 0"]
+    params = {}
+
+    if from_ts:
+        conditions.append(f"{prefix}{ts_col} >= {{from_ts:DateTime64(3)}}")
+        params["from_ts"] = from_ts
+    if to_ts:
+        conditions.append(f"{prefix}{ts_col} <= {{to_ts:DateTime64(3)}}")
+        params["to_ts"] = to_ts
+    if project:
+        conditions.append(f"{prefix}name = {{project:String}}")
+        params["project"] = project
+
+    return " AND ".join(conditions), params
+
+
+async def query(sql: str, params: dict | None = None, use_cache: bool = True) -> list[dict]:
+    """Execute a ClickHouse query and return rows as list of dicts."""
+    key = _cache_key(sql, params)
+    if use_cache:
+        cached = _cache_get(key)
+        if cached is not None:
+            return cached
+
+    url = _get_ch_url()
+    user, password = _get_ch_auth()
+
+    # Use JSON format for easy parsing
+    full_sql = sql.rstrip(";") + " FORMAT JSONEachRow"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            url,
+            content=full_sql,
+            params={"user": user, "password": password,
+                    **({"param_" + k: v for k, v in (params or {}).items()})},
+            headers={"Content-Type": "text/plain"},
+        )
+        resp.raise_for_status()
+
+    text = resp.text.strip()
+    if not text:
+        result = []
+    else:
+        import json
+        result = [json.loads(line) for line in text.split("\n") if line.strip()]
+
+    if use_cache:
+        _cache_set(key, result)
+    return result
+
+
+async def query_one(sql: str, params: dict | None = None) -> dict | None:
+    """Execute query and return first row."""
+    rows = await query(sql, params)
+    return rows[0] if rows else None
+
+
+# ============== Pre-built analytics queries ==============
+
+async def get_kpi(from_ts: str | None = None, to_ts: str | None = None,
+                  project: str | None = None) -> dict:
+    """All KPI metrics in two fast queries."""
+    where, params = _where_clause(from_ts, to_ts, project)
+
+    # Main counts
+    row = await query_one(f"""
+        SELECT
+            count() as traces_count,
+            uniqExact(session_id) as sessions_count,
+            uniqExact(name) as projects_count,
+            uniqExact(toDate(timestamp)) as active_days
+        FROM default.traces
+        WHERE {where}
+    """, params)
+
+    # Traces per session percentiles
+    tps = await query_one(f"""
+        SELECT
+            medianExact(cnt) as median_tps,
+            quantileExact(0.9)(cnt) as p90_tps
+        FROM (
+            SELECT session_id, count() as cnt
+            FROM default.traces
+            WHERE {where} AND session_id IS NOT NULL AND session_id != ''
+            GROUP BY session_id
+        )
+    """, params)
+
+    # Cost + latency from observations (joined to traces for filtering)
+    obs_where, obs_params = _where_clause(from_ts, to_ts, project, "t")
+    cost = await query_one(f"""
+        SELECT
+            sum(coalesce(o.total_cost, 0)) as total_cost,
+            avg(if(o.end_time IS NOT NULL,
+                dateDiff('millisecond', o.start_time, o.end_time), NULL)) as avg_latency_ms
+        FROM default.observations o
+        JOIN default.traces t ON o.trace_id = t.id
+        WHERE {obs_where} AND o.is_deleted = 0
+    """, obs_params)
+
+    # Avg score
+    score_where, score_params = _where_clause(from_ts, to_ts, None, "", "timestamp")
+    score = await query_one(f"""
+        SELECT avg(value) as avg_score
+        FROM default.scores
+        WHERE {score_where}
+    """, score_params)
+
+    return {
+        "traces_count": int(row["traces_count"]) if row else 0,
+        "sessions_count": int(row["sessions_count"]) if row else 0,
+        "projects_count": int(row["projects_count"]) if row else 0,
+        "active_days": int(row["active_days"]) if row else 0,
+        "median_traces_per_session": float(tps["median_tps"]) if tps else 0,
+        "p90_traces_per_session": float(tps["p90_tps"]) if tps else 0,
+        "total_cost": round(float(cost["total_cost"] or 0), 6) if cost else 0,
+        "avg_latency_ms": round(float(cost["avg_latency_ms"] or 0), 1) if cost else 0,
+        "avg_score": round(float(score["avg_score"]), 3) if score and score["avg_score"] else None,
+    }
+
+
+async def get_sessions(from_ts: str | None = None, to_ts: str | None = None,
+                       project: str | None = None, search: str | None = None,
+                       limit: int = 200) -> list[dict]:
+    """Session list with pre-aggregated metrics."""
+    where, params = _where_clause(from_ts, to_ts, project)
+    params["limit"] = limit
+
+    search_clause = ""
+    if search:
+        search_clause = "AND (session_id ILIKE {search:String} OR name ILIKE {search:String})"
+        params["search"] = f"%{search}%"
+
+    rows = await query(f"""
+        SELECT
+            session_id as id,
+            count() as trace_count,
+            min(timestamp) as first_trace,
+            max(timestamp) as last_trace,
+            any(name) as project,
+            coalesce(sum(trace_cost), 0) as total_cost,
+            coalesce(sum(trace_latency_ms), 0) as total_latency_ms,
+            toUInt64(coalesce(sum(trace_tokens), 0)) as total_tokens
+        FROM (
+            SELECT
+                t.id as tid,
+                t.session_id,
+                t.timestamp,
+                t.name,
+                coalesce(sum(coalesce(o.total_cost, 0)), 0) as trace_cost,
+                coalesce(sum(if(o.end_time IS NOT NULL,
+                    dateDiff('millisecond', o.start_time, o.end_time), 0)), 0) as trace_latency_ms,
+                toUInt64(coalesce(sum(o.usage_details['total']), 0)) as trace_tokens
+            FROM default.traces t
+            LEFT JOIN default.observations o ON t.id = o.trace_id AND o.is_deleted = 0
+            WHERE {where} AND t.session_id IS NOT NULL AND t.session_id != ''
+                {search_clause}
+            GROUP BY t.id, t.session_id, t.timestamp, t.name
+        )
+        GROUP BY session_id
+        ORDER BY last_trace DESC
+        LIMIT {{limit:UInt32}}
+    """, params)
+
+    for r in rows:
+        r["total_cost"] = round(float(r.get("total_cost", 0)), 6)
+        r["total_latency_ms"] = round(float(r.get("total_latency_ms", 0)), 1)
+        r["total_tokens"] = int(r.get("total_tokens", 0))
+        r["trace_count"] = int(r.get("trace_count", 0))
+    return rows
+
+
+async def get_heatmap(from_ts: str | None = None, to_ts: str | None = None,
+                      project: str | None = None) -> dict:
+    """Daily trace counts for heatmap."""
+    where, params = _where_clause(from_ts, to_ts, project)
+
+    rows = await query(f"""
+        SELECT toString(toDate(timestamp)) as date, count() as count
+        FROM default.traces
+        WHERE {where}
+        GROUP BY date
+        ORDER BY date
+    """, params)
+
+    max_count = max((int(r["count"]) for r in rows), default=0)
+    return {
+        "days": [{"date": r["date"], "count": int(r["count"])} for r in rows],
+        "max_count": max_count,
+    }
+
+
+async def get_hourly(from_ts: str | None = None, to_ts: str | None = None,
+                     project: str | None = None) -> dict:
+    """7x24 activity matrix."""
+    where, params = _where_clause(from_ts, to_ts, project)
+
+    rows = await query(f"""
+        SELECT
+            toDayOfWeek(timestamp) as dow,
+            toHour(timestamp) as hour,
+            count() as cnt
+        FROM default.traces
+        WHERE {where}
+        GROUP BY dow, hour
+    """, params)
+
+    # toDayOfWeek: 1=Mon, 7=Sun → map to 0-indexed
+    matrix = [[0] * 24 for _ in range(7)]
+    for r in rows:
+        d = int(r["dow"]) - 1  # 0=Mon
+        h = int(r["hour"])
+        matrix[d][h] = int(r["cnt"])
+
+    day_totals = [sum(row) for row in matrix]
+    max_count = max(max(row) for row in matrix) if any(any(row) for row in matrix) else 0
+
+    return {"matrix": matrix, "day_totals": day_totals, "max_count": max_count}
+
+
+async def get_top_sessions(sort: str = "traces", limit: int = 10,
+                           from_ts: str | None = None, to_ts: str | None = None,
+                           project: str | None = None) -> list[dict]:
+    """Top sessions ranked by metric."""
+    where, params = _where_clause(from_ts, to_ts, project)
+    params["limit"] = limit
+
+    order = {
+        "traces": "trace_count DESC",
+        "duration": "total_duration_ms DESC",
+        "cost": "total_cost DESC",
+    }.get(sort, "trace_count DESC")
+
+    rows = await query(f"""
+        SELECT
+            session_id as id,
+            any(name) as project,
+            count() as trace_count,
+            coalesce(sum(trace_latency), 0) as total_duration_ms,
+            coalesce(sum(trace_cost), 0) as total_cost,
+            min(timestamp) as first_trace
+        FROM (
+            SELECT
+                t.id as tid,
+                t.session_id,
+                t.timestamp,
+                t.name,
+                coalesce(sum(if(o.end_time IS NOT NULL,
+                    dateDiff('millisecond', o.start_time, o.end_time), 0)), 0) as trace_latency,
+                coalesce(sum(coalesce(o.total_cost, 0)), 0) as trace_cost
+            FROM default.traces t
+            LEFT JOIN default.observations o ON t.id = o.trace_id AND o.is_deleted = 0
+            WHERE {where} AND t.session_id IS NOT NULL AND t.session_id != ''
+            GROUP BY t.id, t.session_id, t.timestamp, t.name
+        )
+        GROUP BY session_id
+        ORDER BY {order}
+        LIMIT {{limit:UInt32}}
+    """, params)
+
+    for r in rows:
+        r["total_cost"] = round(float(r.get("total_cost", 0)), 6)
+        r["total_duration_ms"] = round(float(r.get("total_duration_ms", 0)), 1)
+        r["trace_count"] = int(r.get("trace_count", 0))
+    return rows
+
+
+async def get_tools(from_ts: str | None = None, to_ts: str | None = None) -> list[dict]:
+    """Span usage analytics."""
+    where, params = _where_clause(from_ts, to_ts, None, "", "start_time")
+
+    rows = await query(f"""
+        SELECT
+            name,
+            count() as count,
+            avg(if(end_time IS NOT NULL,
+                dateDiff('millisecond', start_time, end_time), NULL)) as avg_latency_ms
+        FROM default.observations
+        WHERE {where} AND type = 'SPAN'
+        GROUP BY name
+        ORDER BY count DESC
+    """, params)
+
+    return [{
+        "name": r["name"],
+        "count": int(r["count"]),
+        "avg_latency_ms": round(float(r.get("avg_latency_ms") or 0), 1),
+    } for r in rows]
+
+
+async def get_scores() -> list[dict]:
+    """Score distributions."""
+    rows = await query("""
+        SELECT
+            name,
+            count() as count,
+            avg(value) as avg,
+            min(value) as min,
+            max(value) as max
+        FROM default.scores
+        WHERE is_deleted = 0
+        GROUP BY name
+        ORDER BY name
+    """)
+
+    return [{
+        "name": r["name"],
+        "count": int(r["count"]),
+        "avg": round(float(r["avg"]), 3),
+        "min": round(float(r["min"]), 3),
+        "max": round(float(r["max"]), 3),
+        "values": [],
+    } for r in rows]
+
+
+async def get_projects(from_ts: str | None = None, to_ts: str | None = None) -> list[str]:
+    """Distinct project names."""
+    where, params = _where_clause(from_ts, to_ts, None)
+
+    rows = await query(f"""
+        SELECT DISTINCT name
+        FROM default.traces
+        WHERE {where} AND name != ''
+        ORDER BY name
+    """, params)
+
+    return [r["name"] for r in rows]
+
+
+async def get_session_detail(session_id: str) -> dict:
+    """Full session detail with traces and scores."""
+    rows = await query("""
+        SELECT
+            t.id,
+            t.name,
+            t.timestamp,
+            substring(coalesce(t.input, ''), 1, 500) as input,
+            substring(coalesce(t.output, ''), 1, 500) as output,
+            coalesce(sum(if(o.end_time IS NOT NULL,
+                dateDiff('millisecond', o.start_time, o.end_time), 0)), 0) as latency_ms,
+            coalesce(sum(coalesce(o.total_cost, 0)), 0) as cost,
+            toUInt64(coalesce(sum(o.usage_details['total']), 0)) as tokens
+        FROM default.traces t
+        LEFT JOIN default.observations o ON t.id = o.trace_id AND o.is_deleted = 0
+        WHERE t.is_deleted = 0 AND t.session_id = {session_id:String}
+        GROUP BY t.id, t.name, t.timestamp, t.input, t.output
+        ORDER BY t.timestamp
+    """, {"session_id": session_id})
+
+    # Get scores for these traces
+    trace_ids = [r["id"] for r in rows]
+    scores_map: dict[str, dict[str, float]] = {}
+    if trace_ids:
+        score_rows = await query("""
+            SELECT trace_id, name, value
+            FROM default.scores
+            WHERE is_deleted = 0 AND trace_id IN {trace_ids:Array(String)}
+        """, {"trace_ids": trace_ids})
+        for s in score_rows:
+            tid = s["trace_id"]
+            if tid not in scores_map:
+                scores_map[tid] = {}
+            scores_map[tid][s["name"]] = round(float(s["value"]), 3)
+
+    traces = []
+    total_cost = 0.0
+    total_tokens = 0
+    total_latency = 0.0
+
+    for r in rows:
+        cost = float(r.get("cost", 0))
+        lat = float(r.get("latency_ms", 0))
+        tok = int(r.get("tokens", 0))
+        total_cost += cost
+        total_tokens += tok
+        total_latency += lat
+
+        traces.append({
+            "id": r["id"],
+            "name": r.get("name"),
+            "timestamp": r.get("timestamp"),
+            "input": r.get("input") or None,
+            "output": r.get("output") or None,
+            "latency_ms": round(lat, 1),
+            "cost": round(cost, 6),
+            "tokens": tok,
+            "scores": scores_map.get(r["id"], {}),
+        })
+
+    return {
+        "id": session_id,
+        "traces": traces,
+        "total_cost": round(total_cost, 6),
+        "total_tokens": total_tokens,
+        "total_latency_ms": round(total_latency, 1),
+        "trace_count": len(traces),
+    }
+
+
+async def get_export_traces(from_ts: str | None = None, to_ts: str | None = None,
+                            project: str | None = None) -> list[dict]:
+    """All traces for CSV export."""
+    where, params = _where_clause(from_ts, to_ts, project)
+
+    return await query(f"""
+        SELECT
+            t.id as trace_id,
+            t.session_id,
+            t.name,
+            t.timestamp,
+            coalesce(sum(if(o.end_time IS NOT NULL,
+                dateDiff('millisecond', o.start_time, o.end_time), 0)), 0) / 1000.0 as latency_s,
+            coalesce(sum(coalesce(o.total_cost, 0)), 0) as total_cost,
+            toUInt64(coalesce(sum(o.usage_details['input']), 0)) as input_tokens,
+            toUInt64(coalesce(sum(o.usage_details['output']), 0)) as output_tokens,
+            toUInt64(coalesce(sum(o.usage_details['total']), 0)) as total_tokens,
+            substring(coalesce(t.input, ''), 1, 1000) as input,
+            substring(coalesce(t.output, ''), 1, 1000) as output
+        FROM default.traces t
+        LEFT JOIN default.observations o ON t.id = o.trace_id AND o.is_deleted = 0
+        WHERE {where}
+        GROUP BY t.id, t.session_id, t.name, t.timestamp, t.input, t.output
+        ORDER BY t.timestamp DESC
+    """, params, use_cache=False)

--- a/dashboard/clickhouse_client.py
+++ b/dashboard/clickhouse_client.py
@@ -41,6 +41,11 @@ def _get_ch_auth() -> tuple[str, str]:
     return user, password
 
 
+def _normalize_ts(ts: str) -> str:
+    """Convert ISO 8601 (2026-02-17T04:03:55.365Z) to ClickHouse format (2026-02-17 04:03:55.365)."""
+    return ts.replace("T", " ").rstrip("Z")
+
+
 def _where_clause(from_ts: str | None, to_ts: str | None, project: str | None,
                   table_alias: str = "", ts_col: str = "timestamp") -> tuple[str, dict]:
     """Build WHERE conditions and params for time range + project filter."""
@@ -50,10 +55,10 @@ def _where_clause(from_ts: str | None, to_ts: str | None, project: str | None,
 
     if from_ts:
         conditions.append(f"{prefix}{ts_col} >= {{from_ts:DateTime64(3)}}")
-        params["from_ts"] = from_ts
+        params["from_ts"] = _normalize_ts(from_ts)
     if to_ts:
         conditions.append(f"{prefix}{ts_col} <= {{to_ts:DateTime64(3)}}")
-        params["to_ts"] = to_ts
+        params["to_ts"] = _normalize_ts(to_ts)
     if project:
         conditions.append(f"{prefix}name = {{project:String}}")
         params["project"] = project

--- a/dashboard/data_models.py
+++ b/dashboard/data_models.py
@@ -1,0 +1,109 @@
+from pydantic import BaseModel
+
+
+class KPIResponse(BaseModel):
+    sessions_count: int = 0
+    traces_count: int = 0
+    projects_count: int = 0
+    active_days: int = 0
+    median_traces_per_session: float = 0
+    p90_traces_per_session: float = 0
+    avg_latency_ms: float = 0
+    total_cost: float = 0
+    avg_score: float | None = None
+
+
+class SessionSummary(BaseModel):
+    id: str
+    trace_count: int = 0
+    first_trace: str | None = None
+    last_trace: str | None = None
+    project: str | None = None
+    total_cost: float = 0
+    total_latency_ms: float = 0
+    total_tokens: int = 0
+
+
+class SessionListResponse(BaseModel):
+    sessions: list[SessionSummary]
+    total: int = 0
+    page: int = 1
+    limit: int = 50
+
+
+class TraceDetail(BaseModel):
+    id: str
+    name: str | None = None
+    timestamp: str | None = None
+    input: str | None = None
+    output: str | None = None
+    latency_ms: float = 0
+    cost: float = 0
+    tokens: int = 0
+    scores: dict[str, float] = {}
+
+
+class SessionDetailResponse(BaseModel):
+    id: str
+    traces: list[TraceDetail]
+    total_cost: float = 0
+    total_tokens: int = 0
+    total_latency_ms: float = 0
+    trace_count: int = 0
+
+
+class HeatmapDay(BaseModel):
+    date: str
+    count: int
+
+
+class HeatmapResponse(BaseModel):
+    days: list[HeatmapDay]
+    max_count: int = 0
+
+
+class HourlyActivity(BaseModel):
+    matrix: list[list[int]]  # 7 rows (Mon-Sun) x 24 cols (hours)
+    day_totals: list[int]  # 7 day totals
+    max_count: int = 0
+
+
+class TopSession(BaseModel):
+    id: str
+    project: str | None = None
+    trace_count: int = 0
+    total_duration_ms: float = 0
+    total_cost: float = 0
+    first_trace: str | None = None
+
+
+class TopSessionsResponse(BaseModel):
+    sessions: list[TopSession]
+    sort_by: str = "traces"
+
+
+class ToolUsage(BaseModel):
+    name: str
+    count: int = 0
+    avg_latency_ms: float = 0
+
+
+class ToolsResponse(BaseModel):
+    tools: list[ToolUsage]
+
+
+class ScoreDistribution(BaseModel):
+    name: str
+    count: int = 0
+    avg: float = 0
+    min: float = 0
+    max: float = 0
+    values: list[float] = []
+
+
+class ScoresResponse(BaseModel):
+    scores: list[ScoreDistribution]
+
+
+class ProjectResponse(BaseModel):
+    projects: list[str]

--- a/dashboard/langfuse_client.py
+++ b/dashboard/langfuse_client.py
@@ -1,0 +1,201 @@
+"""Async Langfuse REST API client with in-memory caching."""
+
+import base64
+import hashlib
+import os
+import time
+from datetime import datetime, timezone
+
+import httpx
+
+
+# Cache: {key: (data, expires_at)}
+_cache: dict[str, tuple[object, float]] = {}
+_CACHE_TTL = int(os.environ.get("DASHBOARD_CACHE_TTL", "60"))
+
+
+def _cache_key(method: str, url: str, params: dict | None) -> str:
+    raw = f"{method}:{url}:{sorted((params or {}).items())}"
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+def _cache_get(key: str) -> object | None:
+    if key in _cache:
+        data, expires = _cache[key]
+        if time.time() < expires:
+            return data
+        del _cache[key]
+    return None
+
+
+def _cache_set(key: str, data: object) -> None:
+    _cache[key] = (data, time.time() + _CACHE_TTL)
+
+
+def _get_auth_header() -> str:
+    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY", "pk-lf-1234567890")
+    secret_key = os.environ.get("LANGFUSE_SECRET_KEY", "sk-lf-1234567890")
+    credentials = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
+    return f"Basic {credentials}"
+
+
+def _get_base_url() -> str:
+    # Inside Docker, use internal URL; outside, use LANGFUSE_BASE_URL
+    return os.environ.get(
+        "LANGFUSE_HOST",
+        os.environ.get("LANGFUSE_BASE_URL", "http://localhost:3001"),
+    )
+
+
+async def _api_get(path: str, params: dict | None = None) -> dict:
+    """Make authenticated GET request to Langfuse API."""
+    url = f"{_get_base_url()}/api/public{path}"
+    key = _cache_key("GET", url, params)
+
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(
+            url,
+            params=params,
+            headers={"Authorization": _get_auth_header()},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    _cache_set(key, data)
+    return data
+
+
+async def fetch_traces(
+    from_ts: str | None = None,
+    to_ts: str | None = None,
+    name: str | None = None,
+    session_id: str | None = None,
+    page: int = 1,
+    limit: int = 100,
+) -> dict:
+    """Fetch traces with optional filters."""
+    params = {"page": page, "limit": limit}
+    if from_ts:
+        params["fromTimestamp"] = from_ts
+    if to_ts:
+        params["toTimestamp"] = to_ts
+    if name:
+        params["name"] = name
+    if session_id:
+        params["sessionId"] = session_id
+    return await _api_get("/traces", params)
+
+
+async def fetch_all_traces(
+    from_ts: str | None = None,
+    to_ts: str | None = None,
+    name: str | None = None,
+) -> list[dict]:
+    """Fetch all traces with pagination."""
+    all_traces = []
+    page = 1
+    while True:
+        result = await fetch_traces(
+            from_ts=from_ts, to_ts=to_ts, name=name, page=page, limit=100
+        )
+        traces = result.get("data", [])
+        all_traces.extend(traces)
+        meta = result.get("meta", {})
+        total = meta.get("totalItems", len(traces))
+        if len(all_traces) >= total or not traces:
+            break
+        page += 1
+    return all_traces
+
+
+async def fetch_observations(
+    trace_id: str | None = None,
+    obs_type: str | None = None,
+    page: int = 1,
+    limit: int = 100,
+    from_ts: str | None = None,
+    to_ts: str | None = None,
+) -> dict:
+    """Fetch observations (spans, generations, events)."""
+    params = {"page": page, "limit": limit}
+    if trace_id:
+        params["traceId"] = trace_id
+    if obs_type:
+        params["type"] = obs_type
+    if from_ts:
+        params["fromStartTime"] = from_ts
+    if to_ts:
+        params["toStartTime"] = to_ts
+    return await _api_get("/observations", params)
+
+
+async def fetch_all_observations(
+    obs_type: str | None = None,
+    from_ts: str | None = None,
+    to_ts: str | None = None,
+) -> list[dict]:
+    """Fetch all observations with pagination."""
+    all_obs = []
+    page = 1
+    while True:
+        result = await fetch_observations(
+            obs_type=obs_type, page=page, limit=100,
+            from_ts=from_ts, to_ts=to_ts,
+        )
+        obs = result.get("data", [])
+        all_obs.extend(obs)
+        meta = result.get("meta", {})
+        total = meta.get("totalItems", len(obs))
+        if len(all_obs) >= total or not obs:
+            break
+        page += 1
+    return all_obs
+
+
+async def fetch_scores(
+    page: int = 1,
+    limit: int = 100,
+) -> dict:
+    """Fetch scores."""
+    params = {"page": page, "limit": limit}
+    return await _api_get("/scores", params)
+
+
+async def fetch_all_scores() -> list[dict]:
+    """Fetch all scores with pagination."""
+    all_scores = []
+    page = 1
+    while True:
+        result = await fetch_scores(page=page, limit=100)
+        scores = result.get("data", [])
+        all_scores.extend(scores)
+        meta = result.get("meta", {})
+        total = meta.get("totalItems", len(scores))
+        if len(all_scores) >= total or not scores:
+            break
+        page += 1
+    return all_scores
+
+
+async def fetch_sessions(
+    page: int = 1,
+    limit: int = 50,
+    from_ts: str | None = None,
+    to_ts: str | None = None,
+) -> dict:
+    """Fetch sessions from Langfuse API."""
+    params = {"page": page, "limit": limit}
+    if from_ts:
+        params["fromTimestamp"] = from_ts
+    if to_ts:
+        params["toTimestamp"] = to_ts
+    return await _api_get("/sessions", params)
+
+
+def clear_cache() -> None:
+    """Clear the entire cache."""
+    _cache.clear()

--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -1,0 +1,27 @@
+"""LLM Observatory — Analytics dashboard for Langfuse observability data."""
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+from routes import kpi, sessions, activity, top_sessions, tools, scores, export, projects
+
+app = FastAPI(title="LLM Observatory", version="1.0.0")
+
+# API routes
+app.include_router(kpi.router)
+app.include_router(sessions.router)
+app.include_router(activity.router)
+app.include_router(top_sessions.router)
+app.include_router(tools.router)
+app.include_router(scores.router)
+app.include_router(export.router)
+app.include_router(projects.router)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+# Static files (must be last — catches all remaining paths)
+app.mount("/", StaticFiles(directory="static", html=True), name="static")

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.12
+uvicorn==0.34.2
+httpx==0.28.1
+pydantic==2.11.3

--- a/dashboard/routes/activity.py
+++ b/dashboard/routes/activity.py
@@ -1,67 +1,25 @@
-"""Activity heatmap and hourly breakdown endpoints."""
-
-from collections import defaultdict
-from datetime import datetime, timedelta, timezone
+"""Activity heatmap and hourly — powered by ClickHouse."""
 
 from fastapi import APIRouter, Query
 
-from data_models import HeatmapDay, HeatmapResponse, HourlyActivity
-from langfuse_client import fetch_all_traces
+from clickhouse_client import get_heatmap, get_hourly
 
 router = APIRouter()
 
 
-@router.get("/api/activity/heatmap", response_model=HeatmapResponse)
-async def get_heatmap(
+@router.get("/api/activity/heatmap")
+async def heatmap_endpoint(
     from_ts: str | None = Query(None, alias="from"),
     to_ts: str | None = Query(None, alias="to"),
     project: str | None = Query(None),
 ):
-    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
-
-    day_counts: dict[str, int] = defaultdict(int)
-    for t in traces:
-        ts = t.get("timestamp")
-        if ts:
-            try:
-                day = ts[:10]
-                day_counts[day] += 1
-            except (IndexError, TypeError):
-                pass
-
-    days = [HeatmapDay(date=d, count=c) for d, c in sorted(day_counts.items())]
-    max_count = max((d.count for d in days), default=0)
-
-    return HeatmapResponse(days=days, max_count=max_count)
+    return await get_heatmap(from_ts=from_ts, to_ts=to_ts, project=project)
 
 
-@router.get("/api/activity/by-hour", response_model=HourlyActivity)
-async def get_hourly_activity(
+@router.get("/api/activity/by-hour")
+async def hourly_endpoint(
     from_ts: str | None = Query(None, alias="from"),
     to_ts: str | None = Query(None, alias="to"),
     project: str | None = Query(None),
 ):
-    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
-
-    # 7 rows (Mon=0..Sun=6) x 24 cols (hours)
-    matrix = [[0] * 24 for _ in range(7)]
-
-    for t in traces:
-        ts = t.get("timestamp")
-        if ts:
-            try:
-                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-                weekday = dt.weekday()  # 0=Mon, 6=Sun
-                hour = dt.hour
-                matrix[weekday][hour] += 1
-            except (ValueError, TypeError):
-                pass
-
-    day_totals = [sum(row) for row in matrix]
-    max_count = max(max(row) for row in matrix) if any(any(row) for row in matrix) else 0
-
-    return HourlyActivity(
-        matrix=matrix,
-        day_totals=day_totals,
-        max_count=max_count,
-    )
+    return await get_hourly(from_ts=from_ts, to_ts=to_ts, project=project)

--- a/dashboard/routes/activity.py
+++ b/dashboard/routes/activity.py
@@ -1,0 +1,67 @@
+"""Activity heatmap and hourly breakdown endpoints."""
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Query
+
+from data_models import HeatmapDay, HeatmapResponse, HourlyActivity
+from langfuse_client import fetch_all_traces
+
+router = APIRouter()
+
+
+@router.get("/api/activity/heatmap", response_model=HeatmapResponse)
+async def get_heatmap(
+    from_ts: str | None = Query(None, alias="from"),
+    to_ts: str | None = Query(None, alias="to"),
+    project: str | None = Query(None),
+):
+    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
+
+    day_counts: dict[str, int] = defaultdict(int)
+    for t in traces:
+        ts = t.get("timestamp")
+        if ts:
+            try:
+                day = ts[:10]
+                day_counts[day] += 1
+            except (IndexError, TypeError):
+                pass
+
+    days = [HeatmapDay(date=d, count=c) for d, c in sorted(day_counts.items())]
+    max_count = max((d.count for d in days), default=0)
+
+    return HeatmapResponse(days=days, max_count=max_count)
+
+
+@router.get("/api/activity/by-hour", response_model=HourlyActivity)
+async def get_hourly_activity(
+    from_ts: str | None = Query(None, alias="from"),
+    to_ts: str | None = Query(None, alias="to"),
+    project: str | None = Query(None),
+):
+    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
+
+    # 7 rows (Mon=0..Sun=6) x 24 cols (hours)
+    matrix = [[0] * 24 for _ in range(7)]
+
+    for t in traces:
+        ts = t.get("timestamp")
+        if ts:
+            try:
+                dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                weekday = dt.weekday()  # 0=Mon, 6=Sun
+                hour = dt.hour
+                matrix[weekday][hour] += 1
+            except (ValueError, TypeError):
+                pass
+
+    day_totals = [sum(row) for row in matrix]
+    max_count = max(max(row) for row in matrix) if any(any(row) for row in matrix) else 0
+
+    return HourlyActivity(
+        matrix=matrix,
+        day_totals=day_totals,
+        max_count=max_count,
+    )

--- a/dashboard/routes/export.py
+++ b/dashboard/routes/export.py
@@ -1,0 +1,53 @@
+"""CSV export endpoint."""
+
+import csv
+import io
+
+from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
+
+from langfuse_client import fetch_all_traces
+
+router = APIRouter()
+
+
+@router.get("/api/export/csv")
+async def export_csv(
+    from_ts: str | None = Query(None, alias="from"),
+    to_ts: str | None = Query(None, alias="to"),
+    project: str | None = Query(None),
+):
+    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([
+        "trace_id", "session_id", "name", "timestamp",
+        "latency_s", "total_cost", "input_tokens", "output_tokens",
+        "total_tokens", "input", "output",
+    ])
+
+    for t in traces:
+        usage = t.get("usage") or {}
+        raw_input = t.get("input")
+        raw_output = t.get("output")
+        writer.writerow([
+            t.get("id", ""),
+            t.get("sessionId", ""),
+            t.get("name", ""),
+            t.get("timestamp", ""),
+            t.get("latency", ""),
+            t.get("totalCost", ""),
+            usage.get("inputTokens") or usage.get("input") or "",
+            usage.get("outputTokens") or usage.get("output") or "",
+            usage.get("totalTokens") or usage.get("total") or "",
+            str(raw_input)[:1000] if raw_input else "",
+            str(raw_output)[:1000] if raw_output else "",
+        ])
+
+    output.seek(0)
+    return StreamingResponse(
+        iter([output.getvalue()]),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=traces.csv"},
+    )

--- a/dashboard/routes/export.py
+++ b/dashboard/routes/export.py
@@ -1,4 +1,4 @@
-"""CSV export endpoint."""
+"""CSV export — powered by ClickHouse."""
 
 import csv
 import io
@@ -6,7 +6,7 @@ import io
 from fastapi import APIRouter, Query
 from fastapi.responses import StreamingResponse
 
-from langfuse_client import fetch_all_traces
+from clickhouse_client import get_export_traces
 
 router = APIRouter()
 
@@ -17,7 +17,7 @@ async def export_csv(
     to_ts: str | None = Query(None, alias="to"),
     project: str | None = Query(None),
 ):
-    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
+    traces = await get_export_traces(from_ts=from_ts, to_ts=to_ts, project=project)
 
     output = io.StringIO()
     writer = csv.writer(output)
@@ -28,21 +28,18 @@ async def export_csv(
     ])
 
     for t in traces:
-        usage = t.get("usage") or {}
-        raw_input = t.get("input")
-        raw_output = t.get("output")
         writer.writerow([
-            t.get("id", ""),
-            t.get("sessionId", ""),
+            t.get("trace_id", ""),
+            t.get("session_id", ""),
             t.get("name", ""),
             t.get("timestamp", ""),
-            t.get("latency", ""),
-            t.get("totalCost", ""),
-            usage.get("inputTokens") or usage.get("input") or "",
-            usage.get("outputTokens") or usage.get("output") or "",
-            usage.get("totalTokens") or usage.get("total") or "",
-            str(raw_input)[:1000] if raw_input else "",
-            str(raw_output)[:1000] if raw_output else "",
+            t.get("latency_s", ""),
+            t.get("total_cost", ""),
+            t.get("input_tokens", ""),
+            t.get("output_tokens", ""),
+            t.get("total_tokens", ""),
+            t.get("input", ""),
+            t.get("output", ""),
         ])
 
     output.seek(0)

--- a/dashboard/routes/kpi.py
+++ b/dashboard/routes/kpi.py
@@ -1,89 +1,16 @@
-"""KPI endpoint — aggregate stats across all traces."""
-
-import statistics
-from collections import defaultdict
-from datetime import datetime
+"""KPI endpoint — powered by ClickHouse."""
 
 from fastapi import APIRouter, Query
 
-from data_models import KPIResponse
-from langfuse_client import fetch_all_scores, fetch_all_traces
+from clickhouse_client import get_kpi
 
 router = APIRouter()
 
 
-@router.get("/api/kpi", response_model=KPIResponse)
-async def get_kpi(
+@router.get("/api/kpi")
+async def kpi_endpoint(
     from_ts: str | None = Query(None, alias="from"),
     to_ts: str | None = Query(None, alias="to"),
     project: str | None = Query(None),
 ):
-    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
-
-    if not traces:
-        return KPIResponse()
-
-    # Group by session
-    sessions: dict[str, list[dict]] = defaultdict(list)
-    projects: set[str] = set()
-    days: set[str] = set()
-    total_cost = 0.0
-    latencies = []
-    all_scores = []
-
-    for t in traces:
-        sid = t.get("sessionId") or "no-session"
-        sessions[sid].append(t)
-
-        name = t.get("name")
-        if name:
-            projects.add(name)
-
-        ts = t.get("timestamp")
-        if ts:
-            try:
-                day = ts[:10]
-                days.add(day)
-            except (IndexError, TypeError):
-                pass
-
-        # Cost from usage
-        usage = t.get("usage") or {}
-        cost = t.get("totalCost") or 0
-        total_cost += cost
-
-        # Latency
-        latency = t.get("latency")
-        if latency is not None:
-            latencies.append(latency * 1000)  # seconds to ms
-
-    # Fetch scores separately (trace.scores is a list of IDs, not objects)
-    all_score_objs = await fetch_all_scores()
-    for s in all_score_objs:
-        val = s.get("value")
-        if val is not None:
-            all_scores.append(float(val))
-
-    traces_per_session = [len(v) for v in sessions.values()]
-    median_tps = statistics.median(traces_per_session) if traces_per_session else 0
-    p90_tps = (
-        sorted(traces_per_session)[int(len(traces_per_session) * 0.9)]
-        if traces_per_session
-        else 0
-    )
-
-    return KPIResponse(
-        sessions_count=len(sessions),
-        traces_count=len(traces),
-        projects_count=len(projects),
-        active_days=len(days),
-        median_traces_per_session=median_tps,
-        p90_traces_per_session=p90_tps,
-        avg_latency_ms=(
-            statistics.mean(latencies) if latencies else 0
-        ),
-        total_cost=round(total_cost, 6),
-        avg_score=(
-            round(statistics.mean(all_scores), 3) if all_scores else None
-        ),
-    )
+    return await get_kpi(from_ts=from_ts, to_ts=to_ts, project=project)

--- a/dashboard/routes/kpi.py
+++ b/dashboard/routes/kpi.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from fastapi import APIRouter, Query
 
 from data_models import KPIResponse
-from langfuse_client import fetch_all_traces
+from langfuse_client import fetch_all_scores, fetch_all_traces
 
 router = APIRouter()
 
@@ -57,11 +57,12 @@ async def get_kpi(
         if latency is not None:
             latencies.append(latency * 1000)  # seconds to ms
 
-        # Scores
-        for score in (t.get("scores") or []):
-            val = score.get("value")
-            if val is not None:
-                all_scores.append(val)
+    # Fetch scores separately (trace.scores is a list of IDs, not objects)
+    all_score_objs = await fetch_all_scores()
+    for s in all_score_objs:
+        val = s.get("value")
+        if val is not None:
+            all_scores.append(float(val))
 
     traces_per_session = [len(v) for v in sessions.values()]
     median_tps = statistics.median(traces_per_session) if traces_per_session else 0

--- a/dashboard/routes/kpi.py
+++ b/dashboard/routes/kpi.py
@@ -1,0 +1,88 @@
+"""KPI endpoint — aggregate stats across all traces."""
+
+import statistics
+from collections import defaultdict
+from datetime import datetime
+
+from fastapi import APIRouter, Query
+
+from data_models import KPIResponse
+from langfuse_client import fetch_all_traces
+
+router = APIRouter()
+
+
+@router.get("/api/kpi", response_model=KPIResponse)
+async def get_kpi(
+    from_ts: str | None = Query(None, alias="from"),
+    to_ts: str | None = Query(None, alias="to"),
+    project: str | None = Query(None),
+):
+    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
+
+    if not traces:
+        return KPIResponse()
+
+    # Group by session
+    sessions: dict[str, list[dict]] = defaultdict(list)
+    projects: set[str] = set()
+    days: set[str] = set()
+    total_cost = 0.0
+    latencies = []
+    all_scores = []
+
+    for t in traces:
+        sid = t.get("sessionId") or "no-session"
+        sessions[sid].append(t)
+
+        name = t.get("name")
+        if name:
+            projects.add(name)
+
+        ts = t.get("timestamp")
+        if ts:
+            try:
+                day = ts[:10]
+                days.add(day)
+            except (IndexError, TypeError):
+                pass
+
+        # Cost from usage
+        usage = t.get("usage") or {}
+        cost = t.get("totalCost") or 0
+        total_cost += cost
+
+        # Latency
+        latency = t.get("latency")
+        if latency is not None:
+            latencies.append(latency * 1000)  # seconds to ms
+
+        # Scores
+        for score in (t.get("scores") or []):
+            val = score.get("value")
+            if val is not None:
+                all_scores.append(val)
+
+    traces_per_session = [len(v) for v in sessions.values()]
+    median_tps = statistics.median(traces_per_session) if traces_per_session else 0
+    p90_tps = (
+        sorted(traces_per_session)[int(len(traces_per_session) * 0.9)]
+        if traces_per_session
+        else 0
+    )
+
+    return KPIResponse(
+        sessions_count=len(sessions),
+        traces_count=len(traces),
+        projects_count=len(projects),
+        active_days=len(days),
+        median_traces_per_session=median_tps,
+        p90_traces_per_session=p90_tps,
+        avg_latency_ms=(
+            statistics.mean(latencies) if latencies else 0
+        ),
+        total_cost=round(total_cost, 6),
+        avg_score=(
+            round(statistics.mean(all_scores), 3) if all_scores else None
+        ),
+    )

--- a/dashboard/routes/projects.py
+++ b/dashboard/routes/projects.py
@@ -1,0 +1,24 @@
+"""Projects endpoint — distinct project names from traces."""
+
+from fastapi import APIRouter, Query
+
+from data_models import ProjectResponse
+from langfuse_client import fetch_all_traces
+
+router = APIRouter()
+
+
+@router.get("/api/projects", response_model=ProjectResponse)
+async def get_projects(
+    from_ts: str | None = Query(None, alias="from"),
+    to_ts: str | None = Query(None, alias="to"),
+):
+    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts)
+
+    projects = set()
+    for t in traces:
+        name = t.get("name")
+        if name:
+            projects.add(name)
+
+    return ProjectResponse(projects=sorted(projects))

--- a/dashboard/routes/projects.py
+++ b/dashboard/routes/projects.py
@@ -1,24 +1,16 @@
-"""Projects endpoint — distinct project names from traces."""
+"""Projects — powered by ClickHouse."""
 
 from fastapi import APIRouter, Query
 
-from data_models import ProjectResponse
-from langfuse_client import fetch_all_traces
+from clickhouse_client import get_projects
 
 router = APIRouter()
 
 
-@router.get("/api/projects", response_model=ProjectResponse)
-async def get_projects(
+@router.get("/api/projects")
+async def projects_endpoint(
     from_ts: str | None = Query(None, alias="from"),
     to_ts: str | None = Query(None, alias="to"),
 ):
-    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts)
-
-    projects = set()
-    for t in traces:
-        name = t.get("name")
-        if name:
-            projects.add(name)
-
-    return ProjectResponse(projects=sorted(projects))
+    projects = await get_projects(from_ts=from_ts, to_ts=to_ts)
+    return {"projects": projects}

--- a/dashboard/routes/scores.py
+++ b/dashboard/routes/scores.py
@@ -1,0 +1,38 @@
+"""Quality score analytics."""
+
+import statistics
+from collections import defaultdict
+
+from fastapi import APIRouter, Query
+
+from data_models import ScoreDistribution, ScoresResponse
+from langfuse_client import fetch_all_scores
+
+router = APIRouter()
+
+
+@router.get("/api/scores", response_model=ScoresResponse)
+async def get_scores():
+    all_scores = await fetch_all_scores()
+
+    grouped: dict[str, list[float]] = defaultdict(list)
+    for s in all_scores:
+        name = s.get("name")
+        val = s.get("value")
+        if name and val is not None:
+            grouped[name].append(float(val))
+
+    distributions = []
+    for name, values in sorted(grouped.items()):
+        distributions.append(
+            ScoreDistribution(
+                name=name,
+                count=len(values),
+                avg=round(statistics.mean(values), 3),
+                min=round(min(values), 3),
+                max=round(max(values), 3),
+                values=values,
+            )
+        )
+
+    return ScoresResponse(scores=distributions)

--- a/dashboard/routes/scores.py
+++ b/dashboard/routes/scores.py
@@ -1,38 +1,13 @@
-"""Quality score analytics."""
+"""Quality scores — powered by ClickHouse."""
 
-import statistics
-from collections import defaultdict
+from fastapi import APIRouter
 
-from fastapi import APIRouter, Query
-
-from data_models import ScoreDistribution, ScoresResponse
-from langfuse_client import fetch_all_scores
+from clickhouse_client import get_scores
 
 router = APIRouter()
 
 
-@router.get("/api/scores", response_model=ScoresResponse)
-async def get_scores():
-    all_scores = await fetch_all_scores()
-
-    grouped: dict[str, list[float]] = defaultdict(list)
-    for s in all_scores:
-        name = s.get("name")
-        val = s.get("value")
-        if name and val is not None:
-            grouped[name].append(float(val))
-
-    distributions = []
-    for name, values in sorted(grouped.items()):
-        distributions.append(
-            ScoreDistribution(
-                name=name,
-                count=len(values),
-                avg=round(statistics.mean(values), 3),
-                min=round(min(values), 3),
-                max=round(max(values), 3),
-                values=values,
-            )
-        )
-
-    return ScoresResponse(scores=distributions)
+@router.get("/api/scores")
+async def scores_endpoint():
+    scores = await get_scores()
+    return {"scores": scores}

--- a/dashboard/routes/sessions.py
+++ b/dashboard/routes/sessions.py
@@ -1,157 +1,27 @@
-"""Session list and detail endpoints."""
-
-from collections import defaultdict
+"""Session list and detail — powered by ClickHouse."""
 
 from fastapi import APIRouter, Query
 
-from data_models import (
-    SessionDetailResponse,
-    SessionListResponse,
-    SessionSummary,
-    TraceDetail,
-)
-from langfuse_client import fetch_all_scores, fetch_all_traces, fetch_traces
+from clickhouse_client import get_session_detail, get_sessions
 
 router = APIRouter()
 
 
-def _build_session_summaries(traces: list[dict]) -> list[SessionSummary]:
-    """Group traces into session summaries."""
-    sessions: dict[str, list[dict]] = defaultdict(list)
-    for t in traces:
-        sid = t.get("sessionId")
-        if sid:
-            sessions[sid].append(t)
-
-    summaries = []
-    for sid, session_traces in sessions.items():
-        # Sort by timestamp
-        session_traces.sort(key=lambda t: t.get("timestamp") or "")
-
-        total_cost = sum(t.get("totalCost") or 0 for t in session_traces)
-        total_latency = sum(
-            (t.get("latency") or 0) * 1000 for t in session_traces
-        )
-        total_tokens = 0
-        for t in session_traces:
-            usage = t.get("usage") or {}
-            total_tokens += usage.get("totalTokens") or usage.get("total") or 0
-
-        # Use first trace's name as project
-        project = session_traces[0].get("name") if session_traces else None
-
-        summaries.append(
-            SessionSummary(
-                id=sid,
-                trace_count=len(session_traces),
-                first_trace=session_traces[0].get("timestamp") if session_traces else None,
-                last_trace=session_traces[-1].get("timestamp") if session_traces else None,
-                project=project,
-                total_cost=round(total_cost, 6),
-                total_latency_ms=round(total_latency, 1),
-                total_tokens=total_tokens,
-            )
-        )
-
-    # Sort by most recent first
-    summaries.sort(key=lambda s: s.last_trace or "", reverse=True)
-    return summaries
-
-
-@router.get("/api/sessions", response_model=SessionListResponse)
-async def get_sessions(
+@router.get("/api/sessions")
+async def sessions_endpoint(
     from_ts: str | None = Query(None, alias="from"),
     to_ts: str | None = Query(None, alias="to"),
     project: str | None = Query(None),
-    page: int = Query(1, ge=1),
-    limit: int = Query(50, ge=1, le=200),
+    limit: int = Query(200, ge=1, le=500),
     search: str | None = Query(None),
 ):
-    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
-
-    # Apply search filter
-    if search:
-        search_lower = search.lower()
-        traces = [
-            t for t in traces
-            if search_lower in (t.get("name") or "").lower()
-            or search_lower in (t.get("sessionId") or "").lower()
-            or search_lower in str(t.get("input") or "").lower()
-        ]
-
-    summaries = _build_session_summaries(traces)
-    total = len(summaries)
-
-    # Paginate
-    start = (page - 1) * limit
-    end = start + limit
-    page_summaries = summaries[start:end]
-
-    return SessionListResponse(
-        sessions=page_summaries,
-        total=total,
-        page=page,
-        limit=limit,
+    sessions = await get_sessions(
+        from_ts=from_ts, to_ts=to_ts, project=project,
+        search=search, limit=limit,
     )
+    return {"sessions": sessions, "total": len(sessions), "page": 1, "limit": limit}
 
 
-@router.get("/api/sessions/{session_id}", response_model=SessionDetailResponse)
-async def get_session_detail(session_id: str):
-    result = await fetch_traces(session_id=session_id, limit=100)
-    traces_data = result.get("data", [])
-
-    traces_data.sort(key=lambda t: t.get("timestamp") or "")
-
-    # Build trace_id -> scores mapping from scores API
-    all_scores = await fetch_all_scores()
-    trace_scores: dict[str, dict[str, float]] = defaultdict(dict)
-    for s in all_scores:
-        tid = s.get("traceId")
-        name = s.get("name")
-        val = s.get("value")
-        if tid and name and val is not None:
-            trace_scores[tid][name] = float(val)
-
-    trace_details = []
-    total_cost = 0.0
-    total_tokens = 0
-    total_latency = 0.0
-
-    for t in traces_data:
-        cost = t.get("totalCost") or 0
-        latency = (t.get("latency") or 0) * 1000
-        usage = t.get("usage") or {}
-        tokens = usage.get("totalTokens") or usage.get("total") or 0
-
-        total_cost += cost
-        total_tokens += tokens
-        total_latency += latency
-
-        # Truncate input/output for display
-        raw_input = t.get("input")
-        raw_output = t.get("output")
-        input_str = str(raw_input)[:500] if raw_input else None
-        output_str = str(raw_output)[:500] if raw_output else None
-
-        trace_details.append(
-            TraceDetail(
-                id=t.get("id", ""),
-                name=t.get("name"),
-                timestamp=t.get("timestamp"),
-                input=input_str,
-                output=output_str,
-                latency_ms=round(latency, 1),
-                cost=round(cost, 6),
-                tokens=tokens,
-                scores=trace_scores.get(t.get("id", ""), {}),
-            )
-        )
-
-    return SessionDetailResponse(
-        id=session_id,
-        traces=trace_details,
-        total_cost=round(total_cost, 6),
-        total_tokens=total_tokens,
-        total_latency_ms=round(total_latency, 1),
-        trace_count=len(trace_details),
-    )
+@router.get("/api/sessions/{session_id}")
+async def session_detail_endpoint(session_id: str):
+    return await get_session_detail(session_id)

--- a/dashboard/routes/sessions.py
+++ b/dashboard/routes/sessions.py
@@ -10,7 +10,7 @@ from data_models import (
     SessionSummary,
     TraceDetail,
 )
-from langfuse_client import fetch_all_traces, fetch_traces
+from langfuse_client import fetch_all_scores, fetch_all_traces, fetch_traces
 
 router = APIRouter()
 
@@ -102,6 +102,16 @@ async def get_session_detail(session_id: str):
 
     traces_data.sort(key=lambda t: t.get("timestamp") or "")
 
+    # Build trace_id -> scores mapping from scores API
+    all_scores = await fetch_all_scores()
+    trace_scores: dict[str, dict[str, float]] = defaultdict(dict)
+    for s in all_scores:
+        tid = s.get("traceId")
+        name = s.get("name")
+        val = s.get("value")
+        if tid and name and val is not None:
+            trace_scores[tid][name] = float(val)
+
     trace_details = []
     total_cost = 0.0
     total_tokens = 0
@@ -116,14 +126,6 @@ async def get_session_detail(session_id: str):
         total_cost += cost
         total_tokens += tokens
         total_latency += latency
-
-        # Extract scores
-        scores = {}
-        for score in (t.get("scores") or []):
-            name = score.get("name")
-            val = score.get("value")
-            if name and val is not None:
-                scores[name] = val
 
         # Truncate input/output for display
         raw_input = t.get("input")
@@ -141,7 +143,7 @@ async def get_session_detail(session_id: str):
                 latency_ms=round(latency, 1),
                 cost=round(cost, 6),
                 tokens=tokens,
-                scores=scores,
+                scores=trace_scores.get(t.get("id", ""), {}),
             )
         )
 

--- a/dashboard/routes/sessions.py
+++ b/dashboard/routes/sessions.py
@@ -1,0 +1,155 @@
+"""Session list and detail endpoints."""
+
+from collections import defaultdict
+
+from fastapi import APIRouter, Query
+
+from data_models import (
+    SessionDetailResponse,
+    SessionListResponse,
+    SessionSummary,
+    TraceDetail,
+)
+from langfuse_client import fetch_all_traces, fetch_traces
+
+router = APIRouter()
+
+
+def _build_session_summaries(traces: list[dict]) -> list[SessionSummary]:
+    """Group traces into session summaries."""
+    sessions: dict[str, list[dict]] = defaultdict(list)
+    for t in traces:
+        sid = t.get("sessionId")
+        if sid:
+            sessions[sid].append(t)
+
+    summaries = []
+    for sid, session_traces in sessions.items():
+        # Sort by timestamp
+        session_traces.sort(key=lambda t: t.get("timestamp") or "")
+
+        total_cost = sum(t.get("totalCost") or 0 for t in session_traces)
+        total_latency = sum(
+            (t.get("latency") or 0) * 1000 for t in session_traces
+        )
+        total_tokens = 0
+        for t in session_traces:
+            usage = t.get("usage") or {}
+            total_tokens += usage.get("totalTokens") or usage.get("total") or 0
+
+        # Use first trace's name as project
+        project = session_traces[0].get("name") if session_traces else None
+
+        summaries.append(
+            SessionSummary(
+                id=sid,
+                trace_count=len(session_traces),
+                first_trace=session_traces[0].get("timestamp") if session_traces else None,
+                last_trace=session_traces[-1].get("timestamp") if session_traces else None,
+                project=project,
+                total_cost=round(total_cost, 6),
+                total_latency_ms=round(total_latency, 1),
+                total_tokens=total_tokens,
+            )
+        )
+
+    # Sort by most recent first
+    summaries.sort(key=lambda s: s.last_trace or "", reverse=True)
+    return summaries
+
+
+@router.get("/api/sessions", response_model=SessionListResponse)
+async def get_sessions(
+    from_ts: str | None = Query(None, alias="from"),
+    to_ts: str | None = Query(None, alias="to"),
+    project: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    search: str | None = Query(None),
+):
+    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
+
+    # Apply search filter
+    if search:
+        search_lower = search.lower()
+        traces = [
+            t for t in traces
+            if search_lower in (t.get("name") or "").lower()
+            or search_lower in (t.get("sessionId") or "").lower()
+            or search_lower in str(t.get("input") or "").lower()
+        ]
+
+    summaries = _build_session_summaries(traces)
+    total = len(summaries)
+
+    # Paginate
+    start = (page - 1) * limit
+    end = start + limit
+    page_summaries = summaries[start:end]
+
+    return SessionListResponse(
+        sessions=page_summaries,
+        total=total,
+        page=page,
+        limit=limit,
+    )
+
+
+@router.get("/api/sessions/{session_id}", response_model=SessionDetailResponse)
+async def get_session_detail(session_id: str):
+    result = await fetch_traces(session_id=session_id, limit=100)
+    traces_data = result.get("data", [])
+
+    traces_data.sort(key=lambda t: t.get("timestamp") or "")
+
+    trace_details = []
+    total_cost = 0.0
+    total_tokens = 0
+    total_latency = 0.0
+
+    for t in traces_data:
+        cost = t.get("totalCost") or 0
+        latency = (t.get("latency") or 0) * 1000
+        usage = t.get("usage") or {}
+        tokens = usage.get("totalTokens") or usage.get("total") or 0
+
+        total_cost += cost
+        total_tokens += tokens
+        total_latency += latency
+
+        # Extract scores
+        scores = {}
+        for score in (t.get("scores") or []):
+            name = score.get("name")
+            val = score.get("value")
+            if name and val is not None:
+                scores[name] = val
+
+        # Truncate input/output for display
+        raw_input = t.get("input")
+        raw_output = t.get("output")
+        input_str = str(raw_input)[:500] if raw_input else None
+        output_str = str(raw_output)[:500] if raw_output else None
+
+        trace_details.append(
+            TraceDetail(
+                id=t.get("id", ""),
+                name=t.get("name"),
+                timestamp=t.get("timestamp"),
+                input=input_str,
+                output=output_str,
+                latency_ms=round(latency, 1),
+                cost=round(cost, 6),
+                tokens=tokens,
+                scores=scores,
+            )
+        )
+
+    return SessionDetailResponse(
+        id=session_id,
+        traces=trace_details,
+        total_cost=round(total_cost, 6),
+        total_tokens=total_tokens,
+        total_latency_ms=round(total_latency, 1),
+        trace_count=len(trace_details),
+    )

--- a/dashboard/routes/tools.py
+++ b/dashboard/routes/tools.py
@@ -1,0 +1,56 @@
+"""Tool/span usage analytics."""
+
+from collections import defaultdict
+
+from fastapi import APIRouter, Query
+
+from data_models import ToolUsage, ToolsResponse
+from langfuse_client import fetch_all_observations
+
+router = APIRouter()
+
+
+@router.get("/api/tools", response_model=ToolsResponse)
+async def get_tools(
+    from_ts: str | None = Query(None, alias="from"),
+    to_ts: str | None = Query(None, alias="to"),
+):
+    observations = await fetch_all_observations(
+        obs_type="SPAN", from_ts=from_ts, to_ts=to_ts
+    )
+
+    tool_stats: dict[str, dict] = defaultdict(
+        lambda: {"count": 0, "total_latency": 0.0}
+    )
+
+    for obs in observations:
+        name = obs.get("name") or "unknown"
+        tool_stats[name]["count"] += 1
+
+        start = obs.get("startTime")
+        end = obs.get("endTime")
+        if start and end:
+            from datetime import datetime
+
+            try:
+                s = datetime.fromisoformat(start.replace("Z", "+00:00"))
+                e = datetime.fromisoformat(end.replace("Z", "+00:00"))
+                tool_stats[name]["total_latency"] += (e - s).total_seconds() * 1000
+            except (ValueError, TypeError):
+                pass
+
+    tools = []
+    for name, stats in tool_stats.items():
+        avg_lat = (
+            stats["total_latency"] / stats["count"] if stats["count"] > 0 else 0
+        )
+        tools.append(
+            ToolUsage(
+                name=name,
+                count=stats["count"],
+                avg_latency_ms=round(avg_lat, 1),
+            )
+        )
+
+    tools.sort(key=lambda t: t.count, reverse=True)
+    return ToolsResponse(tools=tools)

--- a/dashboard/routes/tools.py
+++ b/dashboard/routes/tools.py
@@ -1,56 +1,16 @@
-"""Tool/span usage analytics."""
-
-from collections import defaultdict
+"""Tool/span usage — powered by ClickHouse."""
 
 from fastapi import APIRouter, Query
 
-from data_models import ToolUsage, ToolsResponse
-from langfuse_client import fetch_all_observations
+from clickhouse_client import get_tools
 
 router = APIRouter()
 
 
-@router.get("/api/tools", response_model=ToolsResponse)
-async def get_tools(
+@router.get("/api/tools")
+async def tools_endpoint(
     from_ts: str | None = Query(None, alias="from"),
     to_ts: str | None = Query(None, alias="to"),
 ):
-    observations = await fetch_all_observations(
-        obs_type="SPAN", from_ts=from_ts, to_ts=to_ts
-    )
-
-    tool_stats: dict[str, dict] = defaultdict(
-        lambda: {"count": 0, "total_latency": 0.0}
-    )
-
-    for obs in observations:
-        name = obs.get("name") or "unknown"
-        tool_stats[name]["count"] += 1
-
-        start = obs.get("startTime")
-        end = obs.get("endTime")
-        if start and end:
-            from datetime import datetime
-
-            try:
-                s = datetime.fromisoformat(start.replace("Z", "+00:00"))
-                e = datetime.fromisoformat(end.replace("Z", "+00:00"))
-                tool_stats[name]["total_latency"] += (e - s).total_seconds() * 1000
-            except (ValueError, TypeError):
-                pass
-
-    tools = []
-    for name, stats in tool_stats.items():
-        avg_lat = (
-            stats["total_latency"] / stats["count"] if stats["count"] > 0 else 0
-        )
-        tools.append(
-            ToolUsage(
-                name=name,
-                count=stats["count"],
-                avg_latency_ms=round(avg_lat, 1),
-            )
-        )
-
-    tools.sort(key=lambda t: t.count, reverse=True)
-    return ToolsResponse(tools=tools)
+    tools = await get_tools(from_ts=from_ts, to_ts=to_ts)
+    return {"tools": tools}

--- a/dashboard/routes/top_sessions.py
+++ b/dashboard/routes/top_sessions.py
@@ -1,0 +1,57 @@
+"""Top sessions ranked by various metrics."""
+
+from collections import defaultdict
+
+from fastapi import APIRouter, Query
+
+from data_models import TopSession, TopSessionsResponse
+from langfuse_client import fetch_all_traces
+
+router = APIRouter()
+
+
+@router.get("/api/top-sessions", response_model=TopSessionsResponse)
+async def get_top_sessions(
+    sort: str = Query("traces", regex="^(traces|duration|cost)$"),
+    limit: int = Query(10, ge=1, le=50),
+    from_ts: str | None = Query(None, alias="from"),
+    to_ts: str | None = Query(None, alias="to"),
+    project: str | None = Query(None),
+):
+    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
+
+    sessions: dict[str, list[dict]] = defaultdict(list)
+    for t in traces:
+        sid = t.get("sessionId")
+        if sid:
+            sessions[sid].append(t)
+
+    top = []
+    for sid, session_traces in sessions.items():
+        session_traces.sort(key=lambda t: t.get("timestamp") or "")
+        total_cost = sum(t.get("totalCost") or 0 for t in session_traces)
+        total_duration = sum((t.get("latency") or 0) * 1000 for t in session_traces)
+        project_name = session_traces[0].get("name") if session_traces else None
+
+        top.append(
+            TopSession(
+                id=sid,
+                project=project_name,
+                trace_count=len(session_traces),
+                total_duration_ms=round(total_duration, 1),
+                total_cost=round(total_cost, 6),
+                first_trace=session_traces[0].get("timestamp") if session_traces else None,
+            )
+        )
+
+    sort_key = {
+        "traces": lambda s: s.trace_count,
+        "duration": lambda s: s.total_duration_ms,
+        "cost": lambda s: s.total_cost,
+    }
+    top.sort(key=sort_key[sort], reverse=True)
+
+    return TopSessionsResponse(
+        sessions=top[:limit],
+        sort_by=sort,
+    )

--- a/dashboard/routes/top_sessions.py
+++ b/dashboard/routes/top_sessions.py
@@ -1,57 +1,21 @@
-"""Top sessions ranked by various metrics."""
-
-from collections import defaultdict
+"""Top sessions — powered by ClickHouse."""
 
 from fastapi import APIRouter, Query
 
-from data_models import TopSession, TopSessionsResponse
-from langfuse_client import fetch_all_traces
+from clickhouse_client import get_top_sessions
 
 router = APIRouter()
 
 
-@router.get("/api/top-sessions", response_model=TopSessionsResponse)
-async def get_top_sessions(
-    sort: str = Query("traces", regex="^(traces|duration|cost)$"),
+@router.get("/api/top-sessions")
+async def top_sessions_endpoint(
+    sort: str = Query("traces"),
     limit: int = Query(10, ge=1, le=50),
     from_ts: str | None = Query(None, alias="from"),
     to_ts: str | None = Query(None, alias="to"),
     project: str | None = Query(None),
 ):
-    traces = await fetch_all_traces(from_ts=from_ts, to_ts=to_ts, name=project)
-
-    sessions: dict[str, list[dict]] = defaultdict(list)
-    for t in traces:
-        sid = t.get("sessionId")
-        if sid:
-            sessions[sid].append(t)
-
-    top = []
-    for sid, session_traces in sessions.items():
-        session_traces.sort(key=lambda t: t.get("timestamp") or "")
-        total_cost = sum(t.get("totalCost") or 0 for t in session_traces)
-        total_duration = sum((t.get("latency") or 0) * 1000 for t in session_traces)
-        project_name = session_traces[0].get("name") if session_traces else None
-
-        top.append(
-            TopSession(
-                id=sid,
-                project=project_name,
-                trace_count=len(session_traces),
-                total_duration_ms=round(total_duration, 1),
-                total_cost=round(total_cost, 6),
-                first_trace=session_traces[0].get("timestamp") if session_traces else None,
-            )
-        )
-
-    sort_key = {
-        "traces": lambda s: s.trace_count,
-        "duration": lambda s: s.total_duration_ms,
-        "cost": lambda s: s.total_cost,
-    }
-    top.sort(key=sort_key[sort], reverse=True)
-
-    return TopSessionsResponse(
-        sessions=top[:limit],
-        sort_by=sort,
+    sessions = await get_top_sessions(
+        sort=sort, limit=limit, from_ts=from_ts, to_ts=to_ts, project=project,
     )
+    return {"sessions": sessions, "sort_by": sort}

--- a/dashboard/static/css/dashboard.css
+++ b/dashboard/static/css/dashboard.css
@@ -1,31 +1,30 @@
-/* LLM Observatory — Clean light theme */
+/* LLM Observatory — Clean light theme inspired by AgentsView */
 
 :root {
   --bg: #f8f9fa;
   --surface: #ffffff;
-  --border: #e2e8f0;
+  --border: #e5e7eb;
+  --border-light: #f0f0f0;
   --text: #1a202c;
-  --text-secondary: #64748b;
-  --text-muted: #94a3b8;
-  --primary: #3b82f6;
-  --primary-light: #eff6ff;
+  --text-secondary: #6b7280;
+  --text-muted: #9ca3af;
+  --primary: #4f46e5;
+  --primary-light: #eef2ff;
+  --primary-bg: #6366f1;
   --success: #10b981;
   --warning: #f59e0b;
   --danger: #ef4444;
+  --orange: #f97316;
   --heatmap-0: #ebedf0;
   --heatmap-1: #9be9a8;
   --heatmap-2: #40c463;
   --heatmap-3: #30a14e;
   --heatmap-4: #216e39;
-  --sidebar-width: 320px;
-  --header-height: 56px;
+  --sidebar-width: 260px;
+  --header-height: 48px;
 }
 
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
+* { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -35,38 +34,52 @@ body {
   line-height: 1.5;
 }
 
-/* Header */
+/* ==================== HEADER ==================== */
 .header {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  top: 0; left: 0; right: 0;
   height: var(--header-height);
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
-  padding: 0 20px;
+  padding: 0 16px;
   z-index: 100;
-  gap: 16px;
+  gap: 12px;
 }
 
 .header h1 {
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 15px;
+  font-weight: 700;
   white-space: nowrap;
+  color: var(--text);
 }
 
 .header-controls {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   margin-left: auto;
 }
 
 /* Filter controls */
-select, input[type="search"] {
-  height: 32px;
+select {
+  height: 30px;
+  padding: 0 28px 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+  background: var(--surface);
+  color: var(--text);
+  outline: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1L5 5L9 1' stroke='%236b7280' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+
+input[type="search"], input[type="text"] {
+  height: 30px;
   padding: 0 10px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -78,7 +91,35 @@ select, input[type="search"] {
 
 select:focus, input:focus {
   border-color: var(--primary);
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.1);
+}
+
+/* Search button in header */
+.search-trigger {
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 200px;
+}
+
+.search-trigger:hover { border-color: var(--text-muted); }
+
+.search-trigger kbd {
+  font-size: 10px;
+  padding: 1px 5px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: inherit;
+  margin-left: auto;
 }
 
 .time-range-group {
@@ -89,65 +130,42 @@ select:focus, input:focus {
 }
 
 .time-range-group button {
-  height: 32px;
-  padding: 0 12px;
+  height: 30px;
+  padding: 0 10px;
   border: none;
   background: var(--surface);
-  font-size: 13px;
+  font-size: 12px;
   cursor: pointer;
   color: var(--text-secondary);
   border-right: 1px solid var(--border);
 }
 
-.time-range-group button:last-child {
-  border-right: none;
-}
-
-.time-range-group button.active {
-  background: var(--primary);
-  color: white;
-}
-
-.time-range-group button:hover:not(.active) {
-  background: var(--bg);
-}
+.time-range-group button:last-child { border-right: none; }
+.time-range-group button.active { background: var(--primary-bg); color: white; }
+.time-range-group button:hover:not(.active) { background: var(--bg); }
 
 .btn {
-  height: 32px;
-  padding: 0 14px;
-  border: 1px solid var(--border);
+  height: 30px;
+  padding: 0 12px;
+  border: none;
   border-radius: 6px;
-  background: var(--surface);
+  background: transparent;
   font-size: 13px;
   cursor: pointer;
-  color: var(--text);
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  color: var(--text-secondary);
+  white-space: nowrap;
 }
 
-.btn:hover {
-  background: var(--bg);
-}
+.btn:hover { color: var(--text); }
 
-.btn-primary {
-  background: var(--primary);
-  color: white;
-  border-color: var(--primary);
-}
-
-.btn-primary:hover {
-  background: #2563eb;
-}
-
-/* Layout */
+/* ==================== LAYOUT ==================== */
 .layout {
   display: flex;
   margin-top: var(--header-height);
   min-height: calc(100vh - var(--header-height));
 }
 
-/* Sidebar */
+/* ==================== SIDEBAR ==================== */
 .sidebar {
   width: var(--sidebar-width);
   background: var(--surface);
@@ -157,129 +175,180 @@ select:focus, input:focus {
   top: var(--header-height);
   bottom: 0;
   left: 0;
+  display: flex;
+  flex-direction: column;
 }
 
-.sidebar-search {
-  padding: 12px;
-  border-bottom: 1px solid var(--border);
-  position: sticky;
-  top: 0;
-  background: var(--surface);
-  z-index: 10;
-}
-
-.sidebar-search input {
-  width: 100%;
+.sidebar-header {
+  padding: 10px 14px 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  flex-shrink: 0;
 }
 
 .session-list {
   list-style: none;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .session-item {
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--border);
+  padding: 8px 14px;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.1s;
+  border-left: 3px solid transparent;
 }
 
-.session-item:hover {
-  background: var(--bg);
-}
+.session-item:hover { background: var(--bg); }
 
 .session-item.active {
   background: var(--primary-light);
-  border-left: 3px solid var(--primary);
-  padding-left: 11px;
+  border-left-color: var(--primary);
 }
 
-.session-id {
+.session-title {
   font-size: 13px;
   font-weight: 500;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: 1.3;
 }
 
 .session-meta {
-  font-size: 12px;
-  color: var(--text-secondary);
-  margin-top: 2px;
-  display: flex;
-  gap: 10px;
-}
-
-.session-project {
   font-size: 11px;
-  color: var(--primary);
-  background: var(--primary-light);
-  padding: 1px 6px;
-  border-radius: 3px;
-  display: inline-block;
-  margin-top: 4px;
+  color: var(--text-muted);
+  margin-top: 1px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-/* Main content */
+.session-meta .project-name {
+  color: var(--text-secondary);
+}
+
+.session-meta .trace-badge {
+  color: var(--text-muted);
+}
+
+.sidebar-footer {
+  padding: 8px 14px;
+  font-size: 11px;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  display: flex;
+  gap: 12px;
+}
+
+/* ==================== MAIN CONTENT ==================== */
 .main {
   margin-left: var(--sidebar-width);
   flex: 1;
-  padding: 20px;
+  padding: 16px 20px;
   max-width: calc(100% - var(--sidebar-width));
 }
 
-/* KPI Cards */
+/* ==================== KPI CARDS ==================== */
 .kpi-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 12px;
-  margin-bottom: 24px;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1px;
+  margin-bottom: 16px;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .kpi-card {
   background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 14px;
-}
-
-.kpi-label {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--text-muted);
-  margin-bottom: 4px;
+  padding: 14px 16px;
 }
 
 .kpi-value {
-  font-size: 22px;
-  font-weight: 600;
+  font-size: 28px;
+  font-weight: 700;
   color: var(--text);
+  line-height: 1.1;
 }
 
-.kpi-value.small {
-  font-size: 18px;
+.kpi-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
 }
 
-/* Section */
+.kpi-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* ==================== SECTIONS ==================== */
 .section {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 16px;
-  margin-bottom: 20px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
 }
 
 .section-title {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
-  margin-bottom: 12px;
   color: var(--text);
 }
 
-/* Heatmap */
-.heatmap-container {
-  overflow-x: auto;
+/* ==================== HEATMAP ==================== */
+.heatmap-container { overflow-x: auto; }
+
+.heatmap-wrapper {
+  display: inline-flex;
+  gap: 0;
+  min-width: 100%;
+}
+
+.heatmap-day-labels {
+  display: flex;
+  flex-direction: column;
+  padding-top: 22px;
+  gap: 3px;
+  flex-shrink: 0;
+  width: 40px;
+}
+
+.heatmap-day-label {
+  height: 13px;
+  font-size: 11px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 8px;
+}
+
+.heatmap-grid-area { flex: 1; min-width: 0; }
+
+.heatmap-months {
+  height: 18px;
+  position: relative;
+  margin-bottom: 4px;
+}
+
+.heatmap-month {
+  position: absolute;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
 }
 
 .heatmap {
@@ -305,18 +374,6 @@ select:focus, input:focus {
 .heatmap-cell[data-level="3"] { background: var(--heatmap-3); }
 .heatmap-cell[data-level="4"] { background: var(--heatmap-4); }
 
-.heatmap-months {
-  display: flex;
-  font-size: 11px;
-  color: var(--text-muted);
-  margin-bottom: 6px;
-  padding-left: 2px;
-}
-
-.heatmap-month {
-  flex: none;
-}
-
 .heatmap-legend {
   display: flex;
   align-items: center;
@@ -327,17 +384,28 @@ select:focus, input:focus {
   justify-content: flex-end;
 }
 
-.heatmap-legend .heatmap-cell {
-  width: 11px;
-  height: 11px;
+.heatmap-legend .heatmap-cell { width: 11px; height: 11px; }
+
+/* ==================== CHARTS ==================== */
+.charts-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 16px;
 }
 
-/* Hour x Day grid */
+.chart-container { position: relative; height: 220px; }
+
+@media (max-width: 1200px) {
+  .charts-row { grid-template-columns: 1fr; }
+  .kpi-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+/* ==================== HOUR GRID ==================== */
 .hour-grid {
   display: grid;
   grid-template-columns: 36px repeat(24, 1fr);
-  gap: 2px;
-  font-size: 11px;
+  gap: 3px;
 }
 
 .hour-grid-label {
@@ -346,13 +414,15 @@ select:focus, input:focus {
   align-items: center;
   justify-content: flex-end;
   padding-right: 4px;
+  font-size: 11px;
 }
 
 .hour-grid-cell {
-  aspect-ratio: 1;
-  border-radius: 2px;
+  aspect-ratio: 1.5;
+  border-radius: 3px;
   background: var(--heatmap-0);
   min-width: 0;
+  min-height: 16px;
 }
 
 .hour-grid-header {
@@ -361,74 +431,62 @@ select:focus, input:focus {
   font-size: 10px;
 }
 
-/* Charts grid */
-.charts-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-  margin-bottom: 20px;
-}
+/* ==================== TOP SESSIONS ==================== */
+.top-sessions-list { list-style: none; }
 
-@media (max-width: 1200px) {
-  .charts-row {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* Top sessions table */
-.top-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13px;
-}
-
-.top-table th {
-  text-align: left;
-  padding: 8px 10px;
-  border-bottom: 2px solid var(--border);
-  color: var(--text-secondary);
-  font-weight: 500;
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-}
-
-.top-table td {
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border);
-}
-
-.top-table tr:hover td {
-  background: var(--bg);
-}
-
-.top-table .rank {
-  color: var(--text-muted);
-  width: 32px;
-}
-
-.top-table .session-link {
-  color: var(--primary);
+.top-session-item {
+  display: flex;
+  align-items: flex-start;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-light);
+  gap: 10px;
   cursor: pointer;
-  text-decoration: none;
 }
 
-.top-table .session-link:hover {
-  text-decoration: underline;
+.top-session-item:last-child { border-bottom: none; }
+.top-session-item:hover { background: var(--bg); margin: 0 -20px; padding: 8px 20px; }
+
+.top-rank {
+  font-size: 13px;
+  color: var(--text-muted);
+  width: 20px;
+  flex-shrink: 0;
+  padding-top: 1px;
+}
+
+.top-session-info { flex: 1; min-width: 0; }
+
+.top-session-title {
+  font-size: 13px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.top-session-project {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.top-session-metric {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--primary);
+  flex-shrink: 0;
+  padding-top: 2px;
 }
 
 .sort-tabs {
-  display: flex;
+  display: inline-flex;
   gap: 2px;
-  margin-bottom: 12px;
   background: var(--bg);
   border-radius: 6px;
   padding: 2px;
-  display: inline-flex;
 }
 
 .sort-tab {
-  padding: 4px 12px;
+  padding: 3px 10px;
   border: none;
   border-radius: 4px;
   background: transparent;
@@ -443,50 +501,63 @@ select:focus, input:focus {
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 
-/* Tool bars */
+/* ==================== TOOL BARS ==================== */
+.tool-bars-list { max-height: 400px; overflow-y: auto; }
+
 .tool-bar {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
+  margin-bottom: 5px;
 }
 
 .tool-name {
-  font-size: 13px;
+  font-size: 12px;
   width: 120px;
   text-align: right;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+.tool-bar-track {
+  flex: 1;
+  height: 18px;
+  background: var(--bg);
+  border-radius: 3px;
+  overflow: hidden;
 }
 
 .tool-bar-fill {
-  height: 20px;
-  background: var(--primary);
+  height: 100%;
+  background: var(--primary-bg);
   border-radius: 3px;
   min-width: 4px;
-  transition: width 0.3s;
+  opacity: 0.6;
 }
 
 .tool-count {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--text-secondary);
-  width: 40px;
+  width: 32px;
   flex-shrink: 0;
+  text-align: right;
 }
 
-/* Score cards */
+/* ==================== SCORE CARDS ==================== */
 .score-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
 }
 
 .score-card {
   padding: 12px;
   background: var(--bg);
   border-radius: 6px;
+  text-align: center;
 }
 
 .score-name {
@@ -494,95 +565,250 @@ select:focus, input:focus {
   font-weight: 500;
   text-transform: capitalize;
   margin-bottom: 4px;
+  color: var(--text-secondary);
 }
 
-.score-avg {
-  font-size: 28px;
-  font-weight: 700;
+.score-avg { font-size: 28px; font-weight: 700; }
+.score-range { font-size: 10px; color: var(--text-muted); margin-top: 2px; }
+
+/* ==================== SESSION DETAIL VIEW ==================== */
+.session-view {
+  max-width: 800px;
 }
 
-.score-range {
-  font-size: 11px;
-  color: var(--text-muted);
-}
-
-/* Session detail panel */
-.detail-panel {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  margin-bottom: 20px;
-}
-
-.detail-header {
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
+.session-view-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
 }
 
-.detail-header h3 {
-  font-size: 14px;
-}
-
-.detail-stats {
-  display: flex;
-  gap: 20px;
+.session-view-back {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
   font-size: 12px;
   color: var(--text-secondary);
 }
 
-.trace-list {
-  list-style: none;
+.session-view-back:hover { background: var(--bg); }
+
+.session-view-title {
+  font-size: 15px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.trace-item {
-  padding: 12px 16px;
+.session-view-stats {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+  padding-bottom: 12px;
   border-bottom: 1px solid var(--border);
 }
 
-.trace-item:last-child {
-  border-bottom: none;
+.trace-message {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border-light);
 }
 
-.trace-name {
-  font-weight: 500;
-  font-size: 13px;
+.trace-message:last-child { border-bottom: none; }
+
+.trace-message-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
-.trace-time {
+.trace-message-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 12px;
-  color: var(--text-muted);
+  font-weight: 600;
+  color: white;
+  flex-shrink: 0;
 }
 
-.trace-io {
+.trace-message-icon.agent { background: var(--primary-bg); }
+.trace-message-icon.user { background: var(--orange); }
+
+.trace-message-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.trace-message-time {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+.trace-message-body {
+  padding-left: 36px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.trace-message-body .io-block {
+  background: var(--bg);
+  padding: 8px 12px;
+  border-radius: 6px;
   margin-top: 6px;
   font-size: 12px;
-  background: var(--bg);
-  padding: 8px 10px;
-  border-radius: 4px;
-  max-height: 100px;
+  max-height: 120px;
   overflow-y: auto;
   white-space: pre-wrap;
-  word-break: break-all;
+  word-break: break-word;
 }
 
-.trace-scores {
+.trace-message-badges {
+  padding-left: 36px;
   margin-top: 6px;
   display: flex;
-  gap: 8px;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 
-.trace-score-badge {
-  font-size: 11px;
+.trace-badge-pill {
+  font-size: 10px;
   padding: 2px 8px;
   border-radius: 10px;
   background: var(--primary-light);
   color: var(--primary);
 }
 
-/* Loading & Empty states */
+.trace-badge-pill.cost { background: #fef3c7; color: #92400e; }
+.trace-badge-pill.tokens { background: #ecfdf5; color: #065f46; }
+
+/* ==================== SEARCH OVERLAY ==================== */
+.search-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 200;
+  display: flex;
+  justify-content: center;
+  padding-top: 80px;
+}
+
+.search-modal {
+  background: var(--surface);
+  border-radius: 12px;
+  width: 600px;
+  max-height: 500px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.search-input-row {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  gap: 10px;
+}
+
+.search-input-row svg {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.search-input-row input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  background: transparent;
+  color: var(--text);
+}
+
+.search-input-row kbd {
+  font-size: 10px;
+  padding: 2px 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: inherit;
+  color: var(--text-muted);
+}
+
+.search-results {
+  flex: 1;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.search-result-item {
+  padding: 10px 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.search-result-item:hover { background: var(--bg); }
+
+.search-result-icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: white;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.search-result-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-result-project {
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.search-highlight {
+  background: var(--orange);
+  color: white;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
+.search-empty {
+  padding: 30px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+/* ==================== LOADING & STATES ==================== */
 .loading {
   display: flex;
   align-items: center;
@@ -592,8 +818,7 @@ select:focus, input:focus {
 }
 
 .spinner {
-  width: 20px;
-  height: 20px;
+  width: 18px; height: 18px;
   border: 2px solid var(--border);
   border-top-color: var(--primary);
   border-radius: 50%;
@@ -601,57 +826,31 @@ select:focus, input:focus {
   margin-right: 8px;
 }
 
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
+@keyframes spin { to { transform: rotate(360deg); } }
 
 .empty-state {
   text-align: center;
-  padding: 40px;
+  padding: 24px;
   color: var(--text-muted);
+  font-size: 13px;
 }
 
 .error-state {
   text-align: center;
-  padding: 20px;
+  padding: 16px;
   color: var(--danger);
   background: #fef2f2;
   border-radius: 6px;
+  font-size: 13px;
 }
 
-/* Footer */
+/* ==================== FOOTER ==================== */
 .footer {
   text-align: center;
-  padding: 16px;
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-top: 20px;
-}
-
-.footer a {
-  color: var(--primary);
-  text-decoration: none;
-}
-
-.footer a:hover {
-  text-decoration: underline;
-}
-
-/* Tooltip */
-.tooltip {
-  position: absolute;
-  background: var(--text);
-  color: white;
-  padding: 4px 8px;
-  border-radius: 4px;
+  padding: 14px;
   font-size: 11px;
-  pointer-events: none;
-  z-index: 200;
-  white-space: nowrap;
+  color: var(--text-muted);
 }
 
-/* Chart container */
-.chart-container {
-  position: relative;
-  height: 200px;
-}
+.footer a { color: var(--primary); text-decoration: none; }
+.footer a:hover { text-decoration: underline; }

--- a/dashboard/static/css/dashboard.css
+++ b/dashboard/static/css/dashboard.css
@@ -1,0 +1,657 @@
+/* LLM Observatory — Clean light theme */
+
+:root {
+  --bg: #f8f9fa;
+  --surface: #ffffff;
+  --border: #e2e8f0;
+  --text: #1a202c;
+  --text-secondary: #64748b;
+  --text-muted: #94a3b8;
+  --primary: #3b82f6;
+  --primary-light: #eff6ff;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --heatmap-0: #ebedf0;
+  --heatmap-1: #9be9a8;
+  --heatmap-2: #40c463;
+  --heatmap-3: #30a14e;
+  --heatmap-4: #216e39;
+  --sidebar-width: 320px;
+  --header-height: 56px;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+/* Header */
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--header-height);
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  z-index: 100;
+  gap: 16px;
+}
+
+.header h1 {
+  font-size: 16px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+}
+
+/* Filter controls */
+select, input[type="search"] {
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+  background: var(--surface);
+  color: var(--text);
+  outline: none;
+}
+
+select:focus, input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+}
+
+.time-range-group {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.time-range-group button {
+  height: 32px;
+  padding: 0 12px;
+  border: none;
+  background: var(--surface);
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  border-right: 1px solid var(--border);
+}
+
+.time-range-group button:last-child {
+  border-right: none;
+}
+
+.time-range-group button.active {
+  background: var(--primary);
+  color: white;
+}
+
+.time-range-group button:hover:not(.active) {
+  background: var(--bg);
+}
+
+.btn {
+  height: 32px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--text);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.btn:hover {
+  background: var(--bg);
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+}
+
+.btn-primary:hover {
+  background: #2563eb;
+}
+
+/* Layout */
+.layout {
+  display: flex;
+  margin-top: var(--header-height);
+  min-height: calc(100vh - var(--header-height));
+}
+
+/* Sidebar */
+.sidebar {
+  width: var(--sidebar-width);
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  position: fixed;
+  top: var(--header-height);
+  bottom: 0;
+  left: 0;
+}
+
+.sidebar-search {
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  z-index: 10;
+}
+
+.sidebar-search input {
+  width: 100%;
+}
+
+.session-list {
+  list-style: none;
+}
+
+.session-item {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.session-item:hover {
+  background: var(--bg);
+}
+
+.session-item.active {
+  background: var(--primary-light);
+  border-left: 3px solid var(--primary);
+  padding-left: 11px;
+}
+
+.session-id {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-meta {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+  display: flex;
+  gap: 10px;
+}
+
+.session-project {
+  font-size: 11px;
+  color: var(--primary);
+  background: var(--primary-light);
+  padding: 1px 6px;
+  border-radius: 3px;
+  display: inline-block;
+  margin-top: 4px;
+}
+
+/* Main content */
+.main {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  padding: 20px;
+  max-width: calc(100% - var(--sidebar-width));
+}
+
+/* KPI Cards */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.kpi-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+}
+
+.kpi-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.kpi-value {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.kpi-value.small {
+  font-size: 18px;
+}
+
+/* Section */
+.section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: var(--text);
+}
+
+/* Heatmap */
+.heatmap-container {
+  overflow-x: auto;
+}
+
+.heatmap {
+  display: flex;
+  gap: 3px;
+}
+
+.heatmap-week {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.heatmap-cell {
+  width: 13px;
+  height: 13px;
+  border-radius: 2px;
+  background: var(--heatmap-0);
+}
+
+.heatmap-cell[data-level="1"] { background: var(--heatmap-1); }
+.heatmap-cell[data-level="2"] { background: var(--heatmap-2); }
+.heatmap-cell[data-level="3"] { background: var(--heatmap-3); }
+.heatmap-cell[data-level="4"] { background: var(--heatmap-4); }
+
+.heatmap-months {
+  display: flex;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  padding-left: 2px;
+}
+
+.heatmap-month {
+  flex: none;
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  justify-content: flex-end;
+}
+
+.heatmap-legend .heatmap-cell {
+  width: 11px;
+  height: 11px;
+}
+
+/* Hour x Day grid */
+.hour-grid {
+  display: grid;
+  grid-template-columns: 36px repeat(24, 1fr);
+  gap: 2px;
+  font-size: 11px;
+}
+
+.hour-grid-label {
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: 4px;
+}
+
+.hour-grid-cell {
+  aspect-ratio: 1;
+  border-radius: 2px;
+  background: var(--heatmap-0);
+  min-width: 0;
+}
+
+.hour-grid-header {
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 10px;
+}
+
+/* Charts grid */
+.charts-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+@media (max-width: 1200px) {
+  .charts-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Top sessions table */
+.top-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.top-table th {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 2px solid var(--border);
+  color: var(--text-secondary);
+  font-weight: 500;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.top-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.top-table tr:hover td {
+  background: var(--bg);
+}
+
+.top-table .rank {
+  color: var(--text-muted);
+  width: 32px;
+}
+
+.top-table .session-link {
+  color: var(--primary);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.top-table .session-link:hover {
+  text-decoration: underline;
+}
+
+.sort-tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 12px;
+  background: var(--bg);
+  border-radius: 6px;
+  padding: 2px;
+  display: inline-flex;
+}
+
+.sort-tab {
+  padding: 4px 12px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.sort-tab.active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+/* Tool bars */
+.tool-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.tool-name {
+  font-size: 13px;
+  width: 120px;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.tool-bar-fill {
+  height: 20px;
+  background: var(--primary);
+  border-radius: 3px;
+  min-width: 4px;
+  transition: width 0.3s;
+}
+
+.tool-count {
+  font-size: 12px;
+  color: var(--text-secondary);
+  width: 40px;
+  flex-shrink: 0;
+}
+
+/* Score cards */
+.score-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.score-card {
+  padding: 12px;
+  background: var(--bg);
+  border-radius: 6px;
+}
+
+.score-name {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: capitalize;
+  margin-bottom: 4px;
+}
+
+.score-avg {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.score-range {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Session detail panel */
+.detail-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+
+.detail-header {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.detail-header h3 {
+  font-size: 14px;
+}
+
+.detail-stats {
+  display: flex;
+  gap: 20px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.trace-list {
+  list-style: none;
+}
+
+.trace-item {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.trace-item:last-child {
+  border-bottom: none;
+}
+
+.trace-name {
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.trace-time {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.trace-io {
+  margin-top: 6px;
+  font-size: 12px;
+  background: var(--bg);
+  padding: 8px 10px;
+  border-radius: 4px;
+  max-height: 100px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.trace-scores {
+  margin-top: 6px;
+  display: flex;
+  gap: 8px;
+}
+
+.trace-score-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--primary-light);
+  color: var(--primary);
+}
+
+/* Loading & Empty states */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  color: var(--text-muted);
+}
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--border);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  margin-right: 8px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px;
+  color: var(--text-muted);
+}
+
+.error-state {
+  text-align: center;
+  padding: 20px;
+  color: var(--danger);
+  background: #fef2f2;
+  border-radius: 6px;
+}
+
+/* Footer */
+.footer {
+  text-align: center;
+  padding: 16px;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 20px;
+}
+
+.footer a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+/* Tooltip */
+.tooltip {
+  position: absolute;
+  background: var(--text);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  pointer-events: none;
+  z-index: 200;
+  white-space: nowrap;
+}
+
+/* Chart container */
+.chart-container {
+  position: relative;
+  height: 200px;
+}

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -303,23 +303,17 @@
             </div>
           </template>
 
-          <!-- Cost + Token Charts (only if data exists) -->
-          <template x-if="sessions.some(s => s.total_cost > 0) || sessions.some(s => s.total_tokens > 0)">
-            <div class="charts-row">
-              <template x-if="sessions.some(s => s.total_cost > 0)">
-                <div class="section">
-                  <div class="section-title">Cost by Project</div>
-                  <div class="chart-container"><canvas id="cost-chart"></canvas></div>
-                </div>
-              </template>
-              <template x-if="sessions.some(s => s.total_tokens > 0)">
-                <div class="section">
-                  <div class="section-title">Token Usage Trend</div>
-                  <div class="chart-container"><canvas id="token-chart"></canvas></div>
-                </div>
-              </template>
+          <!-- Cost + Token Charts (always in DOM, hidden when empty) -->
+          <div class="charts-row" x-show="sessions.some(s => s.total_cost > 0) || sessions.some(s => s.total_tokens > 0)">
+            <div class="section" x-show="sessions.some(s => s.total_cost > 0)">
+              <div class="section-title">Cost by Project</div>
+              <div class="chart-container"><canvas id="cost-chart"></canvas></div>
             </div>
-          </template>
+            <div class="section" x-show="sessions.some(s => s.total_tokens > 0)">
+              <div class="section-title">Token Usage Trend</div>
+              <div class="chart-container"><canvas id="token-chart"></canvas></div>
+            </div>
+          </div>
 
           <!-- Footer -->
           <footer class="footer">

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -13,76 +13,97 @@
 </head>
 <body x-data="observatory()" x-init="init()">
 
-  <!-- Header -->
+  <!-- ==================== HEADER ==================== -->
   <header class="header">
     <h1>LLM Observatory</h1>
+
+    <select x-model="project" @change="setProject($event.target.value)">
+      <option value="all">All Projects</option>
+      <template x-for="p in projects" :key="p">
+        <option :value="p" x-text="p"></option>
+      </template>
+    </select>
+
     <div class="header-controls">
-      <!-- Project filter -->
-      <select x-model="project" @change="setProject($event.target.value)">
-        <option value="all">All Projects</option>
-        <template x-for="p in projects" :key="p">
-          <option :value="p" x-text="p"></option>
-        </template>
-      </select>
+      <!-- Search trigger -->
+      <button class="search-trigger" @click="openSearch()">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+        Search sessions...
+        <kbd>Ctrl+K</kbd>
+      </button>
 
       <!-- Time range -->
       <div class="time-range-group">
         <template x-for="r in ['7d','30d','90d','1y','all']" :key="r">
-          <button :class="{ active: timeRange === r }" @click="setTimeRange(r)" x-text="r === 'all' ? 'All' : r"></button>
+          <button :class="{ active: timeRange === r }" @click="setTimeRange(r)"
+                  x-text="r === 'all' ? 'All' : r"></button>
         </template>
       </div>
 
-      <!-- Export -->
       <button class="btn" @click="exportCSV()">Export CSV</button>
     </div>
   </header>
 
+  <!-- ==================== SEARCH OVERLAY ==================== -->
+  <template x-if="searchOpen">
+    <div class="search-overlay" @click.self="closeSearch()">
+      <div class="search-modal">
+        <div class="search-input-row">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+          <input id="search-input" type="text" placeholder="Search sessions..."
+                 x-model="searchQuery" @input.debounce.200ms="onSearchInput()"
+                 @keydown.escape="closeSearch()">
+          <kbd>Esc</kbd>
+        </div>
+        <ul class="search-results">
+          <template x-if="searchQuery.length >= 2 && searchResults.length === 0">
+            <li class="search-empty">No results found</li>
+          </template>
+          <template x-for="r in searchResults" :key="r.id">
+            <li class="search-result-item" @click="searchSelect(r.id)">
+              <div class="search-result-icon" style="background: #6366f1;">A</div>
+              <div class="search-result-text" x-text="r.title"></div>
+              <div class="search-result-project" x-text="r.project || ''"></div>
+            </li>
+          </template>
+        </ul>
+      </div>
+    </div>
+  </template>
+
   <div class="layout">
 
-    <!-- Sidebar: Session list -->
+    <!-- ==================== SIDEBAR ==================== -->
     <aside class="sidebar">
-      <div class="sidebar-search">
-        <input type="search" placeholder="Search sessions..." x-model="search" @input="onSearch()">
-      </div>
+      <div class="sidebar-header" x-text="sessionsTotal + ' sessions'"></div>
 
-      <!-- Loading -->
       <template x-if="loading">
-        <div class="loading"><div class="spinner"></div> Loading sessions...</div>
+        <div class="loading"><div class="spinner"></div></div>
       </template>
 
-      <!-- Session list -->
-      <template x-if="!loading">
-        <div>
-          <template x-if="sessions.length === 0">
-            <div class="empty-state">No sessions found</div>
-          </template>
-          <ul class="session-list">
-            <template x-for="s in sessions" :key="s.id">
-              <li class="session-item"
-                  :class="{ active: selectedSession === s.id }"
-                  @click="selectSession(s.id)">
-                <div class="session-id" x-text="s.id"></div>
-                <div class="session-meta">
-                  <span x-text="s.trace_count + ' traces'"></span>
-                  <span x-text="fmtDuration(s.total_latency_ms)"></span>
-                  <span x-text="fmtRelative(s.last_trace)"></span>
-                </div>
-                <template x-if="s.project">
-                  <span class="session-project" x-text="s.project"></span>
-                </template>
-              </li>
-            </template>
-          </ul>
-          <template x-if="sessions.length > 0">
-            <div style="padding: 10px 14px; font-size: 12px; color: var(--text-muted);"
-                 x-text="sessionsTotal + ' total sessions'">
+      <ul class="session-list" x-show="!loading">
+        <template x-for="s in sessions" :key="s.id">
+          <li class="session-item"
+              :class="{ active: selectedSessionId === s.id }"
+              @click="selectSession(s.id)">
+            <div class="session-title" x-text="s.id"></div>
+            <div class="session-meta">
+              <span class="project-name" x-text="s.project || ''"></span>
+              <span x-text="fmtRelative(s.last_trace)"></span>
+              <span class="trace-badge" x-text="'+' + s.trace_count"></span>
             </div>
-          </template>
-        </div>
-      </template>
+          </li>
+        </template>
+      </ul>
+
+      <div class="sidebar-footer" x-show="!loading">
+        <span x-text="sessionsTotal + ' sessions'"></span>
+        <span x-text="kpi.traces_count ? fmtNum(kpi.traces_count) + ' traces' : ''"></span>
+        <span x-text="projects.length + ' projects'"></span>
+      </div>
     </aside>
 
-    <!-- Main content -->
+    <!-- ==================== MAIN CONTENT ==================== -->
     <main class="main">
 
       <!-- Error -->
@@ -95,87 +116,103 @@
         <div class="loading"><div class="spinner"></div> Loading dashboard...</div>
       </template>
 
-      <template x-if="!loading && !error">
-        <div>
+      <!-- ==================== SESSION VIEW ==================== -->
+      <template x-if="!loading && !error && view === 'session'">
+        <div class="session-view">
+          <div class="session-view-header">
+            <button class="session-view-back" @click="backToDashboard()">Dashboard</button>
+            <div class="session-view-title" x-text="selectedSessionId"></div>
+          </div>
 
-          <!-- Session Detail (shown when a session is selected) -->
-          <template x-if="selectedSession && sessionDetail">
-            <div class="detail-panel">
-              <div class="detail-header">
-                <h3>
-                  Session: <span x-text="selectedSession"></span>
-                </h3>
-                <div class="detail-stats">
-                  <span x-text="sessionDetail.trace_count + ' traces'"></span>
-                  <span x-text="fmtDuration(sessionDetail.total_latency_ms)"></span>
-                  <span x-text="fmtCost(sessionDetail.total_cost)"></span>
-                  <span x-text="fmtNum(sessionDetail.total_tokens) + ' tokens'"></span>
-                </div>
+          <template x-if="!sessionDetail">
+            <div class="loading"><div class="spinner"></div> Loading session...</div>
+          </template>
+
+          <template x-if="sessionDetail">
+            <div>
+              <div class="session-view-stats">
+                <span x-text="sessionDetail.trace_count + ' traces'"></span>
+                <span x-text="fmtDuration(sessionDetail.total_latency_ms)"></span>
+                <span x-text="fmtCost(sessionDetail.total_cost)"></span>
+                <span x-text="fmtNum(sessionDetail.total_tokens) + ' tokens'"></span>
               </div>
-              <ul class="trace-list">
-                <template x-for="tr in sessionDetail.traces" :key="tr.id">
-                  <li class="trace-item">
-                    <div style="display: flex; justify-content: space-between; align-items: center;">
-                      <span class="trace-name" x-text="tr.name || 'unnamed'"></span>
-                      <span class="trace-time" x-text="fmtDate(tr.timestamp)"></span>
-                    </div>
-                    <div class="session-meta" style="margin-top: 2px;">
-                      <span x-text="fmtDuration(tr.latency_ms)"></span>
-                      <span x-text="fmtCost(tr.cost)"></span>
-                      <span x-text="fmtNum(tr.tokens) + ' tokens'"></span>
-                    </div>
+
+              <template x-for="tr in sessionDetail.traces" :key="tr.id">
+                <div class="trace-message">
+                  <div class="trace-message-header">
+                    <div class="trace-message-icon agent">A</div>
+                    <div class="trace-message-name" x-text="tr.name || 'Trace'"></div>
+                    <div class="trace-message-time" x-text="fmtDate(tr.timestamp)"></div>
+                  </div>
+                  <div class="trace-message-body">
                     <template x-if="tr.input">
-                      <div class="trace-io"><strong>Input:</strong> <span x-text="tr.input"></span></div>
+                      <div class="io-block" x-text="tr.input"></div>
                     </template>
                     <template x-if="tr.output">
-                      <div class="trace-io"><strong>Output:</strong> <span x-text="tr.output"></span></div>
+                      <div class="io-block" x-text="tr.output"></div>
                     </template>
-                    <template x-if="Object.keys(tr.scores).length > 0">
-                      <div class="trace-scores">
-                        <template x-for="[name, val] in Object.entries(tr.scores)" :key="name">
-                          <span class="trace-score-badge" x-text="name + ': ' + val.toFixed(2)"></span>
-                        </template>
-                      </div>
+                  </div>
+                  <div class="trace-message-badges">
+                    <span class="trace-badge-pill" x-text="fmtDuration(tr.latency_ms)"></span>
+                    <template x-if="tr.cost > 0">
+                      <span class="trace-badge-pill cost" x-text="fmtCost(tr.cost)"></span>
                     </template>
-                  </li>
-                </template>
-              </ul>
+                    <template x-if="tr.tokens > 0">
+                      <span class="trace-badge-pill tokens" x-text="fmtNum(tr.tokens) + ' tokens'"></span>
+                    </template>
+                    <template x-for="[name, val] in Object.entries(tr.scores)" :key="name">
+                      <span class="trace-badge-pill" x-text="name + ': ' + val.toFixed(2)"></span>
+                    </template>
+                  </div>
+                </div>
+              </template>
             </div>
           </template>
+        </div>
+      </template>
+
+      <!-- ==================== DASHBOARD VIEW ==================== -->
+      <template x-if="!loading && !error && view === 'dashboard'">
+        <div>
 
           <!-- KPI Cards -->
           <div class="kpi-grid">
             <div class="kpi-card">
-              <div class="kpi-label">Sessions</div>
               <div class="kpi-value" x-text="fmtNum(kpi.sessions_count)"></div>
+              <div class="kpi-label">Sessions</div>
             </div>
             <div class="kpi-card">
-              <div class="kpi-label">Traces</div>
               <div class="kpi-value" x-text="fmtNum(kpi.traces_count)"></div>
+              <div class="kpi-label">Traces</div>
             </div>
             <div class="kpi-card">
-              <div class="kpi-label">Projects</div>
               <div class="kpi-value" x-text="fmtNum(kpi.projects_count)"></div>
+              <div class="kpi-label">Projects</div>
             </div>
             <div class="kpi-card">
-              <div class="kpi-label">Active Days</div>
               <div class="kpi-value" x-text="fmtNum(kpi.active_days)"></div>
+              <div class="kpi-label">Active Days</div>
             </div>
             <div class="kpi-card">
-              <div class="kpi-label">Med. Traces/Session</div>
-              <div class="kpi-value small" x-text="kpi.median_traces_per_session?.toFixed(1) ?? '—'"></div>
+              <div class="kpi-value" x-text="kpi.median_traces_per_session != null ? kpi.median_traces_per_session.toFixed(1) : '—'"></div>
+              <div class="kpi-label">Traces/Session</div>
+              <div class="kpi-sub" x-text="'med ' + (kpi.median_traces_per_session || 0).toFixed(0) + ' / p90 ' + (kpi.p90_traces_per_session || 0).toFixed(0)"></div>
             </div>
             <div class="kpi-card">
-              <div class="kpi-label">Avg Latency</div>
-              <div class="kpi-value small" x-text="fmtDuration(kpi.avg_latency_ms)"></div>
-            </div>
-            <div class="kpi-card">
-              <div class="kpi-label">Total Cost</div>
-              <div class="kpi-value small" x-text="fmtCost(kpi.total_cost)"></div>
-            </div>
-            <div class="kpi-card">
+              <div class="kpi-value" x-text="kpi.avg_score != null ? (kpi.avg_score * 100).toFixed(1) + '%' : '—'"></div>
               <div class="kpi-label">Avg Score</div>
-              <div class="kpi-value small" x-text="kpi.avg_score != null ? kpi.avg_score.toFixed(2) : '—'"></div>
+            </div>
+          </div>
+
+          <!-- Avg Latency + Total Cost (second row, smaller) -->
+          <div class="kpi-grid" style="grid-template-columns: repeat(2, 1fr); margin-bottom: 16px;">
+            <div class="kpi-card">
+              <div class="kpi-value" x-text="fmtDuration(kpi.avg_latency_ms)"></div>
+              <div class="kpi-label">Avg Latency</div>
+            </div>
+            <div class="kpi-card">
+              <div class="kpi-value" x-text="fmtCost(kpi.total_cost)"></div>
+              <div class="kpi-label">Total Cost</div>
             </div>
           </div>
 
@@ -185,10 +222,10 @@
             <div id="heatmap" class="heatmap-container"></div>
           </div>
 
-          <!-- Activity by Day + Hour Grid -->
+          <!-- Activity by Day + Activity by Hour -->
           <div class="charts-row">
             <div class="section">
-              <div class="section-title">Activity by Day</div>
+              <div class="section-title">Activity by Day and Hour</div>
               <div class="chart-container">
                 <canvas id="day-chart"></canvas>
               </div>
@@ -199,106 +236,90 @@
             </div>
           </div>
 
-          <!-- Top Sessions -->
-          <div class="section">
-            <div class="section-title">Top Sessions</div>
-            <div class="sort-tabs">
-              <template x-for="s in ['traces', 'duration', 'cost']" :key="s">
-                <button class="sort-tab" :class="{ active: topSort === s }"
-                        @click="setTopSort(s)" x-text="s"></button>
-              </template>
-            </div>
-            <template x-if="topSessions.length === 0">
-              <div class="empty-state">No sessions</div>
-            </template>
-            <template x-if="topSessions.length > 0">
-              <table class="top-table">
-                <thead>
-                  <tr>
-                    <th class="rank">#</th>
-                    <th>Session</th>
-                    <th>Project</th>
-                    <th>Traces</th>
-                    <th>Duration</th>
-                    <th>Cost</th>
-                    <th>Started</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <template x-for="(s, i) in topSessions" :key="s.id">
-                    <tr>
-                      <td class="rank" x-text="i + 1"></td>
-                      <td><span class="session-link" @click="selectSession(s.id)" x-text="s.id"></span></td>
-                      <td><span class="session-project" x-text="s.project || '—'"></span></td>
-                      <td x-text="s.trace_count"></td>
-                      <td x-text="fmtDuration(s.total_duration_ms)"></td>
-                      <td x-text="fmtCost(s.total_cost)"></td>
-                      <td x-text="fmtRelative(s.first_trace)"></td>
-                    </tr>
-                  </template>
-                </tbody>
-              </table>
-            </template>
-          </div>
-
-          <!-- Tool Usage + Quality Scores -->
+          <!-- Top Sessions + (right column varies) -->
           <div class="charts-row">
+            <!-- Top Sessions -->
+            <div class="section">
+              <div class="section-header">
+                <div class="section-title">Top Sessions</div>
+                <div class="sort-tabs">
+                  <template x-for="s in ['traces', 'duration', 'cost']" :key="s">
+                    <button class="sort-tab" :class="{ active: topSort === s }"
+                            @click="setTopSort(s)"
+                            x-text="s === 'traces' ? 'By Traces' : s === 'duration' ? 'By Duration' : 'By Cost'"></button>
+                  </template>
+                </div>
+              </div>
+              <template x-if="topSessions.length === 0">
+                <div class="empty-state">No sessions</div>
+              </template>
+              <ol class="top-sessions-list">
+                <template x-for="(s, i) in topSessions" :key="s.id">
+                  <li class="top-session-item" @click="selectSession(s.id)">
+                    <div class="top-rank" x-text="i + 1"></div>
+                    <div class="top-session-info">
+                      <div class="top-session-title" x-text="s.id"></div>
+                      <div class="top-session-project" x-text="s.project || ''"></div>
+                    </div>
+                    <div class="top-session-metric" x-text="topMetricValue(s)"></div>
+                  </li>
+                </template>
+              </ol>
+            </div>
+
+            <!-- Tool / Span Usage -->
             <div class="section">
               <div class="section-title">Tool / Span Usage</div>
               <template x-if="tools.length === 0">
                 <div class="empty-state">No span data</div>
               </template>
-              <template x-if="tools.length > 0">
-                <div>
-                  <template x-for="t in tools" :key="t.name">
-                    <div class="tool-bar">
-                      <span class="tool-name" x-text="t.name" :title="t.name"></span>
+              <div class="tool-bars-list" x-show="tools.length > 0">
+                <template x-for="t in tools" :key="t.name">
+                  <div class="tool-bar">
+                    <span class="tool-name" x-text="t.name" :title="t.name"></span>
+                    <div class="tool-bar-track">
                       <div class="tool-bar-fill" :style="'width:' + (t.count / maxToolCount() * 100) + '%'"></div>
-                      <span class="tool-count" x-text="t.count"></span>
                     </div>
-                  </template>
-                </div>
-              </template>
-            </div>
-            <div class="section">
-              <div class="section-title">Quality Scores</div>
-              <template x-if="scores.length === 0">
-                <div class="empty-state">No score data</div>
-              </template>
-              <template x-if="scores.length > 0">
-                <div>
-                  <div class="chart-container" style="margin-bottom: 12px;">
-                    <canvas id="score-chart"></canvas>
+                    <span class="tool-count" x-text="t.count"></span>
                   </div>
-                  <div class="score-cards">
-                    <template x-for="s in scores" :key="s.name">
-                      <div class="score-card">
-                        <div class="score-name" x-text="s.name"></div>
-                        <div class="score-avg" x-text="s.avg.toFixed(2)"></div>
-                        <div class="score-range" x-text="'Range: ' + s.min.toFixed(2) + ' – ' + s.max.toFixed(2) + ' (' + s.count + ')'"></div>
-                      </div>
-                    </template>
-                  </div>
-                </div>
-              </template>
+                </template>
+              </div>
             </div>
           </div>
 
-          <!-- Cost + Token Charts -->
-          <div class="charts-row">
+          <!-- Quality Scores -->
+          <template x-if="scores.length > 0">
             <div class="section">
-              <div class="section-title">Cost by Project</div>
-              <div class="chart-container">
-                <canvas id="cost-chart"></canvas>
+              <div class="section-title">Quality Scores</div>
+              <div class="score-cards">
+                <template x-for="s in scores" :key="s.name">
+                  <div class="score-card">
+                    <div class="score-name" x-text="s.name"></div>
+                    <div class="score-avg" x-text="s.avg.toFixed(2)"></div>
+                    <div class="score-range" x-text="'Range: ' + s.min.toFixed(2) + ' – ' + s.max.toFixed(2)"></div>
+                  </div>
+                </template>
               </div>
             </div>
-            <div class="section">
-              <div class="section-title">Token Usage Trend</div>
-              <div class="chart-container">
-                <canvas id="token-chart"></canvas>
-              </div>
+          </template>
+
+          <!-- Cost + Token Charts (only if data exists) -->
+          <template x-if="sessions.some(s => s.total_cost > 0) || sessions.some(s => s.total_tokens > 0)">
+            <div class="charts-row">
+              <template x-if="sessions.some(s => s.total_cost > 0)">
+                <div class="section">
+                  <div class="section-title">Cost by Project</div>
+                  <div class="chart-container"><canvas id="cost-chart"></canvas></div>
+                </div>
+              </template>
+              <template x-if="sessions.some(s => s.total_tokens > 0)">
+                <div class="section">
+                  <div class="section-title">Token Usage Trend</div>
+                  <div class="chart-container"><canvas id="token-chart"></canvas></div>
+                </div>
+              </template>
             </div>
-          </div>
+          </template>
 
           <!-- Footer -->
           <footer class="footer">

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LLM Observatory</title>
+  <link rel="stylesheet" href="/css/dashboard.css">
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.8/dist/chart.umd.min.js"></script>
+  <script src="/js/utils.js"></script>
+  <script src="/js/charts.js"></script>
+  <script src="/js/app.js"></script>
+</head>
+<body x-data="observatory()" x-init="init()">
+
+  <!-- Header -->
+  <header class="header">
+    <h1>LLM Observatory</h1>
+    <div class="header-controls">
+      <!-- Project filter -->
+      <select x-model="project" @change="setProject($event.target.value)">
+        <option value="all">All Projects</option>
+        <template x-for="p in projects" :key="p">
+          <option :value="p" x-text="p"></option>
+        </template>
+      </select>
+
+      <!-- Time range -->
+      <div class="time-range-group">
+        <template x-for="r in ['7d','30d','90d','1y','all']" :key="r">
+          <button :class="{ active: timeRange === r }" @click="setTimeRange(r)" x-text="r === 'all' ? 'All' : r"></button>
+        </template>
+      </div>
+
+      <!-- Export -->
+      <button class="btn" @click="exportCSV()">Export CSV</button>
+    </div>
+  </header>
+
+  <div class="layout">
+
+    <!-- Sidebar: Session list -->
+    <aside class="sidebar">
+      <div class="sidebar-search">
+        <input type="search" placeholder="Search sessions..." x-model="search" @input="onSearch()">
+      </div>
+
+      <!-- Loading -->
+      <template x-if="loading">
+        <div class="loading"><div class="spinner"></div> Loading sessions...</div>
+      </template>
+
+      <!-- Session list -->
+      <template x-if="!loading">
+        <div>
+          <template x-if="sessions.length === 0">
+            <div class="empty-state">No sessions found</div>
+          </template>
+          <ul class="session-list">
+            <template x-for="s in sessions" :key="s.id">
+              <li class="session-item"
+                  :class="{ active: selectedSession === s.id }"
+                  @click="selectSession(s.id)">
+                <div class="session-id" x-text="s.id"></div>
+                <div class="session-meta">
+                  <span x-text="s.trace_count + ' traces'"></span>
+                  <span x-text="fmtDuration(s.total_latency_ms)"></span>
+                  <span x-text="fmtRelative(s.last_trace)"></span>
+                </div>
+                <template x-if="s.project">
+                  <span class="session-project" x-text="s.project"></span>
+                </template>
+              </li>
+            </template>
+          </ul>
+          <template x-if="sessions.length > 0">
+            <div style="padding: 10px 14px; font-size: 12px; color: var(--text-muted);"
+                 x-text="sessionsTotal + ' total sessions'">
+            </div>
+          </template>
+        </div>
+      </template>
+    </aside>
+
+    <!-- Main content -->
+    <main class="main">
+
+      <!-- Error -->
+      <template x-if="error">
+        <div class="error-state" x-text="error"></div>
+      </template>
+
+      <!-- Loading -->
+      <template x-if="loading && !error">
+        <div class="loading"><div class="spinner"></div> Loading dashboard...</div>
+      </template>
+
+      <template x-if="!loading && !error">
+        <div>
+
+          <!-- Session Detail (shown when a session is selected) -->
+          <template x-if="selectedSession && sessionDetail">
+            <div class="detail-panel">
+              <div class="detail-header">
+                <h3>
+                  Session: <span x-text="selectedSession"></span>
+                </h3>
+                <div class="detail-stats">
+                  <span x-text="sessionDetail.trace_count + ' traces'"></span>
+                  <span x-text="fmtDuration(sessionDetail.total_latency_ms)"></span>
+                  <span x-text="fmtCost(sessionDetail.total_cost)"></span>
+                  <span x-text="fmtNum(sessionDetail.total_tokens) + ' tokens'"></span>
+                </div>
+              </div>
+              <ul class="trace-list">
+                <template x-for="tr in sessionDetail.traces" :key="tr.id">
+                  <li class="trace-item">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                      <span class="trace-name" x-text="tr.name || 'unnamed'"></span>
+                      <span class="trace-time" x-text="fmtDate(tr.timestamp)"></span>
+                    </div>
+                    <div class="session-meta" style="margin-top: 2px;">
+                      <span x-text="fmtDuration(tr.latency_ms)"></span>
+                      <span x-text="fmtCost(tr.cost)"></span>
+                      <span x-text="fmtNum(tr.tokens) + ' tokens'"></span>
+                    </div>
+                    <template x-if="tr.input">
+                      <div class="trace-io"><strong>Input:</strong> <span x-text="tr.input"></span></div>
+                    </template>
+                    <template x-if="tr.output">
+                      <div class="trace-io"><strong>Output:</strong> <span x-text="tr.output"></span></div>
+                    </template>
+                    <template x-if="Object.keys(tr.scores).length > 0">
+                      <div class="trace-scores">
+                        <template x-for="[name, val] in Object.entries(tr.scores)" :key="name">
+                          <span class="trace-score-badge" x-text="name + ': ' + val.toFixed(2)"></span>
+                        </template>
+                      </div>
+                    </template>
+                  </li>
+                </template>
+              </ul>
+            </div>
+          </template>
+
+          <!-- KPI Cards -->
+          <div class="kpi-grid">
+            <div class="kpi-card">
+              <div class="kpi-label">Sessions</div>
+              <div class="kpi-value" x-text="fmtNum(kpi.sessions_count)"></div>
+            </div>
+            <div class="kpi-card">
+              <div class="kpi-label">Traces</div>
+              <div class="kpi-value" x-text="fmtNum(kpi.traces_count)"></div>
+            </div>
+            <div class="kpi-card">
+              <div class="kpi-label">Projects</div>
+              <div class="kpi-value" x-text="fmtNum(kpi.projects_count)"></div>
+            </div>
+            <div class="kpi-card">
+              <div class="kpi-label">Active Days</div>
+              <div class="kpi-value" x-text="fmtNum(kpi.active_days)"></div>
+            </div>
+            <div class="kpi-card">
+              <div class="kpi-label">Med. Traces/Session</div>
+              <div class="kpi-value small" x-text="kpi.median_traces_per_session?.toFixed(1) ?? '—'"></div>
+            </div>
+            <div class="kpi-card">
+              <div class="kpi-label">Avg Latency</div>
+              <div class="kpi-value small" x-text="fmtDuration(kpi.avg_latency_ms)"></div>
+            </div>
+            <div class="kpi-card">
+              <div class="kpi-label">Total Cost</div>
+              <div class="kpi-value small" x-text="fmtCost(kpi.total_cost)"></div>
+            </div>
+            <div class="kpi-card">
+              <div class="kpi-label">Avg Score</div>
+              <div class="kpi-value small" x-text="kpi.avg_score != null ? kpi.avg_score.toFixed(2) : '—'"></div>
+            </div>
+          </div>
+
+          <!-- Activity Heatmap -->
+          <div class="section">
+            <div class="section-title">Activity</div>
+            <div id="heatmap" class="heatmap-container"></div>
+          </div>
+
+          <!-- Activity by Day + Hour Grid -->
+          <div class="charts-row">
+            <div class="section">
+              <div class="section-title">Activity by Day</div>
+              <div class="chart-container">
+                <canvas id="day-chart"></canvas>
+              </div>
+            </div>
+            <div class="section">
+              <div class="section-title">Activity by Hour</div>
+              <div id="hour-grid"></div>
+            </div>
+          </div>
+
+          <!-- Top Sessions -->
+          <div class="section">
+            <div class="section-title">Top Sessions</div>
+            <div class="sort-tabs">
+              <template x-for="s in ['traces', 'duration', 'cost']" :key="s">
+                <button class="sort-tab" :class="{ active: topSort === s }"
+                        @click="setTopSort(s)" x-text="s"></button>
+              </template>
+            </div>
+            <template x-if="topSessions.length === 0">
+              <div class="empty-state">No sessions</div>
+            </template>
+            <template x-if="topSessions.length > 0">
+              <table class="top-table">
+                <thead>
+                  <tr>
+                    <th class="rank">#</th>
+                    <th>Session</th>
+                    <th>Project</th>
+                    <th>Traces</th>
+                    <th>Duration</th>
+                    <th>Cost</th>
+                    <th>Started</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <template x-for="(s, i) in topSessions" :key="s.id">
+                    <tr>
+                      <td class="rank" x-text="i + 1"></td>
+                      <td><span class="session-link" @click="selectSession(s.id)" x-text="s.id"></span></td>
+                      <td><span class="session-project" x-text="s.project || '—'"></span></td>
+                      <td x-text="s.trace_count"></td>
+                      <td x-text="fmtDuration(s.total_duration_ms)"></td>
+                      <td x-text="fmtCost(s.total_cost)"></td>
+                      <td x-text="fmtRelative(s.first_trace)"></td>
+                    </tr>
+                  </template>
+                </tbody>
+              </table>
+            </template>
+          </div>
+
+          <!-- Tool Usage + Quality Scores -->
+          <div class="charts-row">
+            <div class="section">
+              <div class="section-title">Tool / Span Usage</div>
+              <template x-if="tools.length === 0">
+                <div class="empty-state">No span data</div>
+              </template>
+              <template x-if="tools.length > 0">
+                <div>
+                  <template x-for="t in tools" :key="t.name">
+                    <div class="tool-bar">
+                      <span class="tool-name" x-text="t.name" :title="t.name"></span>
+                      <div class="tool-bar-fill" :style="'width:' + (t.count / maxToolCount() * 100) + '%'"></div>
+                      <span class="tool-count" x-text="t.count"></span>
+                    </div>
+                  </template>
+                </div>
+              </template>
+            </div>
+            <div class="section">
+              <div class="section-title">Quality Scores</div>
+              <template x-if="scores.length === 0">
+                <div class="empty-state">No score data</div>
+              </template>
+              <template x-if="scores.length > 0">
+                <div>
+                  <div class="chart-container" style="margin-bottom: 12px;">
+                    <canvas id="score-chart"></canvas>
+                  </div>
+                  <div class="score-cards">
+                    <template x-for="s in scores" :key="s.name">
+                      <div class="score-card">
+                        <div class="score-name" x-text="s.name"></div>
+                        <div class="score-avg" x-text="s.avg.toFixed(2)"></div>
+                        <div class="score-range" x-text="'Range: ' + s.min.toFixed(2) + ' – ' + s.max.toFixed(2) + ' (' + s.count + ')'"></div>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+
+          <!-- Cost + Token Charts -->
+          <div class="charts-row">
+            <div class="section">
+              <div class="section-title">Cost by Project</div>
+              <div class="chart-container">
+                <canvas id="cost-chart"></canvas>
+              </div>
+            </div>
+            <div class="section">
+              <div class="section-title">Token Usage Trend</div>
+              <div class="chart-container">
+                <canvas id="token-chart"></canvas>
+              </div>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <footer class="footer">
+            LLM Observatory — Dashboard UX inspired by
+            <a href="https://github.com/wesm/agentsview" target="_blank" rel="noopener">AgentsView</a>
+            by Wes McKinney
+          </footer>
+
+        </div>
+      </template>
+
+    </main>
+  </div>
+
+</body>
+</html>

--- a/dashboard/static/js/app.js
+++ b/dashboard/static/js/app.js
@@ -7,16 +7,19 @@ function observatory() {
     // State
     loading: true,
     error: null,
-    timeRange: '30d',
+    timeRange: 'all',
     project: 'all',
-    search: '',
-    searchTimeout: null,
+    view: 'dashboard', // 'dashboard' or 'session'
+
+    // Search
+    searchOpen: false,
+    searchQuery: '',
+    searchResults: [],
 
     // Data
     kpi: {},
     sessions: [],
     sessionsTotal: 0,
-    sessionsPage: 1,
     projects: [],
     heatmap: { days: [], max_count: 0 },
     hourly: { matrix: [], day_totals: [], max_count: 0 },
@@ -24,7 +27,9 @@ function observatory() {
     topSort: 'traces',
     tools: [],
     scores: [],
-    selectedSession: null,
+
+    // Session detail
+    selectedSessionId: null,
     sessionDetail: null,
 
     // Charts
@@ -33,61 +38,65 @@ function observatory() {
     _scoreChart: null,
     _tokenChart: null,
 
-    // Computed filters
     get filterParams() {
-      const p = {};
+      var p = {};
       if (this.timeRange !== 'all') {
-        const days = { '7d': 7, '30d': 30, '90d': 90, '1y': 365 }[this.timeRange];
+        var days = { '7d': 7, '30d': 30, '90d': 90, '1y': 365 }[this.timeRange];
         if (days) p.from = daysAgo(days);
       }
       if (this.project && this.project !== 'all') p.project = this.project;
       return p;
     },
 
-    // Init
     async init() {
+      // Keyboard shortcut: Ctrl+K for search
+      document.addEventListener('keydown', (e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+          e.preventDefault();
+          this.openSearch();
+        }
+        if (e.key === 'Escape' && this.searchOpen) {
+          this.closeSearch();
+        }
+      });
       await this.fetchAll();
     },
 
-    // Fetch all data
     async fetchAll() {
       this.loading = true;
       this.error = null;
       try {
-        const qs = buildQuery(this.filterParams);
-        const q = qs ? '?' + qs : '';
+        var qs = buildQuery(this.filterParams);
+        var q = qs ? '?' + qs : '';
 
-        const [kpiRes, sessRes, projRes, heatRes, hourRes, topRes, toolRes, scoreRes] =
-          await Promise.all([
-            fetch('/api/kpi' + q).then(r => r.json()),
-            fetch('/api/sessions' + q + (q ? '&' : '?') + 'limit=200' +
-              (this.search ? '&search=' + encodeURIComponent(this.search) : '')
-            ).then(r => r.json()),
-            fetch('/api/projects' + q).then(r => r.json()),
-            fetch('/api/activity/heatmap' + q).then(r => r.json()),
-            fetch('/api/activity/by-hour' + q).then(r => r.json()),
-            fetch('/api/top-sessions' + q + (q ? '&' : '?') + 'sort=' + this.topSort).then(r => r.json()),
-            fetch('/api/tools' + q).then(r => r.json()),
-            fetch('/api/scores').then(r => r.json()),
-          ]);
+        var results = await Promise.all([
+          fetch('/api/kpi' + q).then(function(r) { return r.json(); }),
+          fetch('/api/sessions' + q + (q ? '&' : '?') + 'limit=200').then(function(r) { return r.json(); }),
+          fetch('/api/projects' + q).then(function(r) { return r.json(); }),
+          fetch('/api/activity/heatmap' + q).then(function(r) { return r.json(); }),
+          fetch('/api/activity/by-hour' + q).then(function(r) { return r.json(); }),
+          fetch('/api/top-sessions' + q + (q ? '&' : '?') + 'sort=' + this.topSort).then(function(r) { return r.json(); }),
+          fetch('/api/tools' + q).then(function(r) { return r.json(); }),
+          fetch('/api/scores').then(function(r) { return r.json(); }),
+        ]);
 
-        this.kpi = kpiRes;
-        this.sessions = sessRes.sessions || [];
-        this.sessionsTotal = sessRes.total || 0;
-        this.projects = projRes.projects || [];
-        this.heatmap = heatRes;
-        this.hourly = hourRes;
-        this.topSessions = topRes.sessions || [];
-        this.tools = toolRes.tools || [];
-        this.scores = scoreRes.scores || [];
-
+        this.kpi = results[0];
+        this.sessions = results[1].sessions || [];
+        this.sessionsTotal = results[1].total || 0;
+        this.projects = results[2].projects || [];
+        this.heatmap = results[3];
+        this.hourly = results[4];
+        this.topSessions = results[5].sessions || [];
+        this.tools = results[6].tools || [];
+        this.scores = results[7].scores || [];
         this.loading = false;
 
-        // Render charts after DOM update
         this.$nextTick(() => {
-          this.renderHeatmap();
-          this.renderHourGrid();
-          this.renderCharts();
+          if (this.view === 'dashboard') {
+            this.renderHeatmap();
+            this.renderHourGrid();
+            this.renderCharts();
+          }
         });
       } catch (e) {
         this.error = 'Failed to load data: ' + e.message;
@@ -95,178 +104,253 @@ function observatory() {
       }
     },
 
-    // Time range change
     setTimeRange(range) {
       this.timeRange = range;
-      this.selectedSession = null;
+      this.view = 'dashboard';
+      this.selectedSessionId = null;
       this.sessionDetail = null;
       this.fetchAll();
     },
 
-    // Project filter change
     setProject(proj) {
       this.project = proj;
-      this.selectedSession = null;
+      this.view = 'dashboard';
+      this.selectedSessionId = null;
       this.sessionDetail = null;
       this.fetchAll();
+    },
+
+    setTopSort(sort) {
+      this.topSort = sort;
+      var qs = buildQuery(this.filterParams);
+      var q = qs ? '?' + qs + '&' : '?';
+      fetch('/api/top-sessions' + q + 'sort=' + sort)
+        .then(function(r) { return r.json(); })
+        .then((data) => { this.topSessions = data.sessions || []; });
+    },
+
+    // Session selection
+    async selectSession(sessionId) {
+      this.selectedSessionId = sessionId;
+      this.sessionDetail = null;
+      this.view = 'session';
+      try {
+        var data = await fetch('/api/sessions/' + encodeURIComponent(sessionId)).then(function(r) { return r.json(); });
+        this.sessionDetail = data;
+      } catch (e) {
+        this.sessionDetail = { error: e.message, traces: [] };
+      }
+    },
+
+    backToDashboard() {
+      this.view = 'dashboard';
+      this.selectedSessionId = null;
+      this.sessionDetail = null;
+      this.$nextTick(() => {
+        this.renderHeatmap();
+        this.renderHourGrid();
+        this.renderCharts();
+      });
     },
 
     // Search
-    onSearch() {
-      clearTimeout(this.searchTimeout);
-      this.searchTimeout = setTimeout(() => this.fetchAll(), 300);
+    openSearch() {
+      this.searchOpen = true;
+      this.searchQuery = '';
+      this.searchResults = [];
+      this.$nextTick(() => {
+        var input = document.getElementById('search-input');
+        if (input) input.focus();
+      });
     },
 
-    // Top sessions sort
-    setTopSort(sort) {
-      this.topSort = sort;
-      const qs = buildQuery(this.filterParams);
-      const q = qs ? '?' + qs + '&' : '?';
-      fetch('/api/top-sessions' + q + 'sort=' + sort)
-        .then(r => r.json())
-        .then(data => { this.topSessions = data.sessions || []; });
+    closeSearch() {
+      this.searchOpen = false;
+      this.searchQuery = '';
+      this.searchResults = [];
     },
 
-    // Session click
-    async selectSession(sessionId) {
-      if (this.selectedSession === sessionId) {
-        this.selectedSession = null;
-        this.sessionDetail = null;
+    async onSearchInput() {
+      var q = this.searchQuery.trim();
+      if (q.length < 2) {
+        this.searchResults = [];
         return;
       }
-      this.selectedSession = sessionId;
-      this.sessionDetail = null;
       try {
-        const data = await fetch('/api/sessions/' + encodeURIComponent(sessionId)).then(r => r.json());
-        this.sessionDetail = data;
+        var qs = buildQuery(this.filterParams);
+        var url = '/api/sessions' + (qs ? '?' + qs + '&' : '?') + 'limit=20&search=' + encodeURIComponent(q);
+        var data = await fetch(url).then(function(r) { return r.json(); });
+        this.searchResults = (data.sessions || []).map((s) => {
+          return { id: s.id, project: s.project, title: s.id, trace_count: s.trace_count };
+        });
       } catch (e) {
-        this.sessionDetail = { error: e.message };
+        this.searchResults = [];
       }
     },
 
-    // Export
+    searchSelect(sessionId) {
+      this.closeSearch();
+      this.selectSession(sessionId);
+    },
+
     exportCSV() {
       downloadCSV(this.filterParams);
     },
 
-    // Render GitHub-style heatmap
+    // Get a display title for a session (use session ID or first trace info)
+    sessionTitle(session) {
+      if (!session) return 'Untitled';
+      return session.id;
+    },
+
+    // Render heatmap
     renderHeatmap() {
-      const container = document.getElementById('heatmap');
+      var container = document.getElementById('heatmap');
       if (!container) return;
       container.innerHTML = '';
 
-      const days = this.heatmap.days || [];
-      const maxCount = this.heatmap.max_count || 1;
+      var days = this.heatmap.days || [];
+      var maxCount = this.heatmap.max_count || 1;
 
       if (days.length === 0) {
         container.innerHTML = '<div class="empty-state">No activity data</div>';
         return;
       }
 
-      // Build date->count map
-      const countMap = {};
-      days.forEach(d => { countMap[d.date] = d.count; });
+      var countMap = {};
+      days.forEach(function(d) { countMap[d.date] = d.count; });
 
-      // Find range
-      const allDates = days.map(d => new Date(d.date));
-      const minDate = new Date(Math.min(...allDates));
-      const maxDate = new Date(Math.max(...allDates));
+      // Determine range: always show at least the selected time range
+      var allDates = days.map(function(d) { return new Date(d.date + 'T00:00:00'); });
+      var maxDate = new Date(Math.max.apply(null, allDates));
+      var minDate;
 
-      // Extend to full weeks
-      const startDate = new Date(minDate);
-      startDate.setDate(startDate.getDate() - startDate.getDay()); // Start on Sunday
-      const endDate = new Date(maxDate);
-      endDate.setDate(endDate.getDate() + (6 - endDate.getDay())); // End on Saturday
+      if (this.timeRange === 'all' || this.timeRange === '1y') {
+        minDate = new Date(maxDate);
+        minDate.setFullYear(minDate.getFullYear() - 1);
+      } else {
+        minDate = new Date(Math.min.apply(null, allDates));
+        // Ensure at least 12 weeks
+        var twelveWeeks = new Date(maxDate);
+        twelveWeeks.setDate(twelveWeeks.getDate() - 84);
+        if (minDate > twelveWeeks) minDate = twelveWeeks;
+      }
 
-      // Build weeks
-      const heatmapEl = document.createElement('div');
-      heatmapEl.className = 'heatmap';
+      // Align to week boundaries (Sunday start)
+      var startDate = new Date(minDate);
+      startDate.setDate(startDate.getDate() - startDate.getDay());
+      var endDate = new Date(maxDate);
+      endDate.setDate(endDate.getDate() + (6 - endDate.getDay()));
 
-      // Months header
-      const monthsEl = document.createElement('div');
+      // Build structure
+      var wrapper = document.createElement('div');
+      wrapper.className = 'heatmap-wrapper';
+
+      // Day labels (Mon, Wed, Fri)
+      var dayLabels = document.createElement('div');
+      dayLabels.className = 'heatmap-day-labels';
+      var dayNames = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+      for (var i = 0; i < 7; i++) {
+        var lbl = document.createElement('div');
+        lbl.className = 'heatmap-day-label';
+        lbl.textContent = dayNames[i];
+        dayLabels.appendChild(lbl);
+      }
+      wrapper.appendChild(dayLabels);
+
+      // Grid area
+      var gridArea = document.createElement('div');
+      gridArea.className = 'heatmap-grid-area';
+
+      // Month labels
+      var monthsEl = document.createElement('div');
       monthsEl.className = 'heatmap-months';
 
-      let current = new Date(startDate);
-      let weekEl = null;
-      let lastMonth = -1;
-      let weekCount = 0;
+      var heatmapEl = document.createElement('div');
+      heatmapEl.className = 'heatmap';
+
+      var current = new Date(startDate);
+      var lastMonth = -1;
+      var weekCount = 0;
+      var weekEl = null;
+      var cellWidth = 16; // 13px cell + 3px gap
 
       while (current <= endDate) {
-        const dayOfWeek = current.getDay();
+        var dayOfWeek = current.getDay();
 
         if (dayOfWeek === 0) {
           weekEl = document.createElement('div');
           weekEl.className = 'heatmap-week';
           heatmapEl.appendChild(weekEl);
-          weekCount++;
 
-          // Track month labels
-          const month = current.getMonth();
+          var month = current.getMonth();
           if (month !== lastMonth) {
-            const label = document.createElement('span');
-            label.className = 'heatmap-month';
-            label.textContent = current.toLocaleDateString('en-US', { month: 'short' });
-            label.style.marginLeft = ((weekCount - 1) * 16) + 'px';
-            label.style.position = 'absolute';
-            monthsEl.appendChild(label);
+            var monthLabel = document.createElement('span');
+            monthLabel.className = 'heatmap-month';
+            monthLabel.textContent = current.toLocaleDateString('en-US', { month: 'short' });
+            monthLabel.style.left = (weekCount * cellWidth) + 'px';
+            monthsEl.appendChild(monthLabel);
             lastMonth = month;
           }
+          weekCount++;
         }
 
-        const dateStr = current.toISOString().slice(0, 10);
-        const count = countMap[dateStr] || 0;
-        const level = count === 0 ? 0 :
+        var y = current.getFullYear();
+        var m = String(current.getMonth() + 1).padStart(2, '0');
+        var d = String(current.getDate()).padStart(2, '0');
+        var dateStr = y + '-' + m + '-' + d;
+        var count = countMap[dateStr] || 0;
+        var level = count === 0 ? 0 :
           count <= maxCount * 0.25 ? 1 :
           count <= maxCount * 0.5 ? 2 :
           count <= maxCount * 0.75 ? 3 : 4;
 
-        const cell = document.createElement('div');
+        var cell = document.createElement('div');
         cell.className = 'heatmap-cell';
         cell.setAttribute('data-level', level);
         cell.title = dateStr + ': ' + count + ' traces';
 
         if (weekEl) weekEl.appendChild(cell);
-
         current.setDate(current.getDate() + 1);
       }
 
-      monthsEl.style.position = 'relative';
-      monthsEl.style.height = '16px';
-      container.appendChild(monthsEl);
-      container.appendChild(heatmapEl);
+      gridArea.appendChild(monthsEl);
+      gridArea.appendChild(heatmapEl);
+      wrapper.appendChild(gridArea);
+      container.appendChild(wrapper);
 
       // Legend
-      const legend = document.createElement('div');
+      var legend = document.createElement('div');
       legend.className = 'heatmap-legend';
       legend.innerHTML = 'Less ';
-      for (let i = 0; i <= 4; i++) {
-        legend.innerHTML += '<div class="heatmap-cell" data-level="' + i + '"></div>';
+      for (var l = 0; l <= 4; l++) {
+        legend.innerHTML += '<div class="heatmap-cell" data-level="' + l + '"></div>';
       }
       legend.innerHTML += ' More';
       container.appendChild(legend);
     },
 
-    // Render hour x day grid
+    // Hour grid
     renderHourGrid() {
-      const container = document.getElementById('hour-grid');
+      var container = document.getElementById('hour-grid');
       if (!container) return;
       container.innerHTML = '';
 
-      const matrix = this.hourly.matrix || [];
-      const maxCount = this.hourly.max_count || 1;
-      const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+      var matrix = this.hourly.matrix || [];
+      var maxCount = this.hourly.max_count || 1;
+      var dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
       if (matrix.length === 0) {
         container.innerHTML = '<div class="empty-state">No activity data</div>';
         return;
       }
 
-      const grid = document.createElement('div');
+      var grid = document.createElement('div');
       grid.className = 'hour-grid';
 
       // Header row
       grid.innerHTML += '<div></div>';
-      for (let h = 0; h < 24; h++) {
+      for (var h = 0; h < 24; h++) {
         if (h % 3 === 0) {
           grid.innerHTML += '<div class="hour-grid-header">' + h + '</div>';
         } else {
@@ -275,11 +359,11 @@ function observatory() {
       }
 
       // Data rows
-      for (let d = 0; d < 7; d++) {
+      for (var d = 0; d < 7; d++) {
         grid.innerHTML += '<div class="hour-grid-label">' + dayNames[d] + '</div>';
-        for (let h = 0; h < 24; h++) {
-          const count = (matrix[d] && matrix[d][h]) || 0;
-          const level = count === 0 ? 0 :
+        for (var h = 0; h < 24; h++) {
+          var count = (matrix[d] && matrix[d][h]) || 0;
+          var level = count === 0 ? 0 :
             count <= maxCount * 0.25 ? 1 :
             count <= maxCount * 0.5 ? 2 :
             count <= maxCount * 0.75 ? 3 : 4;
@@ -291,49 +375,60 @@ function observatory() {
       container.appendChild(grid);
     },
 
-    // Render Chart.js charts
+    // Charts
     renderCharts() {
-      // Day totals bar chart
-      const dayCtx = document.getElementById('day-chart');
-      if (dayCtx && this.hourly.day_totals) {
+      // Daily activity bar chart (time-series, not day-of-week)
+      var dayCtx = document.getElementById('day-chart');
+      if (dayCtx && this.heatmap.days && this.heatmap.days.length > 0) {
         this._dayChart = destroyChart(this._dayChart);
-        this._dayChart = createDayBarChart(dayCtx.getContext('2d'), this.hourly.day_totals);
+        this._dayChart = createDailyBarChart(dayCtx.getContext('2d'), this.heatmap.days);
       }
 
-      // Cost by project doughnut
-      const costCtx = document.getElementById('cost-chart');
-      if (costCtx && this.sessions.length > 0) {
+      // Cost by project
+      var costCtx = document.getElementById('cost-chart');
+      if (costCtx) {
         this._costChart = destroyChart(this._costChart);
-        const projectCosts = {};
-        this.sessions.forEach(s => {
-          const p = s.project || 'unknown';
-          projectCosts[p] = (projectCosts[p] || 0) + (s.total_cost || 0);
+        var projectCosts = {};
+        var hasCost = false;
+        this.sessions.forEach(function(s) {
+          if (s.total_cost > 0) {
+            hasCost = true;
+            var p = s.project || 'unknown';
+            projectCosts[p] = (projectCosts[p] || 0) + s.total_cost;
+          }
         });
-        const labels = Object.keys(projectCosts);
-        const values = Object.values(projectCosts);
-        if (labels.length > 0) {
-          this._costChart = createCostChart(costCtx.getContext('2d'), labels, values);
+        if (hasCost) {
+          this._costChart = createCostChart(costCtx.getContext('2d'), Object.keys(projectCosts), Object.values(projectCosts));
         }
       }
 
-      // Score distribution chart
-      const scoreCtx = document.getElementById('score-chart');
+      // Score chart
+      var scoreCtx = document.getElementById('score-chart');
       if (scoreCtx && this.scores.length > 0) {
         this._scoreChart = destroyChart(this._scoreChart);
         this._scoreChart = createScoreChart(scoreCtx.getContext('2d'), this.scores);
       }
 
-      // Token trend chart
-      const tokenCtx = document.getElementById('token-chart');
-      if (tokenCtx && this.sessions.length > 0) {
+      // Token trend
+      var tokenCtx = document.getElementById('token-chart');
+      if (tokenCtx) {
         this._tokenChart = destroyChart(this._tokenChart);
-        this._tokenChart = createTokenChart(tokenCtx.getContext('2d'), this.sessions);
+        var hasTokens = this.sessions.some(function(s) { return s.total_tokens > 0; });
+        if (hasTokens) {
+          this._tokenChart = createTokenChart(tokenCtx.getContext('2d'), this.sessions);
+        }
       }
     },
 
-    // Helper: max tool count for bar width
     maxToolCount() {
-      return Math.max(...this.tools.map(t => t.count), 1);
+      return Math.max.apply(null, this.tools.map(function(t) { return t.count; }).concat([1]));
+    },
+
+    // Metric for top sessions display
+    topMetricValue(session) {
+      if (this.topSort === 'cost') return fmtCost(session.total_cost);
+      if (this.topSort === 'duration') return fmtDuration(session.total_duration_ms);
+      return session.trace_count;
     },
   };
 }

--- a/dashboard/static/js/app.js
+++ b/dashboard/static/js/app.js
@@ -1,0 +1,339 @@
+/**
+ * LLM Observatory — Alpine.js application.
+ */
+
+function observatory() {
+  return {
+    // State
+    loading: true,
+    error: null,
+    timeRange: '30d',
+    project: 'all',
+    search: '',
+    searchTimeout: null,
+
+    // Data
+    kpi: {},
+    sessions: [],
+    sessionsTotal: 0,
+    sessionsPage: 1,
+    projects: [],
+    heatmap: { days: [], max_count: 0 },
+    hourly: { matrix: [], day_totals: [], max_count: 0 },
+    topSessions: [],
+    topSort: 'traces',
+    tools: [],
+    scores: [],
+    selectedSession: null,
+    sessionDetail: null,
+
+    // Charts
+    _dayChart: null,
+    _costChart: null,
+    _scoreChart: null,
+    _tokenChart: null,
+
+    // Computed filters
+    get filterParams() {
+      const p = {};
+      if (this.timeRange !== 'all') {
+        const days = { '7d': 7, '30d': 30, '90d': 90, '1y': 365 }[this.timeRange];
+        if (days) p.from = daysAgo(days);
+      }
+      if (this.project && this.project !== 'all') p.project = this.project;
+      return p;
+    },
+
+    // Init
+    async init() {
+      await this.fetchAll();
+    },
+
+    // Fetch all data
+    async fetchAll() {
+      this.loading = true;
+      this.error = null;
+      try {
+        const qs = buildQuery(this.filterParams);
+        const q = qs ? '?' + qs : '';
+
+        const [kpiRes, sessRes, projRes, heatRes, hourRes, topRes, toolRes, scoreRes] =
+          await Promise.all([
+            fetch('/api/kpi' + q).then(r => r.json()),
+            fetch('/api/sessions' + q + (q ? '&' : '?') + 'limit=200' +
+              (this.search ? '&search=' + encodeURIComponent(this.search) : '')
+            ).then(r => r.json()),
+            fetch('/api/projects' + q).then(r => r.json()),
+            fetch('/api/activity/heatmap' + q).then(r => r.json()),
+            fetch('/api/activity/by-hour' + q).then(r => r.json()),
+            fetch('/api/top-sessions' + q + (q ? '&' : '?') + 'sort=' + this.topSort).then(r => r.json()),
+            fetch('/api/tools' + q).then(r => r.json()),
+            fetch('/api/scores').then(r => r.json()),
+          ]);
+
+        this.kpi = kpiRes;
+        this.sessions = sessRes.sessions || [];
+        this.sessionsTotal = sessRes.total || 0;
+        this.projects = projRes.projects || [];
+        this.heatmap = heatRes;
+        this.hourly = hourRes;
+        this.topSessions = topRes.sessions || [];
+        this.tools = toolRes.tools || [];
+        this.scores = scoreRes.scores || [];
+
+        this.loading = false;
+
+        // Render charts after DOM update
+        this.$nextTick(() => {
+          this.renderHeatmap();
+          this.renderHourGrid();
+          this.renderCharts();
+        });
+      } catch (e) {
+        this.error = 'Failed to load data: ' + e.message;
+        this.loading = false;
+      }
+    },
+
+    // Time range change
+    setTimeRange(range) {
+      this.timeRange = range;
+      this.selectedSession = null;
+      this.sessionDetail = null;
+      this.fetchAll();
+    },
+
+    // Project filter change
+    setProject(proj) {
+      this.project = proj;
+      this.selectedSession = null;
+      this.sessionDetail = null;
+      this.fetchAll();
+    },
+
+    // Search
+    onSearch() {
+      clearTimeout(this.searchTimeout);
+      this.searchTimeout = setTimeout(() => this.fetchAll(), 300);
+    },
+
+    // Top sessions sort
+    setTopSort(sort) {
+      this.topSort = sort;
+      const qs = buildQuery(this.filterParams);
+      const q = qs ? '?' + qs + '&' : '?';
+      fetch('/api/top-sessions' + q + 'sort=' + sort)
+        .then(r => r.json())
+        .then(data => { this.topSessions = data.sessions || []; });
+    },
+
+    // Session click
+    async selectSession(sessionId) {
+      if (this.selectedSession === sessionId) {
+        this.selectedSession = null;
+        this.sessionDetail = null;
+        return;
+      }
+      this.selectedSession = sessionId;
+      this.sessionDetail = null;
+      try {
+        const data = await fetch('/api/sessions/' + encodeURIComponent(sessionId)).then(r => r.json());
+        this.sessionDetail = data;
+      } catch (e) {
+        this.sessionDetail = { error: e.message };
+      }
+    },
+
+    // Export
+    exportCSV() {
+      downloadCSV(this.filterParams);
+    },
+
+    // Render GitHub-style heatmap
+    renderHeatmap() {
+      const container = document.getElementById('heatmap');
+      if (!container) return;
+      container.innerHTML = '';
+
+      const days = this.heatmap.days || [];
+      const maxCount = this.heatmap.max_count || 1;
+
+      if (days.length === 0) {
+        container.innerHTML = '<div class="empty-state">No activity data</div>';
+        return;
+      }
+
+      // Build date->count map
+      const countMap = {};
+      days.forEach(d => { countMap[d.date] = d.count; });
+
+      // Find range
+      const allDates = days.map(d => new Date(d.date));
+      const minDate = new Date(Math.min(...allDates));
+      const maxDate = new Date(Math.max(...allDates));
+
+      // Extend to full weeks
+      const startDate = new Date(minDate);
+      startDate.setDate(startDate.getDate() - startDate.getDay()); // Start on Sunday
+      const endDate = new Date(maxDate);
+      endDate.setDate(endDate.getDate() + (6 - endDate.getDay())); // End on Saturday
+
+      // Build weeks
+      const heatmapEl = document.createElement('div');
+      heatmapEl.className = 'heatmap';
+
+      // Months header
+      const monthsEl = document.createElement('div');
+      monthsEl.className = 'heatmap-months';
+
+      let current = new Date(startDate);
+      let weekEl = null;
+      let lastMonth = -1;
+      let weekCount = 0;
+
+      while (current <= endDate) {
+        const dayOfWeek = current.getDay();
+
+        if (dayOfWeek === 0) {
+          weekEl = document.createElement('div');
+          weekEl.className = 'heatmap-week';
+          heatmapEl.appendChild(weekEl);
+          weekCount++;
+
+          // Track month labels
+          const month = current.getMonth();
+          if (month !== lastMonth) {
+            const label = document.createElement('span');
+            label.className = 'heatmap-month';
+            label.textContent = current.toLocaleDateString('en-US', { month: 'short' });
+            label.style.marginLeft = ((weekCount - 1) * 16) + 'px';
+            label.style.position = 'absolute';
+            monthsEl.appendChild(label);
+            lastMonth = month;
+          }
+        }
+
+        const dateStr = current.toISOString().slice(0, 10);
+        const count = countMap[dateStr] || 0;
+        const level = count === 0 ? 0 :
+          count <= maxCount * 0.25 ? 1 :
+          count <= maxCount * 0.5 ? 2 :
+          count <= maxCount * 0.75 ? 3 : 4;
+
+        const cell = document.createElement('div');
+        cell.className = 'heatmap-cell';
+        cell.setAttribute('data-level', level);
+        cell.title = dateStr + ': ' + count + ' traces';
+
+        if (weekEl) weekEl.appendChild(cell);
+
+        current.setDate(current.getDate() + 1);
+      }
+
+      monthsEl.style.position = 'relative';
+      monthsEl.style.height = '16px';
+      container.appendChild(monthsEl);
+      container.appendChild(heatmapEl);
+
+      // Legend
+      const legend = document.createElement('div');
+      legend.className = 'heatmap-legend';
+      legend.innerHTML = 'Less ';
+      for (let i = 0; i <= 4; i++) {
+        legend.innerHTML += '<div class="heatmap-cell" data-level="' + i + '"></div>';
+      }
+      legend.innerHTML += ' More';
+      container.appendChild(legend);
+    },
+
+    // Render hour x day grid
+    renderHourGrid() {
+      const container = document.getElementById('hour-grid');
+      if (!container) return;
+      container.innerHTML = '';
+
+      const matrix = this.hourly.matrix || [];
+      const maxCount = this.hourly.max_count || 1;
+      const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+      if (matrix.length === 0) {
+        container.innerHTML = '<div class="empty-state">No activity data</div>';
+        return;
+      }
+
+      const grid = document.createElement('div');
+      grid.className = 'hour-grid';
+
+      // Header row
+      grid.innerHTML += '<div></div>';
+      for (let h = 0; h < 24; h++) {
+        if (h % 3 === 0) {
+          grid.innerHTML += '<div class="hour-grid-header">' + h + '</div>';
+        } else {
+          grid.innerHTML += '<div></div>';
+        }
+      }
+
+      // Data rows
+      for (let d = 0; d < 7; d++) {
+        grid.innerHTML += '<div class="hour-grid-label">' + dayNames[d] + '</div>';
+        for (let h = 0; h < 24; h++) {
+          const count = (matrix[d] && matrix[d][h]) || 0;
+          const level = count === 0 ? 0 :
+            count <= maxCount * 0.25 ? 1 :
+            count <= maxCount * 0.5 ? 2 :
+            count <= maxCount * 0.75 ? 3 : 4;
+          grid.innerHTML += '<div class="hour-grid-cell heatmap-cell" data-level="' + level +
+            '" title="' + dayNames[d] + ' ' + h + ':00 — ' + count + ' traces"></div>';
+        }
+      }
+
+      container.appendChild(grid);
+    },
+
+    // Render Chart.js charts
+    renderCharts() {
+      // Day totals bar chart
+      const dayCtx = document.getElementById('day-chart');
+      if (dayCtx && this.hourly.day_totals) {
+        this._dayChart = destroyChart(this._dayChart);
+        this._dayChart = createDayBarChart(dayCtx.getContext('2d'), this.hourly.day_totals);
+      }
+
+      // Cost by project doughnut
+      const costCtx = document.getElementById('cost-chart');
+      if (costCtx && this.sessions.length > 0) {
+        this._costChart = destroyChart(this._costChart);
+        const projectCosts = {};
+        this.sessions.forEach(s => {
+          const p = s.project || 'unknown';
+          projectCosts[p] = (projectCosts[p] || 0) + (s.total_cost || 0);
+        });
+        const labels = Object.keys(projectCosts);
+        const values = Object.values(projectCosts);
+        if (labels.length > 0) {
+          this._costChart = createCostChart(costCtx.getContext('2d'), labels, values);
+        }
+      }
+
+      // Score distribution chart
+      const scoreCtx = document.getElementById('score-chart');
+      if (scoreCtx && this.scores.length > 0) {
+        this._scoreChart = destroyChart(this._scoreChart);
+        this._scoreChart = createScoreChart(scoreCtx.getContext('2d'), this.scores);
+      }
+
+      // Token trend chart
+      const tokenCtx = document.getElementById('token-chart');
+      if (tokenCtx && this.sessions.length > 0) {
+        this._tokenChart = destroyChart(this._tokenChart);
+        this._tokenChart = createTokenChart(tokenCtx.getContext('2d'), this.sessions);
+      }
+    },
+
+    // Helper: max tool count for bar width
+    maxToolCount() {
+      return Math.max(...this.tools.map(t => t.count), 1);
+    },
+  };
+}

--- a/dashboard/static/js/app.js
+++ b/dashboard/static/js/app.js
@@ -91,12 +91,16 @@ function observatory() {
         this.scores = results[7].scores || [];
         this.loading = false;
 
+        // Double nextTick + setTimeout ensures Alpine has finished
+        // processing all x-if/x-show templates before we touch the DOM
         this.$nextTick(() => {
-          if (this.view === 'dashboard') {
-            this.renderHeatmap();
-            this.renderHourGrid();
-            this.renderCharts();
-          }
+          setTimeout(() => {
+            if (this.view === 'dashboard') {
+              this.renderHeatmap();
+              this.renderHourGrid();
+              this.renderCharts();
+            }
+          }, 50);
         });
       } catch (e) {
         this.error = 'Failed to load data: ' + e.message;
@@ -147,9 +151,11 @@ function observatory() {
       this.selectedSessionId = null;
       this.sessionDetail = null;
       this.$nextTick(() => {
-        this.renderHeatmap();
-        this.renderHourGrid();
-        this.renderCharts();
+        setTimeout(() => {
+          this.renderHeatmap();
+          this.renderHourGrid();
+          this.renderCharts();
+        }, 50);
       });
     },
 

--- a/dashboard/static/js/charts.js
+++ b/dashboard/static/js/charts.js
@@ -2,23 +2,30 @@
  * Chart.js factory functions for LLM Observatory.
  */
 
-/** Destroy chart if it exists */
 function destroyChart(chartRef) {
   if (chartRef) chartRef.destroy();
   return null;
 }
 
-/** Create activity-by-day bar chart */
-function createDayBarChart(ctx, dayTotals) {
-  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+/** Daily activity bar chart (time series of daily trace counts) */
+function createDailyBarChart(ctx, heatmapDays) {
+  var days = (heatmapDays || []).slice();
+  days.sort(function(a, b) { return a.date.localeCompare(b.date); });
+
+  var labels = days.map(function(d) {
+    return new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  });
+  var counts = days.map(function(d) { return d.count; });
+
   return new Chart(ctx, {
     type: 'bar',
     data: {
-      labels: days,
+      labels: labels,
       datasets: [{
-        data: dayTotals,
-        backgroundColor: 'rgba(59, 130, 246, 0.6)',
-        borderRadius: 4,
+        data: counts,
+        backgroundColor: 'rgba(99, 102, 241, 0.5)',
+        borderRadius: 3,
+        barPercentage: 0.8,
       }]
     },
     options: {
@@ -26,56 +33,44 @@ function createDayBarChart(ctx, dayTotals) {
       maintainAspectRatio: false,
       plugins: { legend: { display: false } },
       scales: {
-        y: { beginAtZero: true, ticks: { precision: 0 } },
-        x: { grid: { display: false } }
+        y: { beginAtZero: true, ticks: { precision: 0 }, grid: { color: '#f0f0f0' } },
+        x: { grid: { display: false }, ticks: { maxTicksLimit: 10, font: { size: 11 } } }
       }
     }
   });
 }
 
-/** Create cost-by-project doughnut chart */
+/** Cost-by-project doughnut chart */
 function createCostChart(ctx, labels, values) {
-  const colors = [
-    '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
-    '#ec4899', '#06b6d4', '#84cc16'
-  ];
+  var colors = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16'];
   return new Chart(ctx, {
     type: 'doughnut',
     data: {
       labels: labels,
-      datasets: [{
-        data: values,
-        backgroundColor: colors.slice(0, labels.length),
-      }]
+      datasets: [{ data: values, backgroundColor: colors.slice(0, labels.length) }]
     },
     options: {
       responsive: true,
       maintainAspectRatio: false,
-      plugins: {
-        legend: { position: 'bottom', labels: { font: { size: 11 } } }
-      }
+      plugins: { legend: { position: 'bottom', labels: { font: { size: 11 } } } }
     }
   });
 }
 
-/** Create score distribution bar chart */
+/** Score distribution bar chart */
 function createScoreChart(ctx, scores) {
-  const labels = scores.map(s => s.name);
-  const avgs = scores.map(s => s.avg);
-  const colors = labels.map((_, i) => {
-    const palette = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6'];
-    return palette[i % palette.length];
-  });
+  var labels = scores.map(function(s) { return s.name; });
+  var avgs = scores.map(function(s) { return s.avg; });
+  var colors = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6'];
 
   return new Chart(ctx, {
     type: 'bar',
     data: {
       labels: labels,
       datasets: [{
-        label: 'Average Score',
         data: avgs,
-        backgroundColor: colors.map(c => c + '99'),
-        borderColor: colors,
+        backgroundColor: labels.map(function(_, i) { return colors[i % colors.length] + '99'; }),
+        borderColor: labels.map(function(_, i) { return colors[i % colors.length]; }),
         borderWidth: 1,
         borderRadius: 4,
       }]
@@ -85,35 +80,33 @@ function createScoreChart(ctx, scores) {
       maintainAspectRatio: false,
       plugins: { legend: { display: false } },
       scales: {
-        y: { beginAtZero: true, max: 1.0 },
+        y: { beginAtZero: true, max: 1.0, grid: { color: '#f0f0f0' } },
         x: { grid: { display: false } }
       }
     }
   });
 }
 
-/** Create token usage trend line chart */
+/** Token usage trend line chart */
 function createTokenChart(ctx, sessions) {
-  // Show token usage per session (ordered by time)
-  const sorted = [...sessions]
-    .filter(s => s.first_trace)
-    .sort((a, b) => (a.first_trace || '').localeCompare(b.first_trace || ''));
+  var sorted = sessions.filter(function(s) { return s.first_trace && s.total_tokens > 0; })
+    .sort(function(a, b) { return (a.first_trace || '').localeCompare(b.first_trace || ''); });
 
-  const labels = sorted.map(s => {
-    if (!s.first_trace) return '';
+  if (sorted.length === 0) return null;
+
+  var labels = sorted.map(function(s) {
     return new Date(s.first_trace).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   });
-  const tokens = sorted.map(s => s.total_tokens || 0);
+  var tokens = sorted.map(function(s) { return s.total_tokens || 0; });
 
   return new Chart(ctx, {
     type: 'line',
     data: {
       labels: labels,
       datasets: [{
-        label: 'Tokens',
         data: tokens,
-        borderColor: '#3b82f6',
-        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+        borderColor: '#6366f1',
+        backgroundColor: 'rgba(99, 102, 241, 0.1)',
         fill: true,
         tension: 0.3,
         pointRadius: 2,
@@ -124,7 +117,7 @@ function createTokenChart(ctx, sessions) {
       maintainAspectRatio: false,
       plugins: { legend: { display: false } },
       scales: {
-        y: { beginAtZero: true },
+        y: { beginAtZero: true, grid: { color: '#f0f0f0' } },
         x: { grid: { display: false }, ticks: { maxTicksLimit: 8 } }
       }
     }

--- a/dashboard/static/js/charts.js
+++ b/dashboard/static/js/charts.js
@@ -1,0 +1,132 @@
+/**
+ * Chart.js factory functions for LLM Observatory.
+ */
+
+/** Destroy chart if it exists */
+function destroyChart(chartRef) {
+  if (chartRef) chartRef.destroy();
+  return null;
+}
+
+/** Create activity-by-day bar chart */
+function createDayBarChart(ctx, dayTotals) {
+  const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  return new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: days,
+      datasets: [{
+        data: dayTotals,
+        backgroundColor: 'rgba(59, 130, 246, 0.6)',
+        borderRadius: 4,
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        y: { beginAtZero: true, ticks: { precision: 0 } },
+        x: { grid: { display: false } }
+      }
+    }
+  });
+}
+
+/** Create cost-by-project doughnut chart */
+function createCostChart(ctx, labels, values) {
+  const colors = [
+    '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
+    '#ec4899', '#06b6d4', '#84cc16'
+  ];
+  return new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: labels,
+      datasets: [{
+        data: values,
+        backgroundColor: colors.slice(0, labels.length),
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { position: 'bottom', labels: { font: { size: 11 } } }
+      }
+    }
+  });
+}
+
+/** Create score distribution bar chart */
+function createScoreChart(ctx, scores) {
+  const labels = scores.map(s => s.name);
+  const avgs = scores.map(s => s.avg);
+  const colors = labels.map((_, i) => {
+    const palette = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6'];
+    return palette[i % palette.length];
+  });
+
+  return new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: labels,
+      datasets: [{
+        label: 'Average Score',
+        data: avgs,
+        backgroundColor: colors.map(c => c + '99'),
+        borderColor: colors,
+        borderWidth: 1,
+        borderRadius: 4,
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        y: { beginAtZero: true, max: 1.0 },
+        x: { grid: { display: false } }
+      }
+    }
+  });
+}
+
+/** Create token usage trend line chart */
+function createTokenChart(ctx, sessions) {
+  // Show token usage per session (ordered by time)
+  const sorted = [...sessions]
+    .filter(s => s.first_trace)
+    .sort((a, b) => (a.first_trace || '').localeCompare(b.first_trace || ''));
+
+  const labels = sorted.map(s => {
+    if (!s.first_trace) return '';
+    return new Date(s.first_trace).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  });
+  const tokens = sorted.map(s => s.total_tokens || 0);
+
+  return new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [{
+        label: 'Tokens',
+        data: tokens,
+        borderColor: '#3b82f6',
+        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+        fill: true,
+        tension: 0.3,
+        pointRadius: 2,
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        y: { beginAtZero: true },
+        x: { grid: { display: false }, ticks: { maxTicksLimit: 8 } }
+      }
+    }
+  });
+}

--- a/dashboard/static/js/utils.js
+++ b/dashboard/static/js/utils.js
@@ -2,69 +2,111 @@
  * Utility functions for LLM Observatory dashboard.
  */
 
-/** Format a number with comma separators */
 function fmtNum(n) {
   if (n == null) return '—';
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
   return n.toLocaleString();
 }
 
-/** Format cost in dollars */
 function fmtCost(n) {
   if (n == null || n === 0) return '$0.00';
   if (n < 0.01) return '$' + n.toFixed(4);
   return '$' + n.toFixed(2);
 }
 
-/** Format duration in ms to human readable */
 function fmtDuration(ms) {
-  if (ms == null) return '—';
+  if (ms == null || ms === 0) return '0ms';
   if (ms < 1000) return Math.round(ms) + 'ms';
   if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
   return (ms / 60000).toFixed(1) + 'm';
 }
 
-/** Format ISO timestamp to relative time (e.g. "2h ago") */
 function fmtRelative(isoStr) {
-  if (!isoStr) return '—';
-  const d = new Date(isoStr);
-  const now = new Date();
-  const diffMs = now - d;
-  const mins = Math.floor(diffMs / 60000);
+  if (!isoStr) return '';
+  var d = new Date(isoStr);
+  var now = new Date();
+  var mins = Math.floor((now - d) / 60000);
   if (mins < 1) return 'just now';
   if (mins < 60) return mins + 'm ago';
-  const hours = Math.floor(mins / 60);
+  var hours = Math.floor(mins / 60);
   if (hours < 24) return hours + 'h ago';
-  const days = Math.floor(hours / 24);
+  var days = Math.floor(hours / 24);
   if (days < 30) return days + 'd ago';
   return d.toLocaleDateString();
 }
 
-/** Format ISO timestamp to short date */
 function fmtDate(isoStr) {
-  if (!isoStr) return '—';
+  if (!isoStr) return '';
   return new Date(isoStr).toLocaleDateString('en-US', {
     month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
   });
 }
 
-/** Get ISO string for N days ago */
+function fmtShortDate(isoStr) {
+  if (!isoStr) return '';
+  return new Date(isoStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
 function daysAgo(n) {
-  const d = new Date();
+  var d = new Date();
   d.setDate(d.getDate() - n);
   return d.toISOString();
 }
 
-/** Build query string from filter params */
 function buildQuery(params) {
-  const p = new URLSearchParams();
-  Object.entries(params).forEach(([k, v]) => {
-    if (v != null && v !== '' && v !== 'all') p.set(k, v);
+  var p = new URLSearchParams();
+  Object.entries(params).forEach(function(e) {
+    if (e[1] != null && e[1] !== '' && e[1] !== 'all') p.set(e[0], e[1]);
   });
   return p.toString();
 }
 
-/** Trigger CSV download */
 function downloadCSV(params) {
-  const qs = buildQuery(params);
+  var qs = buildQuery(params);
   window.location.href = '/api/export/csv' + (qs ? '?' + qs : '');
+}
+
+/** Truncate text to N chars */
+function truncate(str, n) {
+  if (!str) return '';
+  str = String(str);
+  return str.length > n ? str.slice(0, n) + '...' : str;
+}
+
+/** Extract a readable title from trace input */
+function traceTitle(trace) {
+  if (!trace) return 'Untitled';
+  // Try input first
+  var input = trace.input;
+  if (input) {
+    if (typeof input === 'string') return truncate(input, 80);
+    if (typeof input === 'object') {
+      // common patterns
+      if (input.query) return truncate(input.query, 80);
+      if (input.question) return truncate(input.question, 80);
+      if (input.prompt) return truncate(input.prompt, 80);
+      if (input.messages && input.messages.length > 0) {
+        var last = input.messages[input.messages.length - 1];
+        return truncate(last.content || JSON.stringify(last), 80);
+      }
+      return truncate(JSON.stringify(input), 80);
+    }
+  }
+  return trace.name || 'Untitled';
+}
+
+/** Highlight search term in text */
+function highlightText(text, term) {
+  if (!term || !text) return escapeHtml(text || '');
+  var escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  var re = new RegExp('(' + escaped + ')', 'gi');
+  return escapeHtml(text).replace(
+    new RegExp('(' + escaped + ')', 'gi'),
+    '<span class="search-highlight">$1</span>'
+  );
+}
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }

--- a/dashboard/static/js/utils.js
+++ b/dashboard/static/js/utils.js
@@ -1,0 +1,70 @@
+/**
+ * Utility functions for LLM Observatory dashboard.
+ */
+
+/** Format a number with comma separators */
+function fmtNum(n) {
+  if (n == null) return '—';
+  return n.toLocaleString();
+}
+
+/** Format cost in dollars */
+function fmtCost(n) {
+  if (n == null || n === 0) return '$0.00';
+  if (n < 0.01) return '$' + n.toFixed(4);
+  return '$' + n.toFixed(2);
+}
+
+/** Format duration in ms to human readable */
+function fmtDuration(ms) {
+  if (ms == null) return '—';
+  if (ms < 1000) return Math.round(ms) + 'ms';
+  if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+  return (ms / 60000).toFixed(1) + 'm';
+}
+
+/** Format ISO timestamp to relative time (e.g. "2h ago") */
+function fmtRelative(isoStr) {
+  if (!isoStr) return '—';
+  const d = new Date(isoStr);
+  const now = new Date();
+  const diffMs = now - d;
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return mins + 'm ago';
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return hours + 'h ago';
+  const days = Math.floor(hours / 24);
+  if (days < 30) return days + 'd ago';
+  return d.toLocaleDateString();
+}
+
+/** Format ISO timestamp to short date */
+function fmtDate(isoStr) {
+  if (!isoStr) return '—';
+  return new Date(isoStr).toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+  });
+}
+
+/** Get ISO string for N days ago */
+function daysAgo(n) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+}
+
+/** Build query string from filter params */
+function buildQuery(params) {
+  const p = new URLSearchParams();
+  Object.entries(params).forEach(([k, v]) => {
+    if (v != null && v !== '' && v !== 'all') p.set(k, v);
+  });
+  return p.toString();
+}
+
+/** Trigger CSV download */
+function downloadCSV(params) {
+  const qs = buildQuery(params);
+  window.location.href = '/api/export/csv' + (qs ? '?' + qs : '');
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -391,6 +391,12 @@ services:
     ports:
       - "${DASHBOARD_PORT:-8005}:8005"
     environment:
+      # ClickHouse direct connection (fast analytics)
+      - CLICKHOUSE_HOST=langfuse-clickhouse
+      - CLICKHOUSE_HTTP_PORT=8123
+      - CLICKHOUSE_USER=langfuse
+      - CLICKHOUSE_PASSWORD=langfuse123
+      # Langfuse REST API (fallback / session detail)
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-pk-lf-1234567890}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-sk-lf-1234567890}
       - LANGFUSE_HOST=${LANGFUSE_INTERNAL_URL:-http://langfuse-web:3000}
@@ -398,7 +404,7 @@ services:
     profiles:
       - dashboard
     depends_on:
-      langfuse-web:
+      langfuse-clickhouse:
         condition: service_healthy
 
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -377,6 +377,30 @@ services:
     volumes:
       - ./mcp-langfuse-logs:/app/logs
 
+  # =============================================================================
+  # LLM Observatory — Analytics Dashboard
+  # =============================================================================
+  # Enable with --profile dashboard
+  # Start: docker compose --profile langfuse --profile dashboard up -d
+  # Open: http://localhost:8005
+  # =============================================================================
+  dashboard:
+    build:
+      context: ./dashboard
+    container_name: llm-observatory
+    ports:
+      - "${DASHBOARD_PORT:-8005}:8005"
+    environment:
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-pk-lf-1234567890}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-sk-lf-1234567890}
+      - LANGFUSE_HOST=${LANGFUSE_INTERNAL_URL:-http://langfuse-web:3000}
+      - DASHBOARD_CACHE_TTL=${DASHBOARD_CACHE_TTL:-60}
+    profiles:
+      - dashboard
+    depends_on:
+      langfuse-web:
+        condition: service_healthy
+
 volumes:
   # Langfuse volumes
   langfuse-postgres-data:


### PR DESCRIPTION
## Summary

- Adds a lightweight analytics dashboard (`dashboard/`) that queries the Langfuse REST API to visualize LLM observability data
- **Stack**: Python FastAPI backend (`:8005`) + single-page HTML frontend (Alpine.js + Chart.js, no build step)
- **Deployment**: New Docker service under `dashboard` profile, same patterns as existing services
- Dashboard UX inspired by [AgentsView](https://github.com/wesm/agentsview) by Wes McKinney (MIT). All code written from scratch — no AgentsView code is copied.

### Features
- KPI cards: sessions, traces, projects, active days, median traces/session, avg latency, total cost, avg score
- GitHub-style activity heatmap + hour-of-day/day-of-week breakdown
- Session sidebar with search, click-to-expand detail view with trace timeline
- Top sessions ranked by traces/duration/cost
- Tool/span usage bars and quality score distributions
- Cost-by-project doughnut and token usage trend line charts
- Time range filters (7d/30d/90d/1y/all) and project filter dropdown
- CSV export of all traces
- 60s TTL in-memory cache for Langfuse API responses

### Files
- `dashboard/` — 19 new files (Dockerfile, FastAPI app, 8 route modules, Langfuse client, Pydantic models, HTML/CSS/JS)
- `docker-compose.yaml` — new `dashboard` service under `dashboard` profile
- `.env.example` — added `DASHBOARD_PORT` and `DASHBOARD_CACHE_TTL`
- `CLAUDE.md` — updated with dashboard docs

## Test plan

- [ ] `docker compose --profile langfuse --profile dashboard up -d` starts dashboard at `:8005`
- [ ] Seed data with `./scripts/seed-demo-data.sh`, verify KPI cards show correct counts
- [ ] Filter by project and time range — verify all metrics update
- [ ] Click a session in sidebar — verify detail view shows traces with input/output/scores
- [ ] Click Export CSV — verify file downloads with trace data
- [ ] Compare trace counts against Langfuse UI at `:3001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)