### PR TITLE
Fix LibreChat agents emitting raw tool-call XML (MCP tools not bound)

### DIFF
--- a/.agents/skills/troubleshoot/SKILL.md
+++ b/.agents/skills/troubleshoot/SKILL.md
@@ -44,6 +44,7 @@ Diagnose before acting. Most problems resolve with a targeted fix plus an idempo
    |---|---|
    | 401s from SDK/CLI, traces silently missing | Shell-exported `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` override `.env`. `unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY` and retry. |
    | LibreChat agents have no MCP tools | MCP servers init async. Wait 30s, re-run `./scripts/seed-librechat-agents.sh` (idempotent). |
+   | LibreChat agent chat shows raw `<function_calls>` / `<invoke>` / `<tool_call>` XML as text | Agent's MCP tools didn't bind → Claude role-plays the call as text (and may hallucinate the results). See [Agent emits raw tool-call XML](#agent-emits-raw-tool-call-xml) below. |
    | Langfuse not ready after ~2 min | Slow first-boot migrations. Re-run `./setup.sh`. |
    | Traces arrive but no judge scores | Check LLM connection exists (Project Settings > LLM Connections) and `langfuse-worker` logs; evaluators need ~30–60s. |
    | Port conflict | Change the port in `.env` (e.g. `LANGFUSE_PORT`), re-run `./setup.sh`. |
@@ -65,6 +66,56 @@ Diagnose before acting. Most problems resolve with a targeted fix plus an idempo
 
    Re-provision with `./scripts/seed-code-evaluators.sh` /
    `./scripts/seed-llm-judge-evaluators.sh` (both idempotent).
+
+## Agent emits raw tool-call XML
+
+**Symptom:** a LibreChat agent (e.g. *ClickHouse Data Analyst*) answers with blocks of
+literal markup instead of LibreChat's collapsible tool cards:
+
+```
+<function_calls>
+<invoke name="...">
+<parameter name="query">SHOW DATABASES</parameter>
+...
+<function_response>{...}</function_response>
+```
+
+(Older shape: `<tool_call>{"name": "...", "arguments": {...}}</tool_call>`.) The
+"results" may look plausible but are **hallucinated** — the tool never actually ran.
+
+**Root cause:** the agent's MCP tools were **not bound** for that request, so no `tools`
+were sent to the Anthropic API. Claude — instructed to use tools — then writes the
+tool-call syntax (and a fake response) as plain *text*, which LibreChat renders verbatim.
+This is **not** a model, model-id, version, or permission bug. Confirm in a Langfuse
+trace: the `AgentRun` generation has **no `tools` in its input** and there are **no
+tool-execution spans**.
+
+Tools fail to bind when, at chat time, the MCP server wasn't connected, or the agent was
+**seeded before its tools were available** (so it has only the `sys__server__sys_mcp_*`
+stub or an empty/stale tool set). Maintainer note for the underlying LibreChat behaviour:
+[danny-avila/LibreChat #10351](https://github.com/danny-avila/LibreChat/discussions/10351).
+
+**Fix (in order):**
+
+1. Confirm the MCP server is healthy and advertising tools:
+   ```bash
+   docker compose ps mcp-clickhouse                       # must be Up
+   # log in as demo@example.com / demodemo1! to get $TOKEN, then:
+   curl -sf -H "Authorization: Bearer $TOKEN" http://localhost:3080/api/mcp/tools \
+     | jq '.servers | to_entries[] | "\(.key): \(.value.tools|length) tool(s)"'
+   ```
+2. Re-sync the agents' tool bindings (now repairs existing agents, not just new ones):
+   ```bash
+   ./scripts/seed-librechat-agents.sh
+   ```
+   Look for `↻ <agent> (tools re-synced …)`. Verify in Mongo:
+   ```bash
+   docker exec librechat-mongodb mongosh LibreChat --quiet --eval \
+     'printjson(db.agents.findOne({name:"ClickHouse Data Analyst"},{tools:1,_id:0}))'
+   # expect individual *_mcp_clickhouse-playground keys, not just the server stub
+   ```
+3. **Start a brand-new conversation.** LibreChat caches tool state per conversation;
+   an old thread that started broken stays broken.
 
 ## Recovery ladder (least → most destructive)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,8 @@ should be ✓).
 | Symptom | Fix |
 |---|---|
 | `ANTHROPIC_API_KEY is not set and no terminal is available` | Re-run with the key: `ANTHROPIC_API_KEY=sk-ant-... ./setup.sh` |
-| Agents created without tools / "No MCP tools found" | MCP servers initialize async. Wait 30s, run `./scripts/seed-librechat-agents.sh` again (idempotent). |
+| Agents created without tools / "No MCP tools found" | MCP servers initialize async. Wait 30s, run `./scripts/seed-librechat-agents.sh` again (idempotent — it now re-syncs tool bindings on existing agents, not just new ones). |
+| Agent chat shows raw `<function_calls>` / `<tool_call>` XML as text | Agent's MCP tools didn't bind, so Claude role-plays the call as text. Verify MCP is healthy, re-run `./scripts/seed-librechat-agents.sh`, then start a **new** conversation. Details: [troubleshoot skill](.agents/skills/troubleshoot/SKILL.md#agent-emits-raw-tool-call-xml). |
 | 401 errors from Langfuse CLI/scripts | Shell-exported keys override `.env`: `unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY` and retry. |
 | Langfuse not ready after 2 min | `docker compose --profile langfuse logs langfuse-web --tail 50` — usually slow first-boot migrations; re-run `./setup.sh`. |
 | LibreChat not ready | `docker compose logs api --tail 50` |

--- a/scripts/seed-librechat-agents.sh
+++ b/scripts/seed-librechat-agents.sh
@@ -152,8 +152,12 @@ MCP_MAX_ATTEMPTS=15
 while [ $MCP_ATTEMPTS -lt $MCP_MAX_ATTEMPTS ]; do
     MCP_TOOLS=$(auth_curl "${LIBRECHAT_URL}/api/mcp/tools" 2>/dev/null || echo '{}')
 
-    # Check if we have tools from at least one server
-    TOOL_COUNT=$(echo "$MCP_TOOLS" | jq 'if type == "object" then [.[] | keys[]] | length else 0 end' 2>/dev/null || echo "0")
+    # Count actual TOOLS across all servers (not just how many servers exist —
+    # a server can be registered before it has advertised any tools yet).
+    TOOL_COUNT=$(echo "$MCP_TOOLS" | jq '
+        if (.servers? | objects) then [ .servers[]?.tools[]? ] | length
+        elif type == "object" then [ .[]? | objects | keys[]? ] | length
+        else 0 end' 2>/dev/null || echo "0")
     if [ "$TOOL_COUNT" -gt 0 ]; then
         break
     fi
@@ -173,32 +177,45 @@ fi
 echo -e "${GREEN}✓${NC} Found ${TOOL_COUNT} MCP tools"
 echo ""
 
-# Build tool arrays for each MCP server
-# Tool format: server entry = "sys__server__sys_mcp_<serverName>"
-#              individual tool = "<toolName>_mcp_<serverName>"
+# Build tool arrays for each MCP server.
+#
+# A bound tool is identified by its "plugin key": "<toolName>_mcp_<serverName>".
+# The server-level entry "sys__server__sys_mcp_<serverName>" tells LibreChat to
+# expose the whole server; we ALSO bind each individual tool by its plugin key so
+# the agent matches LibreChat's own UI behaviour ("Add MCP Server Tools").
+#
+# /api/mcp/tools has changed shape across LibreChat versions:
+#   v0.8.x : { "servers": { "<server>": { "tools": [ { "pluginKey": ... }, ... ] } } }
+#   legacy : { "<server>": { "<toolName>": { ... } } }
+# We read the authoritative pluginKey from the v0.8.x shape and fall back to
+# constructing it from the legacy shape. The previous version only understood the
+# legacy shape, so on current LibreChat it silently bound NO individual tools —
+# leaving agents with just the server stub. Agents seeded in that state can fail
+# to attach their tools at chat time, and the model then emits raw <function_calls>
+# / <tool_call> XML as plain text instead of using native tool calls.
 build_tools_for_server() {
     local server_name="$1"
     local tools=()
 
-    # Add server entry
+    # Server-level entry (exposes all of this server's tools).
     tools+=("\"sys__server__sys_mcp_${server_name}\"")
 
-    # Extract individual tool names for this server from pluginKey pattern
-    local tool_names
-    tool_names=$(echo "$MCP_TOOLS" | jq -r "
-        if type == \"object\" then
-            to_entries[] |
-            select(.key == \"${server_name}\") |
-            .value | keys[]
+    # Individual tool plugin keys.
+    local plugin_keys
+    plugin_keys=$(echo "$MCP_TOOLS" | jq -r --arg s "$server_name" '
+        if (.servers? | objects | has($s)) then
+            .servers[$s].tools[]?.pluginKey // empty       # v0.8.x nested shape
+        elif (objects | has($s)) then
+            .[$s] | keys[] | "\(.)_mcp_\($s)"               # legacy flat shape
         else
             empty
         end
-    " 2>/dev/null || true)
+    ' 2>/dev/null || true)
 
-    while IFS= read -r tool; do
-        [ -z "$tool" ] && continue
-        tools+=("\"${tool}_mcp_${server_name}\"")
-    done <<< "$tool_names"
+    while IFS= read -r key; do
+        [ -z "$key" ] && continue
+        tools+=("\"${key}\"")
+    done <<< "$plugin_keys"
 
     # Return as JSON array
     local IFS=','
@@ -238,28 +255,51 @@ create_agent() {
 
     local desired_model="${ANTHROPIC_MODEL:-claude-sonnet-4-6}"
 
+    # How many individual (non-stub) tools we actually resolved for this agent.
+    local desired_tool_count
+    desired_tool_count=$(echo "$tools" | jq '[.[] | select(startswith("sys__server__") | not)] | length' 2>/dev/null || echo 0)
+
     if agent_exists "$name"; then
-        # Keep existing agents on the configured model (e.g. after a deprecation bump)
-        local agent_id current_model
+        # Reconcile existing agents toward the desired model AND tool bindings.
+        # Re-running the seed script must be able to REPAIR an agent that was
+        # created before its MCP tools were available (so it only has the server
+        # stub, or an empty/stale tool set) — otherwise the agent keeps emitting
+        # raw <function_calls> XML instead of native tool calls.
+        local agent_id detail current_model current_tools
         agent_id=$(agent_field "$name" "id")
-        current_model=$(agent_field "$name" "model")
-        if [ -n "$agent_id" ] && [ -z "$current_model" ]; then
-            # list endpoint omits model — fetch the agent detail
-            current_model=$(auth_curl "${LIBRECHAT_URL}/api/agents/${agent_id}" 2>/dev/null \
-                | jq -r '.model // empty' || true)
+        detail=$(auth_curl "${LIBRECHAT_URL}/api/agents/${agent_id}" 2>/dev/null || echo '{}')
+        current_model=$(echo "$detail" | jq -r '.model // empty')
+        current_tools=$(echo "$detail" | jq -c '.tools // []' 2>/dev/null || echo '[]')
+
+        local patch='{}' changes=()
+        if [ -n "$current_model" ] && [ "$current_model" != "$desired_model" ]; then
+            patch=$(echo "$patch" | jq --arg m "$desired_model" '. + {model: $m}')
+            changes+=("model ${current_model} → ${desired_model}")
         fi
-        if [ -n "$agent_id" ] && [ -n "$current_model" ] && [ "$current_model" != "$desired_model" ]; then
+        # Only re-sync tools when we actually resolved individual tools (guard
+        # against wiping a good binding with a stub-only set when MCP is still
+        # initializing) and the desired set differs from what's stored.
+        local cur_sorted des_sorted
+        cur_sorted=$(echo "$current_tools" | jq -cS '. // [] | sort' 2>/dev/null || echo '[]')
+        des_sorted=$(echo "$tools" | jq -cS 'sort' 2>/dev/null || echo '[]')
+        if [ "$desired_tool_count" -gt 0 ] && [ "$cur_sorted" != "$des_sorted" ]; then
+            patch=$(echo "$patch" | jq --argjson t "$tools" '. + {tools: $t}')
+            changes+=("tools re-synced (${desired_tool_count} tool(s))")
+        fi
+
+        if [ -n "$agent_id" ] && [ "$patch" != "{}" ]; then
             if auth_curl -X PATCH "${LIBRECHAT_URL}/api/agents/${agent_id}" \
-                -H "Content-Type: application/json" \
-                -d "$(jq -n --arg m "$desired_model" '{model: $m}')" > /dev/null 2>&1; then
-                echo -e "  ${GREEN}↻${NC} ${name} (model updated: ${current_model} → ${desired_model})"
+                -H "Content-Type: application/json" -d "$patch" > /dev/null 2>&1; then
+                local summary
+                summary=$(printf '%s; ' "${changes[@]}"); summary=${summary%; }
+                echo -e "  ${GREEN}↻${NC} ${name} (${summary})"
                 UPDATED=$((UPDATED + 1))
             else
-                echo -e "  ${YELLOW}⤳${NC} ${name} (exists; model update failed — update manually in agent settings)"
+                echo -e "  ${YELLOW}⤳${NC} ${name} (exists; update failed — update manually in agent settings)"
                 SKIPPED=$((SKIPPED + 1))
             fi
         else
-            echo -e "  ${YELLOW}⤳${NC} ${name} (already exists, skipping)"
+            echo -e "  ${YELLOW}⤳${NC} ${name} (already exists, up to date)"
             SKIPPED=$((SKIPPED + 1))
         fi
         return 0
@@ -287,7 +327,14 @@ create_agent() {
         -d "$payload" 2>&1)
 
     if echo "$response" | jq -e '.id' > /dev/null 2>&1; then
-        echo -e "  ${GREEN}✓${NC} ${name}"
+        if [ "$desired_tool_count" -gt 0 ]; then
+            echo -e "  ${GREEN}✓${NC} ${name} (${desired_tool_count} tool(s) bound)"
+        else
+            # Created with only a server-level stub — MCP tools weren't live yet.
+            # The agent may emit raw tool-call XML until re-synced.
+            echo -e "  ${YELLOW}!${NC} ${name} — created with NO individual MCP tools (server still initializing?)."
+            echo -e "      Re-run ${GREEN}./scripts/seed-librechat-agents.sh${NC} once MCP servers are healthy to bind them."
+        fi
         CREATED=$((CREATED + 1))
     else
         echo -e "  ${RED}✗${NC} ${name} — failed to create"


### PR DESCRIPTION
## The report

A user chatting with the **ClickHouse Data Analyst** agent saw the response filled with raw markup instead of LibreChat's collapsible tool cards:

```
<function_calls>
<invoke name="mcp_clickhouse_clickhouse_query">
<parameter name="query">SHOW DATABASES</parameter>
</invoke>
</function_calls>
<function_response>{...}</function_response>
```

The numbers looked real but were **hallucinated** — the tool never ran.

## Root cause (what actually happened)

This is **not** a model, model-id, version, or permission bug. I confirmed:

- The raw Anthropic API returns proper native `tool_use` for `claude-sonnet-4-6` when given a `tools` param ✅
- `MCP_SERVERS` permission is `USE: true` for both roles ✅
- LibreChat v0.8.6 + `@langchain/anthropic` 1.3.28 are current ✅

The smoking gun is in Langfuse: the `AgentRun` generations have **no `tools` in their input** and **zero tool-execution spans**. So no tools reached the model — and Claude, told by its instructions to "use the available MCP tools", role-plays the tool call (and a fake response) as plain text, which LibreChat renders verbatim. The tool name in the screenshot (`mcp_clickhouse_clickhouse_query`) doesn't even exist on the server (real tools are `list_databases`, `list_tables`, `run_select_query`) — proof it's hallucinated. This matches the LibreChat behaviour danny-avila describes in [discussion #10351](https://github.com/danny-avila/LibreChat/discussions/10351).

The repo bug that lands an agent in that state: **`seed-librechat-agents.sh` parsed the old `/api/mcp/tools` shape.** LibreChat v0.8.x changed it from flat `{ "<server>": { "<tool>": … } }` to nested `{ "servers": { "<server>": { "tools": [ { "pluginKey": … } ] } } }`. The old `jq` therefore extracted **zero** individual tools and seeded agents with only the `sys__server__sys_mcp_<server>` stub — and re-running the script only PATCHed the model, never the tools, so a broken agent could **not self-repair**.

> Verified live: the **Agentic RAG Assistant** on the running stack had only stubs (`sys__server__sys_mcp_*`, no individual tools). After this fix, re-running the seed script repaired it to the full set (`retrieve_kb`, `list_documents`, + the clickhouse tools).

## Changes

**`scripts/seed-librechat-agents.sh`**
- Read the authoritative `pluginKey` from the v0.8.x nested shape, with a fallback to the legacy flat shape.
- Wait-loop counts **actual tools** (not servers), so it genuinely waits for tools to come live.
- Re-running now **reconciles tools on existing agents** (not just the model), guarded so a stub-only/empty resolve never overwrites a good binding — `./scripts/seed-librechat-agents.sh` is now a one-command repair.
- Warn loudly when an agent is created with only a server stub.

**Docs** — `troubleshoot` skill + `AGENTS.md`: add symptom → cause → fix (verify MCP healthy → re-run seed → **start a new conversation**, since LibreChat caches tool state per conversation).

## Testing

- `bash -n` clean; ran the seed script live against the stack.
- First run repaired the Agentic RAG agent (`↻ … tools re-synced (5)`); agents that were already correct were left untouched (`up to date`); Prompt Engineer (whose `langfuse-prompts` MCP has 0 live tools) was correctly **not** wiped.
- Second run fully idempotent — every agent `up to date`.

## For the user who reported it

Their instance most likely seeded/re-seeded against LibreChat v0.8.x (only stubs bound), or chatted while `mcp-clickhouse` was unhealthy. Recovery on their side:
1. `docker compose ps mcp-clickhouse` → must be **Up**
2. `./scripts/seed-librechat-agents.sh` → look for `↻ … tools re-synced`
3. **Start a brand-new conversation** (old threads stay broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)