### PR TITLE
Fix review findings (compliance fail-open, key-isolation, CI gate, prompt A/B, judge scoping)

### DIFF
--- a/demos/agentic-rag/graph.py
+++ b/demos/agentic-rag/graph.py
@@ -177,7 +177,14 @@ class AgenticRAG:
 
     def generate_node(self, state: AgentState) -> AgentState:
         context = state.get("context", "")
-        with lf.observe("generate", as_type="generation") as obs:
+        # Name the generation by whether it has retrieved context. The independent
+        # managed judges (scripts/seed-agentic-rag-evaluators.sh) filter on
+        # name="generate", so direct-route answers (no context) are named
+        # "generate-direct" and correctly SKIPPED — mirroring reflect_node, which
+        # also skips grounding for context-less answers. Prevents faithfulness /
+        # context-relevance from scoring an answer against an empty context.
+        gen_name = "generate" if context else "generate-direct"
+        with lf.observe(gen_name, as_type="generation") as obs:
             if context:
                 # Prompt management: pull the generation prompt from Langfuse
                 # (versioned, label-routed). Link it to this generation so the

--- a/demos/brand-promo-multi-agent/scripts/run_experiment.py
+++ b/demos/brand-promo-multi-agent/scripts/run_experiment.py
@@ -398,7 +398,10 @@ def main() -> int:
         query = inp.get("query", str(inp)) if isinstance(inp, dict) else str(inp)
 
         if system_prompt_content:
-            os.environ["PROMO_SYSTEM_PROMPT_OVERRIDE"] = system_prompt_content[:500]
+            # Full content — strategy_crew.py reads this and appends it to the
+            # strategist's backstory. (Was truncated to 500 chars, which both
+            # lost most of the prompt and was never read by anything.)
+            os.environ["PROMO_SYSTEM_PROMPT_OVERRIDE"] = system_prompt_content
 
         item_id = getattr(item, "id", None)
         extra_metadata = {

--- a/demos/brand-promo-multi-agent/scripts/run_experiment.py
+++ b/demos/brand-promo-multi-agent/scripts/run_experiment.py
@@ -71,7 +71,7 @@ def parse_args():
     parser.add_argument("--ci", action="store_true",
                         help="CI mode: exit 1 if certification gate fails")
     parser.add_argument("--system-prompt-file", type=str, default=None,
-                        help="Path to a markdown file used as alternative system prompt (recorded in metadata)")
+                        help="Path to a markdown file appended to the strategist's system prompt for a prompt A/B run (e.g. prompts/strategy_v2.md)")
     parser.add_argument("--dry-run", action="store_true",
                         help="Preview dataset items without running the experiment")
     return parser.parse_args()

--- a/demos/brand-promo-multi-agent/scripts/seed_evaluators.py
+++ b/demos/brand-promo-multi-agent/scripts/seed_evaluators.py
@@ -94,53 +94,27 @@ def seed_evaluators() -> int:
         _emit_manual_checklist(cfg)
         return 0
 
