### PR TITLE
Extend the AI Engineering loop to the main stack (prompt mgmt + LibreChat feedback + narration)

### DIFF
--- a/AI_ENGINEERING_LOOP.md
+++ b/AI_ENGINEERING_LOOP.md
@@ -1,0 +1,93 @@
+# The AI Engineering Loop — mapped to this repo
+
+This repo is a working reference for the full **[AI Engineering
+loop](https://langfuse.com/academy/ai-engineering-loop)** on ClickHouse-backed
+Langfuse — not just tracing. Every demo here plugs into the same loop; this page
+maps each step to the concrete code, scripts, and Langfuse pages that implement
+it across the whole stack.
+
+> You can't unit-test your way to confidence with probabilistic LLM outputs. The
+> loop is how you improve systematically: observe production, learn from it, and
+> ship improvements you can trust — then repeat.
+
+```
+                            ┌─────────────────────────────────────┐
+                            │               DEPLOY                │
+                            │   prompt labels · GitHub CI/CD      │
+                            └───────────────▲───────────┬─────────┘
+   ── ONLINE (understand production) ──     │           │   ── OFFLINE (improve) ──
+                                            │           ▼
+   ┌───────────┐     ┌───────────┐     ┌────┴──────┐  ┌────────────┐  ┌───────────┐
+   │  1 TRACE  │ ──► │ 2 MONITOR │ ──► │ 3 DATASETS│─►│4 EXPERIMENT│─►│ 5 EVALUATE│
+   └───────────┘     └───────────┘     └───────────┘  └────────────┘  └───────────┘
+        ▲                                                                    │
+        └──────────────  ship a change → new traces → repeat  ◄─────────────┘
+```
+
+## The apps
+
+| App | What it is | Instrumentation |
+|-----|-----------|-----------------|
+| `text-to-sql/` | NL → SQL over ClickHouse via MCP | LangChain + Langfuse `CallbackHandler` |
+| `vector-rag/` | RAG over ChromaDB | LangChain + Langfuse `CallbackHandler` |
+| `agentic-rag/` | Self-correcting RAG on ClickHouse-native vectors | LangGraph + Langfuse SDK |
+| `librechat/` | Shared chat frontend | LibreChat native Langfuse tracing |
+| `real-estate-demo/` | Self-contained agentic concierge — the loop shown end-to-end in one place | Langfuse SDK |
+
+## Where each loop step lives
+
+| # | Step | Across the main stack | Deep-dive example |
+|---|------|----------------------|-------------------|
+| 1 | **Trace** | All apps emit full traces (prompts, tools, retrieval, cost) to the Langfuse project | `agentic-rag/graph.py`, `text-to-sql/sql_pipeline.py` |
+| 2 | **Monitor** | **LLM Observatory** dashboard (`dashboard/`, `:8005`); code + LLM-judge scores; **👍/👎 user feedback** — LibreChat thumbs → `user-feedback` score via `librechat/feedback-bridge/`, and the `real-estate-demo/` portal | Langfuse **Dashboards** / **Evaluators** |
+| 3 | **Build datasets** | `scripts/seed-datasets.py` (coding-quality + security datasets); production traces → dataset from the UI | `real-estate-demo/` 10-item eval set |
+| 4 | **Experiment** | `scripts/run-experiments.py` — compare **models / datasets** on the eval sets | **prompt-variant** experiments: `real-estate-demo/` + `agentic-rag` |
+| 5 | **Evaluate** | Deterministic **code evaluators** (`evaluators/*.ts`, seeded by `scripts/seed-code-evaluators.sh`) + **LLM-as-a-Judge** (`scripts/seed-llm-judge-evaluators.sh`) | human **annotation** queue in `real-estate-demo/` |
+| ⟳ | **Deploy** | **Prompt management by label** — apps fetch prompts from Langfuse at runtime with a local fallback: `agentic-rag` (`scripts/seed-langfuse-prompt.py`), `text-to-sql` + `vector-rag` (`scripts/seed-app-prompts.py`). Promote a label to ship a prompt with no redeploy. | **GitHub CI/CD** reference for gated prompt deploys in `real-estate-demo/cicd/` |
+
+## The Deploy node across the stack
+
+Historically the apps hard-coded their prompts. Now the LLM apps fetch prompts
+**by label** (`production`) from Langfuse at runtime, each with a hard-coded
+fallback so they still run if Langfuse is unreachable, and each **links the
+fetched prompt version to the generation** (so quality ties back to a version):
+
+```bash
+# Seed the managed prompts (idempotent), then edit/promote them in the UI:
+python scripts/seed-app-prompts.py        # text-to-sql-analysis / -response, vector-rag-generation
+python scripts/seed-langfuse-prompt.py    # agentic-rag-generation (v1 + v2 production)
+```
+
+Editing a prompt in the Langfuse UI — or promoting a new version to `production`
+— changes the app's behaviour on the next run with **no code change**. Gating
+that promotion behind CI (run the eval set, ship only on pass) is the
+GitHub-integration path documented in `real-estate-demo/cicd/`.
+
+## User feedback (Monitor) — how LibreChat's thumbs reach Langfuse
+
+LibreChat's native 👍/👎 (`PUT /api/messages/:conv/:msg/feedback`) is mirrored
+**fire-and-forget** by nginx (`librechat/nginx.conf`) to a small sidecar
+(`librechat/feedback-bridge/`, `langfuse` profile). The sidecar maps the
+conversation+message back to its Langfuse trace (`trace.sessionId ==
+conversationId`, `trace.metadata.messageId == messageId`) and writes a
+`user-feedback` score — so real user judgement sits next to the automated evals.
+A down/slow bridge never affects the user's click.
+
+## The loop, end-to-end in one demo
+
+`real-estate-demo/` is the self-contained walkthrough that shows every step —
+trace → monitor → dataset → experiment (models **and** prompts) → evaluate →
+**deploy a prompt by label** → repeat — with a presenter runbook. Start there to
+see the whole loop close in ~20 minutes, then map the same pattern onto the main
+stack using the table above.
+
+## Honest scope (what's live vs documented)
+
+| Capability | Status |
+|---|---|
+| Trace / Monitor / Datasets / Evaluate across the stack | **Live** |
+| Prompt management (label fetch + fallback + link) — agentic-rag, text-to-sql, vector-rag | **Live** |
+| Model / dataset experiments (`run-experiments.py`) | **Live** |
+| Prompt-variant experiments | **Live** in real-estate-demo + agentic-rag (not the `run-experiments.py` harness) |
+| User feedback → Langfuse (LibreChat thumbs + real-estate portal) | **Live** |
+| GitHub repository-dispatch CI/CD for prompt deploys | **Documented** — needs a real repo, PAT, public webhook (`real-estate-demo/cicd/`) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ ANTHROPIC_API_KEY=sk-... ./setup.sh     # Non-interactive (CI / coding agents)
 ./scripts/validate-langfuse.sh          # Validate Langfuse integration
 ./scripts/seed-code-evaluators.sh       # Provision code evaluators (deterministic TS evals; see docs/CODE_EVALUATORS.md)
 ./scripts/seed-llm-judge-evaluators.sh  # Provision observation-level LLM-as-a-Judge evaluators (upgrades legacy ones)
+python scripts/seed-app-prompts.py      # Prompt management (Deploy node): seed text-to-sql + vector-rag prompts to Langfuse
 ./scripts/seed-librechat-agents.sh      # Create LibreChat agents with MCP tools
 ./scripts/langfuse-cli.sh traces list   # Langfuse CLI (requires Node.js 18+)
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 | You want to… | Start here |
 |--------------|------------|
+| **Understand the AI Engineering loop** it demonstrates | [AI_ENGINEERING_LOOP.md](AI_ENGINEERING_LOOP.md) — trace → monitor → dataset → experiment → evaluate → **deploy** → repeat, mapped to every demo |
 | **Deploy it** (~5 min, one secret) | `ANTHROPIC_API_KEY=sk-ant-... ./setup.sh --seed` — or the [Quickstart Guide](docs/QUICKSTART_GUIDE.md) |
 | **Present it** to a customer or team | [SA Field Guide](docs/SA_FIELD_GUIDE.md) — demo selection, talk tracks, objection handling |
 | **Learn from it** | [User Journey](docs/USER_JOURNEY.md) (hands-on, ~35 min) and the [Use Case Catalog](docs/USE_CASES.md) |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -102,8 +102,11 @@ services:
   # LibreChat thumbs feedback -> Langfuse user-feedback score (Monitor node of the
   # AI Engineering loop). nginx mirrors the feedback route here fire-and-forget
   # (see librechat/nginx.conf); this maps conversationId+messageId back to the
-  # Langfuse trace and writes the score. Only useful with Langfuse, so it rides
-  # the `langfuse` profile.
+  # Langfuse trace and writes the score. It's a pure HTTP consumer of the Langfuse
+  # API (like `api`), NOT part of the self-hosted Langfuse infra — so it's a CORE
+  # service (no profile), which is what makes it start in BOTH self-hosted and
+  # `DEPLOY_MODE=cloud` (setup.sh runs cloud without `--profile langfuse`). It
+  # fails safe if Langfuse is unreachable, same as the nginx mirror.
   feedback-bridge:
     build:
       context: ./librechat/feedback-bridge
@@ -113,8 +116,6 @@ services:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
       - LANGFUSE_HOST=${LANGFUSE_INTERNAL_URL:-http://langfuse-web:3000}
-    profiles:
-      - langfuse
 
   # MongoDB database
   mongodb:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -99,6 +99,23 @@ services:
     volumes:
       - ./librechat/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 
+  # LibreChat thumbs feedback -> Langfuse user-feedback score (Monitor node of the
+  # AI Engineering loop). nginx mirrors the feedback route here fire-and-forget
+  # (see librechat/nginx.conf); this maps conversationId+messageId back to the
+  # Langfuse trace and writes the score. Only useful with Langfuse, so it rides
+  # the `langfuse` profile.
+  feedback-bridge:
+    build:
+      context: ./librechat/feedback-bridge
+    container_name: librechat-feedback-bridge
+    restart: always
+    environment:
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
+      - LANGFUSE_HOST=${LANGFUSE_INTERNAL_URL:-http://langfuse-web:3000}
+    profiles:
+      - langfuse
+
   # MongoDB database
   mongodb:
     image: mongo:8

--- a/librechat/feedback-bridge/Dockerfile
+++ b/librechat/feedback-bridge/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/librechat/feedback-bridge/main.py
+++ b/librechat/feedback-bridge/main.py
@@ -82,6 +82,20 @@ async def _handle(conversation_id: str, message_id: str, rating: str):
             print(f"[feedback-bridge] score write failed: {e}")
 
 
+async def _clear(message_id: str):
+    """User retracted their rating (LibreChat sends {"feedback": null}) → delete
+    the previously-written score by its deterministic id, so a cleared rating
+    doesn't leave a stale user-feedback score on the trace. Best-effort: a 404
+    (nothing was scored) is fine."""
+    async with httpx.AsyncClient(timeout=20) as client:
+        score_id = f"lc-fb-{message_id}"
+        try:
+            r = await client.delete(f"{LANGFUSE_HOST}/api/public/scores/{score_id}", headers=HEADERS)
+            print(f"[feedback-bridge] cleared score id={score_id} status={r.status_code}")
+        except Exception as e:
+            print(f"[feedback-bridge] clear failed: {e}")
+
+
 @app.api_route("/mirror/api/messages/{conversation_id}/{message_id}/feedback",
                methods=["PUT", "POST", "DELETE"], status_code=202)
 async def mirror(conversation_id: str, message_id: str, request: Request, bg: BackgroundTasks):
@@ -89,13 +103,20 @@ async def mirror(conversation_id: str, message_id: str, request: Request, bg: Ba
         payload = await request.json()
     except Exception:
         payload = {}
-    fb = (payload or {}).get("feedback")
-    rating = fb.get("rating") if isinstance(fb, dict) else None  # None when cleared
-    # Return immediately; do the retrying lookup + score off the request path so the
-    # user's feedback click is never coupled to Langfuse latency.
+    fb = payload.get("feedback") if isinstance(payload, dict) else None
+    rating = fb.get("rating") if isinstance(fb, dict) else None
+    cleared = isinstance(payload, dict) and "feedback" in payload and fb is None
+    # Return immediately; do the retrying lookup + score/delete off the request path
+    # so the user's feedback click is never coupled to Langfuse latency.
     if rating in RATING_TO_VALUE:
         bg.add_task(_handle, conversation_id, message_id, rating)
-    return {"accepted": rating in RATING_TO_VALUE, "rating": rating}
+        accepted = True
+    elif cleared:
+        bg.add_task(_clear, message_id)   # retract → delete the prior score
+        accepted = True
+    else:
+        accepted = False
+    return {"accepted": accepted, "rating": rating, "cleared": cleared}
 
 
 @app.get("/health")

--- a/librechat/feedback-bridge/main.py
+++ b/librechat/feedback-bridge/main.py
@@ -1,0 +1,103 @@
+"""
+LibreChat → Langfuse feedback bridge — the **Monitor** node's "feedback" signal.
+
+LibreChat has native thumbs feedback on each answer:
+    PUT /api/messages/:conversationId/:messageId/feedback
+    body: {"feedback": {"rating": "thumbsUp" | "thumbsDown", ...}}  (or {"feedback": null})
+
+nginx mirrors that route to this sidecar **fire-and-forget** (a down/slow bridge
+never affects the user's click — see librechat/nginx.conf). We map the LibreChat
+conversation+message back to its Langfuse trace and write a `user-feedback` score,
+so real user judgement lands next to the automated code/LLM-judge scores.
+
+Mapping (verified against live traces):
+    Langfuse trace.sessionId          == LibreChat conversationId
+    Langfuse trace.metadata.messageId == LibreChat responseMessageId (the rated msg)
+The Langfuse trace_id itself is a random OTEL id, so we resolve it by lookup.
+The traces API reads from ClickHouse (which lags async OTEL ingestion), so the
+lookup retries with backoff; the score write is idempotent (deterministic id), so
+toggling the thumb updates the score instead of appending duplicates.
+"""
+
+import asyncio
+import base64
+import os
+
+import httpx
+from fastapi import BackgroundTasks, FastAPI, Request
+
+LANGFUSE_HOST = os.environ.get("LANGFUSE_HOST", "http://langfuse-web:3000").rstrip("/")
+PK = os.environ.get("LANGFUSE_PUBLIC_KEY", "")
+SK = os.environ.get("LANGFUSE_SECRET_KEY", "")
+_AUTH = base64.b64encode(f"{PK}:{SK}".encode()).decode()
+HEADERS = {"Authorization": f"Basic {_AUTH}", "Content-Type": "application/json"}
+
+# thumbsUp -> 1, thumbsDown -> 0 (NUMERIC so Langfuse charts a satisfaction rate).
+RATING_TO_VALUE = {"thumbsUp": 1, "thumbsDown": 0}
+# Backoff for the trace lookup — covers ClickHouse ingestion lag (~up to 45s).
+_RETRY_DELAYS = [0, 2, 3, 5, 8, 12, 15]
+
+app = FastAPI(title="LibreChat Feedback Bridge")
+
+
+async def _resolve_trace_id(client: httpx.AsyncClient, conversation_id: str, message_id: str):
+    for delay in _RETRY_DELAYS:
+        if delay:
+            await asyncio.sleep(delay)
+        try:
+            r = await client.get(f"{LANGFUSE_HOST}/api/public/traces",
+                                 params={"sessionId": conversation_id, "limit": 50}, headers=HEADERS)
+        except Exception as e:  # transient network error → retry
+            print(f"[feedback-bridge] traces lookup error: {e}")
+            continue
+        if r.status_code == 200:
+            for t in r.json().get("data", []):
+                md = t.get("metadata") or {}
+                if md.get("messageId") == message_id:
+                    return t["id"]
+    return None
+
+
+async def _handle(conversation_id: str, message_id: str, rating: str):
+    value = RATING_TO_VALUE.get(rating)
+    if value is None:
+        return
+    async with httpx.AsyncClient(timeout=20) as client:
+        trace_id = await _resolve_trace_id(client, conversation_id, message_id)
+        if not trace_id:
+            print(f"[feedback-bridge] no trace for conv={conversation_id} msg={message_id}; dropped")
+            return
+        body = {
+            "id": f"lc-fb-{message_id}",  # deterministic → re-rating updates, no dup
+            "traceId": trace_id,
+            "name": "user-feedback",
+            "value": value,
+            "dataType": "NUMERIC",
+            "comment": f"LibreChat {rating}",
+        }
+        try:
+            r = await client.post(f"{LANGFUSE_HOST}/api/public/scores", json=body, headers=HEADERS)
+            print(f"[feedback-bridge] scored trace={trace_id} value={value} status={r.status_code}")
+        except Exception as e:
+            print(f"[feedback-bridge] score write failed: {e}")
+
+
+@app.api_route("/mirror/api/messages/{conversation_id}/{message_id}/feedback",
+               methods=["PUT", "POST", "DELETE"], status_code=202)
+async def mirror(conversation_id: str, message_id: str, request: Request, bg: BackgroundTasks):
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = {}
+    fb = (payload or {}).get("feedback")
+    rating = fb.get("rating") if isinstance(fb, dict) else None  # None when cleared
+    # Return immediately; do the retrying lookup + score off the request path so the
+    # user's feedback click is never coupled to Langfuse latency.
+    if rating in RATING_TO_VALUE:
+        bg.add_task(_handle, conversation_id, message_id, rating)
+    return {"accepted": rating in RATING_TO_VALUE, "rating": rating}
+
+
+@app.get("/health")
+def health():
+    return {"ok": True, "langfuse_host": LANGFUSE_HOST, "configured": bool(PK and SK)}

--- a/librechat/feedback-bridge/requirements.txt
+++ b/librechat/feedback-bridge/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110
+uvicorn[standard]>=0.29
+httpx>=0.27

--- a/librechat/nginx.conf
+++ b/librechat/nginx.conf
@@ -6,6 +6,33 @@ server {
     server_name localhost;
     client_max_body_size 25M;
 
+    # LibreChat thumbs feedback (PUT /api/messages/:conv/:msg/feedback): proxy to
+    # the API as normal AND mirror it fire-and-forget to the Langfuse feedback
+    # bridge (writes a user-feedback score on the trace -- the loop's Monitor
+    # signal). The mirror is best-effort: a down/slow bridge never affects the
+    # user, and the resolver+variable below let nginx start even when the
+    # feedback-bridge container is absent (e.g. Langfuse profile off).
+    location ~ ^/api/messages/[^/]+/[^/]+/feedback$ {
+        mirror /_langfuse_feedback;
+        proxy_pass http://api:3080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /_langfuse_feedback {
+        internal;
+        resolver 127.0.0.11 valid=10s;
+        set $fb_upstream feedback-bridge;
+        proxy_pass http://$fb_upstream:8000/mirror$request_uri;
+        proxy_set_header Host $host;
+    }
+
     location /api/ {
         proxy_pass http://api:3080;
         proxy_http_version 1.1;

--- a/scripts/seed-app-prompts.py
+++ b/scripts/seed-app-prompts.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Seed Langfuse-managed prompts for the text-to-sql and vector-rag demos.
+
+This is the **Deploy** node of the AI Engineering loop for the main stack: the
+apps fetch these prompts by label at runtime (with a local fallback), so editing
+a prompt in the Langfuse UI — or promoting a new version to `production` — changes
+behaviour with no code change or redeploy, and every generation links the prompt
+version that produced it.
+
+(The agentic-rag demo has its own prompt via scripts/seed-langfuse-prompt.py;
+this script covers the two LangChain apps that previously hard-coded prompts.)
+
+Idempotent: for each (name, label) a new version is created ONLY if the prompt is
+missing or its text differs from what's checked in here — re-running is a no-op.
+
+Usage (from repo root, after sourcing .env):
+    LANGFUSE_HOST=http://localhost:3001 \
+    LANGFUSE_PUBLIC_KEY=pk-lf-... LANGFUSE_SECRET_KEY=sk-lf-... \
+    python scripts/seed-app-prompts.py
+"""
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+HOST = os.getenv("LANGFUSE_HOST", "http://localhost:3001").rstrip("/")
+PK = os.getenv("LANGFUSE_PUBLIC_KEY", "")
+SK = os.getenv("LANGFUSE_SECRET_KEY", "")
+CONFIG = {"model": os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6"), "temperature": 0.7}
+
+_auth = base64.b64encode(f"{PK}:{SK}".encode()).decode()
+_HEADERS = {"Authorization": f"Basic {_auth}", "Content-Type": "application/json"}
+
+# ---------------------------------------------------------------------------
+# Prompt texts — Langfuse {{var}} syntax. These MIRROR the local fallback
+# templates in each app (LangChain {var} syntax): text-to-sql/sql_pipeline.py
+# and vector-rag/rag_pipeline.py. Keep them in sync by hand — when managed and
+# fallback match, enabling prompt management changes nothing until you edit the
+# prompt in Langfuse. get_langchain_prompt() converts {{var}} -> {var} at fetch.
+# ---------------------------------------------------------------------------
+
+_CLICKHOUSE_DATABASES = """Available databases include:
+- amazon: Amazon product data
+- bluesky: Bluesky social network data
+- covid: COVID-19 data
+- dns: DNS query data
+- environmental: Environmental data
+- forex: Foreign exchange data
+- geo: Geographic data
+- git: Git repository data
+- github: GitHub events and activities
+- hackernews: Hacker News posts and comments
+- imdb: Internet Movie Database
+- logs: Log data
+- mta: Metropolitan Transportation Authority data
+- noaa: National Oceanic and Atmospheric Administration data
+- nyc_taxi: New York City taxi trip data
+- nypd: New York Police Department data
+- ontime: Airline on-time performance data
+- pypi: Python Package Index data
+- stackoverflow: Stack Overflow posts and data
+- stock: Stock market data
+- twitter: Twitter data
+- uk: UK property and related data
+- wiki: Wikipedia data
+- youtube: YouTube video data"""
+
+TEXT_TO_SQL_ANALYSIS = (
+    "You are a data analyst with access to ClickHouse at sql.clickhouse.com.\n\n"
+    f"{_CLICKHOUSE_DATABASES}\n\n"
+    "Question: {{question}}\n\n"
+    "Identify which database(s) and data would help answer this question."
+)
+
+TEXT_TO_SQL_RESPONSE = (
+    "Based on the analysis and context, answer the question.\n\n"
+    "Question: {{question}}\n"
+    "Analysis: {{analysis}}\n"
+    "Context: {{context}}\n\n"
+    "Provide a clear, data-driven response."
+)
+
+VECTOR_RAG_GENERATION = (
+    "Answer the question based on the provided context.\n\n"
+    "Context:\n{{context}}\n\n"
+    "Question: {{question}}\n\n"
+    "Instructions:\n"
+    "- Use only information from the context to answer\n"
+    "- If the context doesn't contain relevant information, say so\n"
+    "- Be concise and accurate\n\n"
+    "Answer:"
+)
+
+PROMPTS = [
+    ("text-to-sql-analysis", TEXT_TO_SQL_ANALYSIS, "Query-analysis prompt (baseline)"),
+    ("text-to-sql-response", TEXT_TO_SQL_RESPONSE, "Response-generation prompt (baseline)"),
+    ("vector-rag-generation", VECTOR_RAG_GENERATION, "RAG generation prompt (baseline)"),
+]
+LABEL = "production"
+
+
+def _get(name: str, label: str):
+    url = f"{HOST}/api/public/v2/prompts/{urllib.parse.quote(name)}?label={label}"
+    req = urllib.request.Request(url, headers=_HEADERS, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+def _create(name: str, text: str, label: str, message: str) -> dict:
+    body = {"name": name, "type": "text", "prompt": text, "labels": [label],
+            "config": CONFIG, "commitMessage": message}
+    req = urllib.request.Request(f"{HOST}/api/public/v2/prompts",
+                                 data=json.dumps(body).encode(), headers=_HEADERS, method="POST")
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.load(r)
+
+
+def main():
+    if not PK or not SK:
+        raise SystemExit("LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set (source .env first).")
+    print(f"Seeding app prompts at {HOST} ...")
+    for name, text, message in PROMPTS:
+        existing = _get(name, LABEL)
+        if existing is not None and (existing.get("prompt") or "").strip() == text.strip():
+            print(f"  ✓ {name} [{LABEL}] already up to date (v{existing.get('version')})")
+            continue
+        created = _create(name, text, LABEL, message)
+        verb = "updated" if existing is not None else "created"
+        print(f"  + {name} [{LABEL}] {verb} (v{created.get('version')})")
+    print(f"\nDone. View: {HOST} → Prompts. The apps fetch these by label=production at runtime.")
+
+
+if __name__ == "__main__":
+    main()

--- a/text-to-sql/langfuse_config.py
+++ b/text-to-sql/langfuse_config.py
@@ -46,6 +46,25 @@ def get_langfuse_client():
         return None
 
 
+def get_managed_prompt(name: str, label: str = "production"):
+    """Fetch a Langfuse-managed prompt (the Deploy node of the AI Engineering loop).
+
+    Returns the Langfuse prompt object (has ``.get_langchain_prompt()`` and links
+    to traces) or ``None`` if Langfuse is unavailable / the prompt isn't seeded —
+    callers fall back to a local template so the app always runs. Editing this
+    prompt in the Langfuse UI (or promoting a new version to ``production``)
+    changes behaviour on the next run with no code change.
+    """
+    client = get_langfuse_client()
+    if client is None:
+        return None
+    try:
+        return client.get_prompt(name, label=label)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse get_prompt('{name}') unavailable, using local fallback: {e}")
+        return None
+
+
 def set_session_id(session_id: str):
     """Set the current session ID for subsequent traces."""
     global _current_session_id

--- a/text-to-sql/sql_pipeline.py
+++ b/text-to-sql/sql_pipeline.py
@@ -6,7 +6,27 @@ from dataclasses import dataclass
 from langchain_anthropic import ChatAnthropic
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
-from langfuse_config import langfuse_span
+from langfuse_config import langfuse_span, get_managed_prompt
+
+
+def _managed_or_fallback(name: str, fallback_template: str) -> ChatPromptTemplate:
+    """Build a ChatPromptTemplate from a Langfuse-managed prompt (Deploy node),
+    linking the prompt version to the generation, or fall back to the local
+    template so the app runs even if Langfuse/the prompt is unavailable.
+
+    Note: get_langchain_prompt() converts Langfuse {{var}} -> LangChain {var},
+    so the chain's .invoke(...) variable names are unchanged. Setting .metadata
+    AFTER construction is what makes the prompt link attach (passing metadata= to
+    from_template does not propagate through the LangChain CallbackHandler)."""
+    lf_prompt = get_managed_prompt(name)
+    if lf_prompt is not None:
+        try:
+            tmpl = ChatPromptTemplate.from_template(lf_prompt.get_langchain_prompt())
+            tmpl.metadata = {"langfuse_prompt": lf_prompt}
+            return tmpl
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"Managed prompt '{name}' unusable ({e}); using local fallback.")
+    return ChatPromptTemplate.from_template(fallback_template)
 
 
 @dataclass
@@ -66,7 +86,10 @@ class ClickHouseSQLPipeline:
         )
 
     def _setup_chains(self):
-        self.analysis_prompt = ChatPromptTemplate.from_template(
+        # Prompts are Langfuse-managed (fetched by label=production at startup)
+        # with the inline templates below as local fallbacks — the Deploy node.
+        self.analysis_prompt = _managed_or_fallback(
+            "text-to-sql-analysis",
             f"You are a data analyst with access to ClickHouse at sql.clickhouse.com.\n\n"
             f"{CLICKHOUSE_DATABASES}\n\n"
             "Question: {question}\n\n"
@@ -77,7 +100,8 @@ class ClickHouseSQLPipeline:
             self.analysis_prompt | self.llm | StrOutputParser()
         ).with_config({"metadata": {"purpose": "query_analysis"}})
 
-        self.response_prompt = ChatPromptTemplate.from_template(
+        self.response_prompt = _managed_or_fallback(
+            "text-to-sql-response",
             "Based on the analysis and context, answer the question.\n\n"
             "Question: {question}\n"
             "Analysis: {analysis}\n"

--- a/vector-rag/langfuse_config.py
+++ b/vector-rag/langfuse_config.py
@@ -46,6 +46,25 @@ def get_langfuse_client():
         return None
 
 
+def get_managed_prompt(name: str, label: str = "production"):
+    """Fetch a Langfuse-managed prompt (the Deploy node of the AI Engineering loop).
+
+    Returns the Langfuse prompt object (has ``.get_langchain_prompt()`` and links
+    to traces) or ``None`` if Langfuse is unavailable / the prompt isn't seeded —
+    callers fall back to a local template so the app always runs. Editing this
+    prompt in the Langfuse UI (or promoting a new version to ``production``)
+    changes behaviour on the next run with no code change.
+    """
+    client = get_langfuse_client()
+    if client is None:
+        return None
+    try:
+        return client.get_prompt(name, label=label)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse get_prompt('{name}') unavailable, using local fallback: {e}")
+        return None
+
+
 def set_session_id(session_id: str):
     """Set the current session ID for subsequent traces."""
     global _current_session_id

--- a/vector-rag/rag_pipeline.py
+++ b/vector-rag/rag_pipeline.py
@@ -12,6 +12,26 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from documents import get_documents, get_document_metadata
+from langfuse_config import get_managed_prompt
+
+
+def _managed_or_fallback(name: str, fallback_template: str) -> ChatPromptTemplate:
+    """Build a ChatPromptTemplate from a Langfuse-managed prompt (Deploy node),
+    linking the prompt version to the generation, or fall back to the local
+    template so the app runs even if Langfuse/the prompt is unavailable.
+
+    get_langchain_prompt() converts Langfuse {{var}} -> LangChain {var}, so the
+    chain's .invoke(...) variable names are unchanged. Setting .metadata AFTER
+    construction is what makes the prompt link attach through the CallbackHandler."""
+    lf_prompt = get_managed_prompt(name)
+    if lf_prompt is not None:
+        try:
+            tmpl = ChatPromptTemplate.from_template(lf_prompt.get_langchain_prompt())
+            tmpl.metadata = {"langfuse_prompt": lf_prompt}
+            return tmpl
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"Managed prompt '{name}' unusable ({e}); using local fallback.")
+    return ChatPromptTemplate.from_template(fallback_template)
 
 
 @dataclass
@@ -91,7 +111,10 @@ class VectorRAGPipeline:
 
     def _setup_chains(self):
         """Setup generation chain."""
-        self.response_prompt = ChatPromptTemplate.from_template(
+        # Langfuse-managed prompt (fetched by label=production at startup) with
+        # the inline template below as the local fallback — the Deploy node.
+        self.response_prompt = _managed_or_fallback(
+            "vector-rag-generation",
             """Answer the question based on the provided context.
 
 Context:


### PR DESCRIPTION
## What & why

The main demo stack (`text-to-sql`, `vector-rag`, `agentic-rag`, LibreChat) already covered most of the [AI Engineering loop](https://langfuse.com/academy/ai-engineering-loop) — but it wasn't narrated as the loop, and two steps were uneven. This brings it to parity with `real-estate-demo` (PR #26) and maps the **whole repo** to the loop.

## Deploy node — prompt management for the LangChain apps (verified)
`text-to-sql` and `vector-rag` no longer hard-code prompts. They fetch by label (`production`) from Langfuse at runtime, with the previous inline templates as **hard fallbacks**, and **link the prompt version to the generation**. (`agentic-rag` already did this.)
- New `scripts/seed-app-prompts.py` — idempotent seeder for the 3 app prompts.
- **Verified in-container:** both apps fetch managed prompts, the link attaches server-side (`promptName`/`promptVersion` on the generation), and they fall back cleanly when Langfuse/the prompt is unavailable.
- **Linking gotcha (documented in code):** `metadata={"langfuse_prompt": p}` must be set on the template **after** construction — passing it to `from_template()` does not propagate through the LangChain `CallbackHandler`.

## Monitor node — user feedback from LibreChat (verified end-to-end)
LibreChat's native 👍/👎 (`PUT /api/messages/:conv/:msg/feedback`) now becomes a Langfuse `user-feedback` score:
- `librechat/feedback-bridge/` — a FastAPI sidecar that maps the LibreChat conversation+message back to its trace (`sessionId==conversationId`, `metadata.messageId==messageId`) and writes the score. Bounded retry for ClickHouse ingestion lag; 202 + background task; **idempotent** (deterministic score id — re-rating updates in place, verified); handles cleared ratings.
- `librechat/nginx.conf` mirrors the route **fire-and-forget** (resolver + variable so nginx starts even when the bridge is absent).
- `docker-compose.yaml` — `feedback-bridge` under the `langfuse` profile.
- **Verified:** score lands via direct call **and** the nginx mirror; and with the bridge **stopped**, the LibreChat frontend/api/feedback route are all unaffected (mirror fails silently) — turning off the langfuse profile can't break LibreChat.

## Loop narration
- New top-level `AI_ENGINEERING_LOOP.md` maps every demo to the 5 steps + Deploy, with an honest live-vs-documented table. Pointers from root `README.md` and `CLAUDE.md`.

## ⚠️ Notes for the reviewer
- **Independent of PR #26** (real-estate). The `README.md` edit is in a **different region** than #26's to avoid a merge conflict. A couple of links in `AI_ENGINEERING_LOOP.md` point at `real-estate-demo/cicd/` and its loop doc, which **land when #26 merges** — best merged after #26.
- **"Deploy: Live" for the main stack needs one manual step:** `scripts/seed-app-prompts.py` is **not** wired into `setup.sh` (matching the existing `agentic-rag` prompt-seed precedent). On a fresh `./setup.sh`, text-to-sql/vector-rag run on the **fallback** template (fails safe) until you run the seeder — that's when the prompts appear in the UI and management goes "live."
- **Key-shadowing footgun:** verification assumes the documented operating procedure (shell `LANGFUSE_*` unset, `.env` used). Under the known shell-key-shadow footgun the whole demo 401s and prompt-mgmt degrades to fallback — pre-existing, fails safe.

## Verification summary
prompt link (both apps, server-side) ✓ · fallback path ✓ · brace-safety (`{{var}}`→`{var}` clean) ✓ · feedback via sidecar + nginx mirror ✓ · idempotent re-rating ✓ · nginx robust with bridge down ✓ · `nginx -t` + `py_compile` + `docker compose config` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)