### PR TITLE
Disable fault injection during eval/CI + regression tests for the #31 fixes

### DIFF
--- a/demos/brand-promo-multi-agent/scripts/run_experiment.py
+++ b/demos/brand-promo-multi-agent/scripts/run_experiment.py
@@ -291,6 +291,14 @@ def _print_summary(result, args, run_name: str) -> None:
 def main() -> int:
     args = parse_args()
 
+    # Disable probabilistic fault injection for the whole eval run. Injected
+    # faults exist for synthetic-history / live-demo realism; against the golden
+    # dataset they're pure noise and score items on labels they can't match
+    # (e.g. TOOL_ERROR -> compliance "ERROR", never an expected label), which
+    # would drag avg_compliance_status_match under the certification gate. Set
+    # before any tool import/call so maybe_inject() sees it. (see src/tools/error_injection.py)
+    os.environ["PROMO_DISABLE_FAULT_INJECTION"] = "1"
+
     # Load env before importing langfuse so keys are available
     from src.config import load_env, resolve_backend
     env = load_env()

--- a/demos/brand-promo-multi-agent/src/tools/error_injection.py
+++ b/demos/brand-promo-multi-agent/src/tools/error_injection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import random
 from enum import StrEnum
 from functools import lru_cache
@@ -32,7 +33,16 @@ def _get_rng() -> random.Random:
 
 
 def maybe_inject(tool_name: str) -> InjectedFault | None:
-    """Roll the dice for a fault injection. Returns None most of the time."""
+    """Roll the dice for a fault injection. Returns None most of the time.
+
+    Disabled entirely when PROMO_DISABLE_FAULT_INJECTION is set. Fault injection
+    exists for synthetic-history / live-demo realism; during a golden-dataset
+    experiment it only adds noise and scores items against labels they can't
+    match (e.g. a TOOL_ERROR -> compliance status "ERROR", which is never an
+    expected label), so run_experiment.py sets this to keep eval/CI scoring clean.
+    """
+    if os.getenv("PROMO_DISABLE_FAULT_INJECTION"):
+        return None
     cfg = load_config()
     dist = cfg.synthetic_history.failure_mode_distribution
     rng = _get_rng()