-    try:
-        import httpx
-    except ImportError:
-        console.print("[red]httpx not installed[/red]")
-        return 1
-
-    host = env.langfuse_host or cfg.langfuse.host
-    judge_model = cfg.llm.models.judge
-
-    # Langfuse v3 evaluator API - attempt programmatic creation
-    success_count = 0
-    for ev in EVALUATORS:
-        prompt_text = PROMPTS.get(ev["prompt_key"], "")
-        payload = {
-            "name": ev["name"],
-            "type": "llm",
-            "enabled": True,
-            "samplingRate": 0.10,
-            "targetType": ev["target_type"],
-            "scoreName": ev["score_name"],
-            "model": judge_model,
-            "prompt": prompt_text,
-            "scoreRange": ev["score_range"],
-        }
-        try:
-            resp = httpx.post(
-                f"{host}/api/public/score-configs",
-                auth=(env.langfuse_public_key, env.langfuse_secret_key),
-                json=payload,
-                timeout=10,
-            )
-            if resp.status_code in (200, 201):
-                console.print(f"[green]Created evaluator: {ev['name']}[/green]")
-                success_count += 1
-            elif resp.status_code == 409:
-                console.print(f"[yellow]Evaluator already exists: {ev['name']}[/yellow]")
-                success_count += 1
-            else:
-                console.print(f"[yellow]API returned {resp.status_code} for {ev['name']} - may need manual setup[/yellow]")
-        except Exception as e:
-            console.print(f"[yellow]API call failed for {ev['name']}: {e}[/yellow]")
-
-    if success_count < len(EVALUATORS):
-        console.print("\n[yellow]Some evaluators need manual setup:[/yellow]")
-        _emit_manual_checklist(cfg)
-
-    console.print(f"\n[bold]Evaluator setup: {success_count}/{len(EVALUATORS)} via API[/bold]")
+    # This Langfuse version has no stable PUBLIC API for creating LLM-as-judge
+    # evaluators. A previous version of this script POSTed a judge-shaped payload
+    # (model/prompt/samplingRate/targetType) to /api/public/score-configs — the
+    # WRONG endpoint: it defines score *configs* (name/dataType/range), not
+    # judges. That silently created orphan score-configs (or 4xx'd) while printing
+    # "Created evaluator: ...", i.e. false success with no judge actually wired.
+    #
+    # Until a stable evaluators API exists, create these live judges once in the
+    # UI (checklist below). For a self-hosted stack you can instead seed
+    # job_configurations directly in Postgres — see scripts/seed-llm-judge-evaluators.sh
+    # and scripts/seed-agentic-rag-evaluators.sh for that pattern.
+    console.print(
+        "[yellow]Live LLM-as-judge evaluators aren't creatable via a stable public "
+        "API on this Langfuse version — configure them once in the UI:[/yellow]"
+    )
+    _emit_manual_checklist(cfg)
+    console.print(
+        "\n[dim]Self-hosted alternative: seed job_configurations in Postgres, per "
+        "scripts/seed-llm-judge-evaluators.sh. The offline experiment judges in "
+        "src/evals/evaluators.py already run via scripts/run_experiment.py.[/dim]"
+    )
     return 0
 
 

--- a/demos/brand-promo-multi-agent/scripts/seed_evaluators.py
+++ b/demos/brand-promo-multi-agent/scripts/seed_evaluators.py
@@ -14,7 +14,6 @@ from rich.console import Console
 from rich.panel import Panel
 
 from src.config import load_config, load_env
-from src.prompts.judge import PROMPTS
 
 console = Console()
 

--- a/demos/brand-promo-multi-agent/src/agents/compliance_agent.py
+++ b/demos/brand-promo-multi-agent/src/agents/compliance_agent.py
@@ -1,4 +1,4 @@
-"""LangGraph compliance mini-graph with parallel brand + regulatory checks."""
+"""LangGraph compliance mini-graph: sequential brand + regulatory checks."""
 
 from __future__ import annotations
 
@@ -22,13 +22,18 @@ class ComplianceState(TypedDict):
     brand_findings: list[ComplianceFinding]
     regulatory_findings: list[ComplianceFinding]
     all_findings: list[ComplianceFinding]
-    status: str  # APPROVED, CONDITIONAL, REJECTED
+    # Per-check errors (e.g. an injected TOOL_ERROR). Tracked so a failed check
+    # NEVER silently reports APPROVED — compliance fails CLOSED.
+    brand_error: str | None
+    regulatory_error: str | None
+    status: str  # APPROVED, CONDITIONAL, REJECTED, ERROR
     summary: str
 
 
 def _run_brand_check(state: ComplianceState) -> dict[str, Any]:
     result = check_brand_guidelines.invoke({"brief": state["brief"]})
     findings: list[ComplianceFinding] = []
+    error: str | None = None
     if result.get("status") == "ok":
         for f in result.get("findings", []):
             findings.append(
@@ -39,7 +44,11 @@ def _run_brand_check(state: ComplianceState) -> dict[str, Any]:
                     source="brand_guidelines",
                 )
             )
-    return {"brand_findings": findings}
+    else:
+        # Tool failed (e.g. injected TOOL_ERROR) — record it so aggregation can
+        # fail closed instead of treating "no findings" as "approved".
+        error = result.get("error") or result.get("status") or "brand check failed"
+    return {"brand_findings": findings, "brand_error": error}
 
 
 def _run_regulatory_check(state: ComplianceState) -> dict[str, Any]:
@@ -48,6 +57,7 @@ def _run_regulatory_check(state: ComplianceState) -> dict[str, Any]:
         "jurisdictions": state.get("jurisdictions"),
     })
     findings: list[ComplianceFinding] = []
