### PR TITLE
Add independent managed LLM judges for agentic-rag (self vs independent grading)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ ANTHROPIC_API_KEY=sk-... ./setup.sh     # Non-interactive (CI / coding agents)
 ./scripts/validate-langfuse.sh          # Validate Langfuse integration
 ./scripts/seed-code-evaluators.sh       # Provision code evaluators (deterministic TS evals; see docs/CODE_EVALUATORS.md)
 ./scripts/seed-llm-judge-evaluators.sh  # Provision observation-level LLM-as-a-Judge evaluators (upgrades legacy ones)
+./scripts/seed-agentic-rag-evaluators.sh # Independent managed judges for agentic-rag (faithfulness/context-relevance/answer-relevance) — complements the in-graph self-grades
 python scripts/seed-app-prompts.py      # Prompt management (Deploy node): seed text-to-sql + vector-rag prompts to Langfuse
 ./scripts/seed-librechat-agents.sh      # Create LibreChat agents with MCP tools
 ./scripts/langfuse-cli.sh traces list   # Langfuse CLI (requires Node.js 18+)

--- a/demos/agentic-rag/graph.py
+++ b/demos/agentic-rag/graph.py
@@ -202,7 +202,13 @@ class AgenticRAG:
             else:
                 answer = _ask(f"Answer concisely.\n\nQuestion: {state['question']}\n\nAnswer:")
             if obs:
-                obs.update(output=answer)
+                # Expose question + retrieved context on the generation so a
+                # Langfuse-managed judge (Faithfulness / Relevance, seeded by
+                # scripts/seed-agentic-rag-evaluators.sh) can score it
+                # observation-level — an INDEPENDENT check alongside the agent's
+                # in-graph self-grade (reflect groundedness).
+                obs.update(input={"question": state["question"], "context": context},
+                           output=answer)
         log = state.get("trace", []) + ["generate → drafted answer"]
         return {"answer": answer, "trace": log}
 

--- a/docs/AGENTIC_RAG_DEMO_RUNBOOK.md
+++ b/docs/AGENTIC_RAG_DEMO_RUNBOOK.md
@@ -137,6 +137,20 @@ print('ANSWER :', r['answer'][:400])
 **Say:**
 > "Two kinds of evaluator scores here. `retrieval_relevance` is logged on *each* grade step — so on this self-correcting run you can see attempt 1 scored **0** (not relevant), the agent rewrote and retried, and attempt 2 scored **1**. `groundedness` is the trace-level outcome score for the final answer. Both are real Langfuse Scores, so I can chart retrieval quality and groundedness over time, filter traces by them, and compare naive vs agentic RAG."
 
+**Self-grade vs independent judge (optional, higher-value).** The scores above are
+the agent grading *itself* in-graph. Run `./scripts/seed-agentic-rag-evaluators.sh`
+once and Langfuse *independently* scores the same answers server-side (async, in the
+worker): `faithfulness` (↔ the agent's `groundedness`), `context-relevance` (↔
+`retrieval_relevance`), and `answer-relevance`. On the `generate` observation you'll
+see them side by side.
+
+> "The agent checks its own work — but who checks the checker? These `faithfulness`
+> and `context-relevance` scores are computed independently by Langfuse, not the
+> agent. When they *agree* you trust the self-grade; when they *diverge* — e.g. the
+> agent grades its retrieval relevant but the independent judge says 0.4 — that's a
+> calibration signal telling you the agent's self-assessment is drifting. In-graph
+> evals *drive* the loop synchronously; managed evals *monitor* it independently."
+
 **Action:** Left sidebar → **Sessions** → open the agent's session.
 
 **Say:**