--- a/demos/brand-promo-multi-agent/tests/test_compliance_agent.py
+++ b/demos/brand-promo-multi-agent/tests/test_compliance_agent.py
@@ -1,0 +1,59 @@
+"""Tests for the compliance mini-graph aggregation — must fail CLOSED on a tool error."""
+
+from __future__ import annotations
+
+from src.agents.compliance_agent import _aggregate
+
+
+def _state(**overrides):
+    base = {
+        "brief": "some campaign brief",
+        "jurisdictions": None,
+        "brand_findings": [],
+        "regulatory_findings": [],
+        "all_findings": [],
+        "brand_error": None,
+        "regulatory_error": None,
+        "status": "APPROVED",
+        "summary": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _finding(severity: str, source: str = "brand_guidelines"):
+    return {"rule": "R1", "severity": severity, "detail": "d", "source": source}
+
+
+def test_aggregate_approved_when_clean():
+    out = _aggregate(_state())
+    assert out["status"] == "APPROVED"
+
+
+def test_aggregate_fails_closed_on_brand_tool_error():
+    # Regression: a TOOL_ERROR produces no findings; aggregation must NOT treat
+    # "no findings" as APPROVED — it must surface ERROR (fail closed).
+    out = _aggregate(_state(brand_error="tool_error"))
+    assert out["status"] == "ERROR"
+    assert "not approved" in out["summary"].lower()
+
+
+def test_aggregate_fails_closed_on_regulatory_tool_error():
+    out = _aggregate(_state(regulatory_error="tool_error"))
+    assert out["status"] == "ERROR"
+
+
+def test_aggregate_error_takes_precedence_over_findings():
+    # Even with findings present, an errored check means we can't certify.
+    out = _aggregate(_state(brand_error="tool_error", brand_findings=[_finding("MEDIUM")]))
+    assert out["status"] == "ERROR"
+
+
+def test_aggregate_rejected_on_high_severity():
+    out = _aggregate(_state(brand_findings=[_finding("HIGH")]))
+    assert out["status"] == "REJECTED"
+
+
+def test_aggregate_conditional_on_medium_severity():
+    out = _aggregate(_state(regulatory_findings=[_finding("MEDIUM", source="regulatory")]))
+    assert out["status"] == "CONDITIONAL"

--- a/demos/brand-promo-multi-agent/tests/test_evaluators.py
+++ b/demos/brand-promo-multi-agent/tests/test_evaluators.py
@@ -305,3 +305,59 @@ class TestRunLevelFactories:
         result = gate(item_results=item_results)
         assert result.value == 0.0
         assert "FAILED" in result.comment
+
+    def test_gate_pass_deterministic_only(self):
+        # Regression: `--evaluators deterministic` never produces a
+        # response_factuality score. The gate must PASS on the deterministic
+        # dimensions, not fail on the ABSENT factuality one (previously counted
+        # as "no data" -> automatic failure, so `--evaluators deterministic --ci`
+        # could never pass).
+        from dataclasses import dataclass
+
+        from src.evals.evaluators import promo_certification_gate
+        gate = promo_certification_gate(
+            intent_threshold=0.85, compliance_threshold=0.90, factuality_threshold=0.80,
+        )
+
+        @dataclass
+        class FakeEval:
+            name: str
+            value: float
+            comment: str = ""
+
+        @dataclass
+        class FakeResult:
+            evaluations: list
+
+        item_results = [
+            FakeResult(evaluations=[
+                FakeEval("intent_classification_accuracy", 0.90),
+                FakeEval("compliance_status_match", 0.95),
+                # no response_factuality — judge not run in deterministic mode
+            ]),
+        ]
+        result = gate(item_results=item_results)
+        assert result.value == 1.0
+        assert "PASSED" in result.comment
+
+    def test_gate_fail_when_no_dimensions_scored(self):
+        # Guard the vacuous-pass edge: if NO gated dimension has data, fail.
+        from dataclasses import dataclass
+
+        from src.evals.evaluators import promo_certification_gate
+        gate = promo_certification_gate()
+
+        @dataclass
+        class FakeEval:
+            name: str
+            value: float
+            comment: str = ""
+
+        @dataclass
+        class FakeResult:
+            evaluations: list
+
+        item_results = [FakeResult(evaluations=[FakeEval("unrelated_score", 1.0)])]
+        result = gate(item_results=item_results)
+        assert result.value == 0.0
+        assert "FAILED" in result.comment


### PR DESCRIPTION
Follow-up to #31 (merged). Addresses the one non-blocking cross-fix interaction the review of #31 flagged, and adds the regression tests those fixes were missing.

## The interaction
#31 made the compliance agent fail **closed** (`status="ERROR"` on a tool error) — correct. But `maybe_inject()` fires on **every** compliance tool call, including golden-dataset **experiment** runs. So ~8% of eval items hit an injected `TOOL_ERROR` → `"ERROR"`, which is never an expected label, dragging `avg_compliance_status_match` under the certification gate that #31 just unblocked (`--evaluators deterministic --ci`). Fault injection is for synthetic-history / live-demo realism, not for scoring against golden labels.

## Fix
- `src/tools/error_injection.py`: `maybe_inject()` returns `None` when `PROMO_DISABLE_FAULT_INJECTION` is set.
- `scripts/run_experiment.py`: sets that flag at the top of `main()`, so the entire eval run is injection-free and scores cleanly.

## Regression tests (were missing for #31's fixes)
- `tests/test_compliance_agent.py` (new): `_aggregate` fails closed on a brand/regulatory tool error (`ERROR`, taking precedence over any findings), and still returns APPROVED / REJECTED / CONDITIONAL correctly otherwise.
- `tests/test_evaluators.py`: the certification gate **passes** on a deterministic-only run (no `response_factuality`) and **fails** when no dimension was scored.

## Verification
`uv run pytest tests/test_compliance_agent.py tests/test_evaluators.py` → **35 passed, 1 failed**. The single failure (`TestSkuValidity::test_valid_sku`) is **pre-existing** — it fails on `main` with these changes stashed, is unrelated to `sku_validity` (untouched here), and looks like a Python-3.14 env artifact from `uv`'s default interpreter. Done in an isolated git worktree to avoid the shared-checkout race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)