+    error: str | None = None
     if result.get("status") == "ok":
         for f in result.get("findings", []):
             findings.append(
@@ -58,12 +68,27 @@ def _run_regulatory_check(state: ComplianceState) -> dict[str, Any]:
                     source="regulatory",
                 )
             )
-    return {"regulatory_findings": findings}
+    else:
+        error = result.get("error") or result.get("status") or "regulatory check failed"
+    return {"regulatory_findings": findings, "regulatory_error": error}
 
 
 def _aggregate(state: ComplianceState) -> dict[str, Any]:
     all_findings = state.get("brand_findings", []) + state.get("regulatory_findings", [])
     severities = {f["severity"] for f in all_findings}
+
+    # Fail CLOSED: if a check errored, we can't certify compliance — never let a
+    # tool failure fall through to APPROVED just because it produced no findings.
+    errors = [e for e in (state.get("brand_error"), state.get("regulatory_error")) if e]
+    if errors:
+        return {
+            "all_findings": all_findings,
+            "status": "ERROR",
+            "summary": (
+                "ERROR: compliance could not be fully verified (" + "; ".join(errors)
+                + "). Treating as NOT approved pending a re-run."
+            ),
+        }
 
     if "HIGH" in severities:
         status = "REJECTED"
@@ -127,6 +152,8 @@ def run_compliance_check(
         "brand_findings": [],
         "regulatory_findings": [],
         "all_findings": [],
+        "brand_error": None,
+        "regulatory_error": None,
         "status": "APPROVED",
         "summary": "",
     }