--- a/scripts/seed-agentic-rag-evaluators.sh
+++ b/scripts/seed-agentic-rag-evaluators.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Provision INDEPENDENT observation-level LLM-as-a-Judge evaluators for the
+# agentic-rag demo — a Langfuse-side check that complements the agent's own
+# IN-GRAPH self-grades (reflect `groundedness` + grade `retrieval_relevance`).
+#
+# Seeds three judges over the agentic-rag GENERATION "generate" observation
+# (which exposes {question, context} on its input — see demos/agentic-rag/graph.py):
+#   faithfulness      (Faithfulness,      {context,answer})     ↔ pairs with in-graph `groundedness`
+#   context-relevance (Contextrelevance,  {query,context})      ↔ pairs with in-graph `retrieval_relevance`
+#   answer-relevance  (Relevance,         {query,generation})   additive answer-quality signal
+#
+# Mechanism mirrors scripts/seed-llm-judge-evaluators.sh: Postgres upsert into
+# job_configurations (schema-coupled to the langfuse:3 image). time_scope=NEW so
+# only NEW traces are scored — regenerate agentic-rag traffic to see them.
+# Idempotent. Self-hosted only (prints UI guidance in cloud mode).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; cd "$SCRIPT_DIR/.."
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+ok(){ echo -e "  ${GREEN}✓${NC} $1"; }; warn(){ echo -e "  ${YELLOW}⚠${NC} $1"; }; fail(){ echo -e "  ${RED}✗${NC} $1"; exit 1; }
+[ -f .env ] && set -a && source .env && set +a
+
+PG="${LANGFUSE_POSTGRES_CONTAINER:-langfuse-postgres}"
+REDIS="${LANGFUSE_REDIS_CONTAINER:-langfuse-redis}"
+EVAL_MODEL="${LANGFUSE_EVAL_MODEL:-claude-haiku-4-5-20251001}"
+
+echo ""
+echo "Provisioning independent LLM-as-a-Judge evaluators for agentic-rag..."
+
+if [ "${DEPLOY_MODE:-self-hosted}" = "cloud" ]; then
+  warn "DEPLOY_MODE=cloud — create these observation-level judges in the Langfuse UI:"
+  echo "     Evaluators > New evaluator > target Observations, filter"
+  echo "       type=GENERATION, name any-of [generate], tags any-of [agentic-rag]:"
+  echo "       - Faithfulness      (context<-input.context, answer<-output)      score 'faithfulness'"
+  echo "       - Contextrelevance  (query<-input.question, context<-input.context) score 'context-relevance'"
+  echo "       - Relevance         (query<-input.question, generation<-output)   score 'answer-relevance'"
+  exit 0
+fi
+
+docker ps --format '{{.Names}}' | grep -q "^${PG}$" || fail "Postgres ${PG} not running (run ./setup.sh first)"
+pg(){ docker exec -i "$PG" sh -c 'psql -v ON_ERROR_STOP=1 -q -t -A -U "$POSTGRES_USER" -d "$POSTGRES_DB"'; }
+
+PID=$(echo "SELECT project_id FROM api_keys WHERE public_key='${LANGFUSE_PUBLIC_KEY:-pk-lf-1234567890}' LIMIT 1;" | pg)
+PID="${PID:-demo-project}"; ok "Project: ${PID}"
+
+# ── Default eval model (reuse the Anthropic connection setup.sh provisions) ──
+if [ "$(echo "SELECT count(*) FROM default_llm_models WHERE project_id='${PID}';" | pg)" = "0" ]; then
+  LLM_KEY_ID=$(echo "SELECT id FROM llm_api_keys WHERE project_id='${PID}' AND adapter='anthropic' LIMIT 1;" | pg)
+  if [ -n "$LLM_KEY_ID" ]; then
+    echo "INSERT INTO default_llm_models (id, project_id, llm_api_key_id, provider, adapter, model, model_params, created_at, updated_at)
+          SELECT 'default-eval-model-${PID}','${PID}','${LLM_KEY_ID}',provider,adapter,'${EVAL_MODEL}','{}'::jsonb,now(),now()
+          FROM llm_api_keys WHERE id='${LLM_KEY_ID}' ON CONFLICT (project_id) DO NOTHING;" | pg >/dev/null
+    ok "Default eval model set (${EVAL_MODEL})"
+  else
+    warn "No Anthropic LLM connection — run ./setup.sh first; judges stay blocked until a default eval model exists"
+  fi
+else
+  ok "Default eval model already configured"
+fi
+
+# ── Template lookup by name + a required var (disambiguates the two RAGAS
+#    Faithfulness variants; unlike the main script we DON'T exclude partner
+#    templates, because Faithfulness/Contextrelevance ship as partner=ragas). ──
+tmpl(){ echo "SELECT id FROM eval_templates WHERE project_id IS NULL AND name='$1' AND '$2'=ANY(vars) ORDER BY version DESC LIMIT 1;" | pg; }
+
+# All three watch the agentic-rag answer generation only (type GENERATION +
+# name 'generate' + trace tag agentic-rag) — NOT the route/grade/rewrite/reflect
+# LLM calls, which are also GENERATIONs.
+FILTER='[{"type":"stringOptions","value":["GENERATION"],"column":"type","operator":"any of"},{"type":"stringOptions","value":["generate"],"column":"name","operator":"any of"},{"type":"arrayOptions","value":["agentic-rag"],"column":"tags","operator":"any of"}]'
+
+seed(){ # <config_id> <template_name> <required_var> <score_name> <mapping_json>
+  local cid="$1" tname="$2" rvar="$3" sname="$4" map="$5" tid
+  tid=$(tmpl "$tname" "$rvar")
+  if [ -z "$tid" ]; then warn "template '${tname}' ({${rvar}}) not found — skipped"; return; fi
+  echo "INSERT INTO job_configurations (id, project_id, job_type, eval_template_id, score_name, filter, target_object, variable_mapping, sampling, delay, status, time_scope, created_at, updated_at)
+        VALUES ('${cid}','${PID}','EVAL','${tid}','${sname}','${FILTER}'::jsonb,'event','${map}'::jsonb,1.0,0,'ACTIVE',ARRAY['NEW'],now(),now())
+        ON CONFLICT (id) DO UPDATE SET eval_template_id=EXCLUDED.eval_template_id, score_name=EXCLUDED.score_name, filter=EXCLUDED.filter, variable_mapping=EXCLUDED.variable_mapping, status='ACTIVE', blocked_at=NULL, block_reason=NULL, block_message=NULL, updated_at=now();" | pg >/dev/null
+  ok "${sname} → observation-level judge (${tname})"
+}
+
+seed "arag-faithfulness" "Faithfulness" "context" "faithfulness" \
+  '[{"templateVariable":"context","langfuseObject":"event","selectedColumnId":"input","jsonSelector":"context"},{"templateVariable":"answer","langfuseObject":"event","selectedColumnId":"output"}]'
+
+seed "arag-context-relevance" "Contextrelevance" "context" "context-relevance" \
+  '[{"templateVariable":"query","langfuseObject":"event","selectedColumnId":"input","jsonSelector":"question"},{"templateVariable":"context","langfuseObject":"event","selectedColumnId":"input","jsonSelector":"context"}]'
+
+seed "arag-answer-relevance" "Relevance" "query" "answer-relevance" \
+  '[{"templateVariable":"query","langfuseObject":"event","selectedColumnId":"input","jsonSelector":"question"},{"templateVariable":"generation","langfuseObject":"event","selectedColumnId":"output"}]'
+
+# Clear the worker's "no evaluators" cache so the new configs pick up traffic now.
+if docker ps --format '{{.Names}}' | grep -q "^${REDIS}$"; then
+  docker exec "$REDIS" redis-cli del \
+    "langfuse:eval:no-event-and-experiment-job-configs:${PID}" \
+    "langfuse:eval:no-trace-and-dataset-job-configs:${PID}" >/dev/null 2>&1 || true
+  ok "Cleared evaluator config cache"
+fi
+
+echo ""
+ok "Independent judges seeded (time_scope=NEW). Regenerate agentic-rag traffic, then compare:"
+echo "     self (in-graph)  vs  independent (managed)"
+echo "     groundedness      ↔  faithfulness"
+echo "     retrieval_relevance ↔ context-relevance"
+echo "  View: ${LANGFUSE_BASE_URL:-http://localhost:3001}/project/${PID}/evals"
+echo ""


