### PR TITLE
Replace @observe with guarded langfuse_span context manager

### DIFF
--- a/text-to-sql/langfuse_config.py
+++ b/text-to-sql/langfuse_config.py
@@ -105,6 +105,29 @@ def langfuse_trace(trace_name="text-to-sql", tags=None):
         yield
 
 
+@contextmanager
+def langfuse_span(name: str):
+    """Context manager that creates a child span nested under the current trace.
+
+    Mirrors the v3 pattern used by langfuse_session(); no-op when Langfuse is
+    not configured. Use to instrument non-LangChain steps (e.g. MCP calls) so
+    they appear as spans within the active trace.
+    """
+    if not LANGFUSE_ENABLED:
+        yield
+        return
+
+    try:
+        from langfuse import get_client
+
+        client = get_client()
+        with client.start_as_current_observation(as_type="span", name=name):
+            yield
+    except Exception as e:
+        print(f"Failed to create Langfuse span '{name}': {e}")
+        yield
+
+
 def get_langfuse_handler():
     """
     Get Langfuse callback handler for LangChain with session support.

--- a/text-to-sql/sql_pipeline.py
+++ b/text-to-sql/sql_pipeline.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from langchain_anthropic import ChatAnthropic
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
-from langfuse import observe
+from langfuse_config import langfuse_span
 
 
 @dataclass
@@ -89,17 +89,17 @@ class ClickHouseSQLPipeline:
             self.response_prompt | self.llm | StrOutputParser()
         ).with_config({"metadata": {"purpose": "response_generation"}})
 
-    @observe(name="retrieve-context")
     def retrieve_context(self, question: str, analysis: str) -> str:
         """Retrieve context from ClickHouse via MCP."""
-        try:
-            from mcp_client import create_mcp_client
-            mcp = create_mcp_client()
-            self._context = mcp.get_context_for_question(question, analysis)
-            return self._context
-        except Exception as e:
-            self._context = f"[MCP unavailable: {e}]"
-            return self._context
+        with langfuse_span("retrieve-context"):
+            try:
+                from mcp_client import create_mcp_client
+                mcp = create_mcp_client()
+                self._context = mcp.get_context_for_question(question, analysis)
+                return self._context
+            except Exception as e:
+                self._context = f"[MCP unavailable: {e}]"
+                return self._context
 
     def query(self, question: str, callbacks: list = None) -> str:
         """Execute the full Text-to-SQL pipeline.


### PR DESCRIPTION
Follow-up to the code review on PR #17, which added `@observe` to `ClickHouseSQLPipeline.retrieve_context()`. This replaces that decorator with a guarded `langfuse_span()` context manager that follows the codebase's existing v3 instrumentation pattern.

## Changes
- **`langfuse_config.py`**: new `langfuse_span(name)` context manager mirroring `langfuse_session()` — uses `start_as_current_observation`, gated on `LANGFUSE_ENABLED`, langfuse import is lazy + try/except guarded.
- **`sql_pipeline.py`**: removed the top-level `from langfuse import observe` and the `@observe` decorator; wrapped the MCP call in `with langfuse_span("retrieve-context")`.

## Why
| Review finding | Fix |
|---|---|
| `@observe` diverges from the v3 `trace()/span()` patterns in CLAUDE.md | uses `start_as_current_observation` like the rest of `langfuse_config.py` |
| unconditional top-level langfuse import (ImportError risk) | import is now lazy and guarded inside `langfuse_config` |
| `@observe` not gated on `LANGFUSE_ENABLED` | `langfuse_span` is a no-op when tracing is disabled |

Span topology is unchanged: it nests under the active trace via the same OTel context as `session-root`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)