--- a/demos/brand-promo-multi-agent/src/agents/strategy_crew.py
+++ b/demos/brand-promo-multi-agent/src/agents/strategy_crew.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from crewai import LLM, Agent, Crew, Process, Task
@@ -29,12 +30,22 @@ def build_strategy_crew(
     """Build the strategy crew for a given research context."""
     llm = _get_llm(callbacks=callbacks)
 
+    # --system-prompt-file experiment hook: run_experiment.py sets this env var
+    # from the alternative prompt file. Appending it to the strategist's backstory
+    # is what makes the A/B run (e.g. prompts/strategy_v2.md's margin-protection
+    # constraints) actually change behavior — otherwise the flag only altered a
+    # metadata label and the "v2" run was identical to baseline.
+    strategist_backstory = PROMPTS["promo_strategist_backstory"]
+    prompt_override = os.getenv("PROMO_SYSTEM_PROMPT_OVERRIDE", "").strip()
+    if prompt_override:
+        strategist_backstory += "\n\nAdditional strategy constraints:\n" + prompt_override
+
     promo_strategist = Agent(
         role=PROMPTS["promo_strategist_role"],
         goal=PROMPTS["promo_strategist_goal"]
         .replace("{{brand}}", brand or "the brand")
         .replace("{{region}}", region or "all regions"),
-        backstory=PROMPTS["promo_strategist_backstory"],
+        backstory=strategist_backstory,
         tools=[],
         llm=llm,
         max_iter=5,

--- a/demos/brand-promo-multi-agent/src/config.py
+++ b/demos/brand-promo-multi-agent/src/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 from pydantic import BaseModel, field_validator, model_validator
 
 
@@ -171,11 +171,23 @@ def load_env() -> EnvConfig:
     in front of `uv run python ...`) wins over the dotenv file. Otherwise a
     stale BACKEND value in .env silently flips the backend out from under the
     operator.
+
+    Key-isolation exception: the Langfuse project keys must come from THIS demo's
+    .env, never an ambient shell export. With plain `override=False`, a stray
+    shell-exported `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` (a documented
+    footgun in this dev environment) would shadow the file and silently send this
+    demo's seeding/traffic into the wrong project. So we hard-set the Langfuse
+    keys from the .env file when it defines them (mirroring the guard in
+    demos/real-estate/agent/config.py, which calls this "the #1 landmine").
     """
     project_root = Path(__file__).parent.parent
     env_file = project_root / ".env"
     if env_file.exists():
         load_dotenv(env_file, override=False)
+        file_vals = dotenv_values(env_file)
+        for key in ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST"):
+            if file_vals.get(key):
+                os.environ[key] = file_vals[key]  # .env wins for project keys
     else:
         load_dotenv(override=False)
     backend_env = os.getenv("BACKEND")

--- a/demos/brand-promo-multi-agent/src/evals/evaluators.py
+++ b/demos/brand-promo-multi-agent/src/evals/evaluators.py
@@ -469,10 +469,17 @@ def promo_certification_gate(
 ):
     """Factory: multi-dimensional PASS/FAIL gate for PromoPlanner experiments.
 
-    PASS requires all three thresholds to be met:
+    Each threshold is enforced only when its score is PRESENT in the run, so a
+    fast `--evaluators deterministic` CI run gates on the deterministic
+    dimensions (intent, compliance) and `response_factuality` is enforced only
+    when the judges actually run (`--evaluators all|judge`). A dimension whose
+    evaluator didn't run is reported N/A and is not a failure — otherwise the
+    documented `--evaluators deterministic --ci` gate could never pass.
+
+    PASS requires every PRESENT dimension to meet its threshold:
     - avg intent_classification_accuracy >= intent_threshold (default 0.85)
     - avg compliance_status_match >= compliance_threshold (default 0.90)
-    - avg response_factuality >= factuality_threshold (default 0.80)
+    - avg response_factuality >= factuality_threshold (default 0.80), if run
     """
     def evaluator(*, item_results, **kwargs):
         def avg(score_name):
@@ -495,11 +502,15 @@ def promo_certification_gate(
         }
 
         failures = []
+        evaluated = 0
         for dim, (score, threshold) in checks.items():
             if score is None:
-                failures.append(f"{dim}=no data")
-            elif score < threshold:
+                continue  # dimension not evaluated in this mode — don't gate on it
+            evaluated += 1
+            if score < threshold:
                 failures.append(f"{dim}={score:.1%} < {threshold:.0%}")
+        if evaluated == 0:
+            failures.append("no scored dimensions to gate on")
 
         passed = not failures
         comment_parts = []


### PR DESCRIPTION
Follow-up to the code review of #29 (merged) and #30 (closed) — fixes the high-confidence findings, on `main`. Done in an isolated git worktree to avoid the shared-checkout race that produced those PRs' history.

## brand-promo-multi-agent
- **Compliance fails closed.** A tool error (e.g. injected `TOOL_ERROR`) in a check node was dropped, so `_aggregate` saw no findings and returned **APPROVED** — the compliance agent silently passing when it never checked. Each check now records its error and `_aggregate` returns `status="ERROR"` (not approved) if any check errored. (`src/agents/compliance_agent.py`)
- **Key-isolation.** `load_env` kept `override=False` (so a shell `BACKEND` export wins — intentional), but that also let ambient shell `LANGFUSE_*` keys shadow the demo `.env`, risking seeding into the wrong project. The Langfuse keys are now hard-set from the `.env` file when present (BACKEND override preserved), mirroring the real-estate guard. (`src/config.py`)
- **CI gate can pass again.** The gate treated an absent score as "no data" → fail, so the documented `--evaluators deterministic --ci` could never pass (`response_factuality` only exists in judge mode). Each threshold is now enforced only when its score is present. (`src/evals/evaluators.py`)
- **`--system-prompt-file` A/B now works.** The override was written to an env var, truncated to 500 chars, and never read. `strategy_crew.py` now appends the (full) override to the strategist's backstory, so v2-vs-baseline actually differs. (`src/agents/strategy_crew.py`, `scripts/run_experiment.py`)
- **`seed_evaluators.py` no longer false-succeeds.** It stopped POSTing a judge payload to the wrong endpoint (`/api/public/score-configs`) and printing "Created evaluator". This Langfuse version has no stable public LLM-judge API, so it now honestly points to the UI checklist + the self-hosted Postgres pattern (`seed-llm-judge-evaluators.sh`).

## agentic-rag
- **Judge scoping.** The independent managed judges scored empty-context `direct`-route answers (default demo greeting), producing spurious "divergence." Direct-route generations are now named `generate-direct`, which the `name=generate` judge filter skips (mirroring `reflect_node`). **Verified live:** direct → `generate-direct` (skipped), kb → `generate` (scored). (`demos/agentic-rag/graph.py`)

Not included (below the fix bar / noted as minor in the review): the `compliance_agent` "parallel" docstring (corrected to "sequential" here), null-token/$0-cost synthetic telemetry, and the residual `PepGPT` reference — happy to follow up on those if you want.

All changed files `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)