### PR DESCRIPTION
## What

The agentic-rag agent grades itself in-graph (`reflect` → `groundedness`, `grade` → `retrieval_relevance`) to drive its self-correction loop. Those are the right place for control-flow evals (synchronous, in-graph), but the agent is judging *itself*. This adds an **independent, Langfuse-side** check that runs in the worker and complements them.

## Changes
- **`demos/agentic-rag/graph.py`**: the `generate` observation now exposes `{question, context}` on its input (previously unset) so an observation-level judge can map them.
- **`scripts/seed-agentic-rag-evaluators.sh`** (new): seeds three observation-level managed judges (Postgres upsert into `job_configurations` — same mechanism as `seed-llm-judge-evaluators.sh`), filtered to the agentic-rag `generate` GENERATION observation (`type` + `name=generate` + tag `agentic-rag`):
  - `faithfulness` (Faithfulness) ↔ pairs with in-graph `groundedness`
  - `context-relevance` (Contextrelevance) ↔ pairs with in-graph `retrieval_relevance`
  - `answer-relevance` (Relevance) — additive answer-quality signal
  - `time_scope=NEW`, idempotent, clears the worker eval cache.
- Docs: CLAUDE.md command + a runbook section on the self-vs-independent comparison.

## Verified end-to-end
- Judges seed **ACTIVE** (not blocked); targeting is **clean** — scores land only on `generate`, not the route/grade/rewrite/reflect LLM calls (which are also GENERATIONs).
- A regenerated batch shows self vs independent side by side, including real **divergences** that are the calibration story — e.g. agent grades its retrieval relevant while independent `context-relevance` = 0.4; agent's grader too harsh (`retrieval_relevance` [0,0]) while independent `context-relevance` = 0.85.

In-graph evals *drive* the loop; managed evals *monitor* it independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)