### PR TITLE
Instrument retrieve_context with Langfuse @observe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ __pycache__/
 *.pyc
 *.pyo
 *.sqlite
+
+# Database backups
+backups/

--- a/text-to-sql/sql_pipeline.py
+++ b/text-to-sql/sql_pipeline.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from langchain_anthropic import ChatAnthropic
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
+from langfuse import observe
 
 
 @dataclass
@@ -88,6 +89,7 @@ class ClickHouseSQLPipeline:
             self.response_prompt | self.llm | StrOutputParser()
         ).with_config({"metadata": {"purpose": "response_generation"}})
 
+    @observe(name="retrieve-context")
     def retrieve_context(self, question: str, analysis: str) -> str:
         """Retrieve context from ClickHouse via MCP."""
         try:


### PR DESCRIPTION
Adds Langfuse `@observe(name="retrieve-context")` instrumentation to `ClickHouseSQLPipeline.retrieve_context()` so the MCP context-retrieval step shows up as its own span in traces. Also gitignores the local `backups/` directory.

This commit landed on `feature/agentic-rag-clickhouse` after PR #16 merged, so it needs its own PR to reach `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)