### PR TITLE
agentic-rag: run the full graph from LibreChat (identical scoring) + rename AgentRun→LibreChat

### DIFF
--- a/.agents/skills/run-demo/SKILL.md
+++ b/.agents/skills/run-demo/SKILL.md
@@ -74,7 +74,7 @@ internal agent IDs (cryptic but harmless); don't apologize for them, just narrat
 
 Conversation-title generation is disabled in `librechat.yaml`
 (`endpoints.all.titleConvo: false`) so the trace list stays clean. If a customer's
-instance has titling on, filter **Trace Name = AgentRun** in Langfuse to hide the
+instance has titling on, filter **Trace Name = LibreChat** in Langfuse to hide the
 `TitleRun` noise.
 
 ## 4. After the demo

--- a/.agents/skills/troubleshoot/SKILL.md
+++ b/.agents/skills/troubleshoot/SKILL.md
@@ -87,7 +87,7 @@ literal markup instead of LibreChat's collapsible tool cards:
 were sent to the Anthropic API. Claude — instructed to use tools — then writes the
 tool-call syntax (and a fake response) as plain *text*, which LibreChat renders verbatim.
 This is **not** a model, model-id, version, or permission bug. Confirm in a Langfuse
-trace: the `AgentRun` generation has **no `tools` in its input** and there are **no
+trace: the `LibreChat` generation has **no `tools` in its input** and there are **no
 tool-execution spans**.
 
 Tools fail to bind when, at chat time, the MCP server wasn't connected, or the agent was

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ This solution integrates multiple open-source tools—all powered by ClickHouse:
 |-----------|-------------|--------------------:|----------:|
 | **Text-to-SQL** | Converts natural language to SQL and runs it against ClickHouse's public demo database (UK property, GitHub events, OpenSky flights) | `text-to-sql` | `text-to-sql` |
 | **Vector RAG** | Retrieval-augmented generation — embeds documents with sentence-transformers, stores in ChromaDB, retrieves context for LLM answers | `vector-rag` | `vector-rag` |
-| **LibreChat** | Full chat UI with native Langfuse tracing — use it like ChatGPT, every conversation is traced | `AgentRun` | `librechat` |
+| **LibreChat** | Full chat UI with native Langfuse tracing — use it like ChatGPT, every conversation is traced | `LibreChat` | `librechat` |
 | **Test Scenarios** | Pre-crafted prompt/response pairs that intentionally fail in different ways — used to demo Langfuse evaluators | per-scenario name | `test-scenario` |
 | **Langfuse** | The observability platform — stores traces in ClickHouse, provides UI for search, cost tracking, and LLM-as-a-Judge evaluation | — | — |
 

--- a/demos/agentic-rag/DEMO_QUESTIONS.md
+++ b/demos/agentic-rag/DEMO_QUESTIONS.md
@@ -1,0 +1,137 @@
+# Agentic RAG — Demo Questions & Self-Correction
+
+Which questions to ask, what each one demonstrates, and specifically how to make the
+agent **grade its own retrieval, reject it, rewrite the query, and recover** — the
+`retrieval_relevance`-scored-twice moment.
+
+Everything here works identically whether you drive the graph from the CLI
+(`main.py` / `/query`) or from **LibreChat** (the `Agentic RAG Assistant` agent →
+`agentic_rag_answer` MCP tool). Both execute the same `graph.py`, so both emit the
+same fully-scored `agentic-rag` Langfuse trace. See
+[../../docs/AGENTIC_RAG_DEMO_RUNBOOK.md](../../docs/AGENTIC_RAG_DEMO_RUNBOOK.md) for
+the full talk track.
+
+---
+
+## How the agent decides what to do
+
+The graph (`graph.py`) runs: **route → retrieve → grade → (rewrite → retrieve)\* →
+generate → reflect**.
+
+- **route** picks one of three paths from the question:
+  - `kb` — answer from the knowledge base (concepts / how-to). This is the path that
+    can self-correct.
+  - `sql` — dataset-number questions run a live ClickHouse `SELECT` (`sql-tool` node).
+  - `direct` — chit-chat / no retrieval needed.
+- **grade** asks the LLM *"is this context relevant? yes/no"* and emits a
+  `retrieval_relevance` score **on that grade observation** (span-level, so it can be
+  scored more than once per run — `grade_node`).
+- If **not relevant**, `_grade_edge` routes to **rewrite** (which is prompted to
+  *expand abbreviations, add synonyms, be specific*), then back to **retrieve** — up
+  to `MAX_RETRIEVE_ATTEMPTS = 2` (initial + one rewrite).
+- **reflect** grades whether the answer is grounded in the context and emits a
+  trace-level `groundedness` score (`reflect_node`).
+
+---
+
+## Question catalog (the 5 CLI demo questions)
+
+From `main.py` → `DEMO_QUESTIONS`. Ask any of them verbatim in LibreChat too.
+
+| # | Question | Route | Shows |
+|---|----------|-------|-------|
+| 1 | What is ClickHouse and what is it used for? | `kb` | Clean single-shot RAG (grade passes first try) |
+| 2 | How does RAG architecture reduce hallucinations? | `kb` | Single-shot RAG |
+| 3 | **What vector databases exist and how does ClickHouse compare?** | `kb` | **Self-correction** — grade fails, rewrite, re-retrieve, recovers ⭐ |
+| 4 | Why is ClickHouse well-suited for storing observability data? | `kb` | Single-shot RAG |
+| 5 | Hello, what can you help me with? | `direct` | Direct route — no retrieval, no `retrieval_relevance`, reflect skipped |
+
+For the **`sql` route**, ask a dataset-number question, e.g. *"How many rides are in
+the nyc_taxi dataset?"* — the graph writes and runs a `SELECT`. Note: in **LibreChat**
+the agent answers number questions with the ClickHouse playground tools directly (per
+its instructions), so the graph's internal `sql` route is exercised via the CLI /
+direct `/query`, not through `agentic_rag_answer`.
+
+---
+
+## ⭐ The self-correction question (`retrieval_relevance` scored twice)
+
+> **"What vector databases exist and how does ClickHouse compare?"**
+
+This is the reliable fail-then-recover case. The returned step log:
+
+```
+route → kb
+retrieve (attempt 1) → 4 chunks
+grade → not relevant          ← retrieval_relevance = 0.0
+rewrite → 'List of vector databases and vector search engines available'
+retrieve (attempt 2) → 4 chunks
+grade → relevant              ← retrieval_relevance = 1.0
+generate → drafted answer
+reflect → grounded
+```
+
+The resulting `agentic-rag` trace carries **two** `retrieval_relevance` scores:
+
+```
+retrieval_relevance = 0  | "attempt 1: context graded not relevant"
+retrieval_relevance = 1  | "attempt 2: context graded relevant"
+```
+
+**In the Langfuse UI:** open the trace and you'll see two `grade-relevance`
+observations, each with its own score badge (0.00 then 1.00), and the graph view
+draws the `retrieve → grade → rewrite → retrieve → grade` loop.
+
+### Why this question and not just any hard one
+
+The lever is: **first retrieval must miss, but the rewritten query must hit.** Because
+the `rewrite-query` node expands abbreviations and adds synonyms, abbreviation-heavy
+questions (e.g. *"How does CH stack up vs other vector DBs for storing obs data?"*)
+**do** trigger the rewrite loop — but with the small (~28-chunk) demo KB the second
+pass often still grades *not relevant*, giving `0.0 → 0.0` (self-corrects but does not
+recover). Question #3 fails **and recovers**, which is the story you want.
+
+### Caveat: the grader is an LLM
+
+`grade` is an LLM yes/no, so the loop is not 100% deterministic run-to-run. Question #3
+is the designed self-correction case and triggers reliably on demand, but if you need a
+*guaranteed* fail-then-recover for a high-stakes rehearsal, re-run it once to confirm,
+or lower the grader's first-pass bar in `graph.py`.
+
+---
+
+## Scores you'll see on an `agentic-rag` trace, and where each comes from
+
+| Score | Source | How it's produced |
+|-------|--------|-------------------|
+| `retrieval_relevance` | in-graph self-grade | `grade_node` posts it per grade (span-level) |
+| `groundedness` | in-graph self-grade | `reflect_node` posts it once (trace-level) |
+| `faithfulness`, `context-relevance`, `answer-relevance` | managed LLM judges | Langfuse worker; seeded by `../../scripts/seed-agentic-rag-evaluators.sh` (filter: observation `name=generate` + trace tag `agentic-rag`) |
+| `credential-leak`, `leak-type` | code evaluator | `../../evaluators/credential-leak-guard.ts` on every generation |
+
+The managed judges are `NEW`-scoped: run
+`../../scripts/seed-agentic-rag-evaluators.sh` once, then generate fresh traffic for
+`faithfulness` / `context-relevance` / `answer-relevance` to appear.
+
+---
+
+## Running the questions
+
+**CLI (all 5, one shared session):**
+
+```bash
+docker compose --profile demo run --rm agentic-rag python main.py
+docker compose --profile demo run --rm agentic-rag python main.py --interactive
+```
+
+**HTTP (single question):**
+
+```bash
+curl -s localhost:8006/query -H 'content-type: application/json' \
+  -d '{"question":"What vector databases exist and how does ClickHouse compare?"}'
+```
+
+**LibreChat:** open the **Agentic RAG Assistant** agent and ask the question. It calls
+the `agentic_rag_answer` tool, which runs this same graph server-side — so you get a
+separate, fully-scored `agentic-rag` trace (with the double `retrieval_relevance` for
+question #3), alongside a thin `LibreChat` orchestration trace.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -287,10 +287,14 @@ services:
       - vector-rag-models:/root/.cache
 
   # =============================================================================
-  # MCP RAG Retriever — exposes ClickHouse vector search as an MCP tool
+  # MCP RAG Retriever — exposes the agentic-rag pipeline as MCP tools
   # =============================================================================
-  # Lets LibreChat agents run the SAME retrieval as the LangGraph agentic-rag
-  # service (single source of truth: mounts ./demos/agentic-rag for store/embeddings).
+  # Two granularities for LibreChat agents (single source of truth: mounts
+  # ./demos/agentic-rag for store/embeddings, and proxies AGENTIC_RAG_URL/query):
+  #   * retrieve_kb / list_documents — raw ClickHouse-native vector search.
+  #   * agentic_rag_answer           — the FULL self-correcting LangGraph, so a
+  #     LibreChat answer emits a fully-scored `agentic-rag` trace (retrieval_relevance,
+  #     groundedness, faithfulness, context/answer-relevance) identical to the seed path.
   # =============================================================================
   mcp-rag-retriever:
     build:
@@ -307,9 +311,13 @@ services:
       - CH_VECTORS_DB=agentic_rag
       - CH_VECTORS_USER=agentic
       - CH_VECTORS_PASSWORD=agentic123
+      # Full agentic-rag graph (agentic_rag_answer tool proxies to its /query endpoint)
+      - AGENTIC_RAG_URL=http://agentic-rag:8000
     depends_on:
       clickhouse-vectors:
         condition: service_healthy
+      agentic-rag:
+        condition: service_started
     volumes:
       - ./demos/agentic-rag:/agentic-rag:ro
       - vector-rag-models:/root/.cache

--- a/docs/AGENTIC_RAG_DEMO_RUNBOOK.md
+++ b/docs/AGENTIC_RAG_DEMO_RUNBOOK.md
@@ -5,6 +5,8 @@
 
 **The story:** "Naive RAG retrieves once and hopes. Agentic RAG *routes*, *grades* what it retrieved, *self-corrects*, uses *tools*, and *reflects* on its own answer — all on ClickHouse-native vector search, all observable in Langfuse." See [AGENTIC_RAG_ARCHITECTURE.md](./AGENTIC_RAG_ARCHITECTURE.md) for the diagram.
 
+**Which questions to ask** (question catalog + the reliable self-correction trigger, for both CLI and LibreChat): [../demos/agentic-rag/DEMO_QUESTIONS.md](../demos/agentic-rag/DEMO_QUESTIONS.md).
+
 ---
 
 ## Pre-Demo Checklist (15 min before)

--- a/docs/AGENTIC_RAG_DEMO_RUNBOOK.md
+++ b/docs/AGENTIC_RAG_DEMO_RUNBOOK.md
@@ -181,14 +181,14 @@ see them side by side.
 
 **Action:** Ask: *"How does RAG reduce hallucinations, and how does ClickHouse fit in?"*
 
-**What audience sees:** The agent calling the `retrieve_kb` MCP tool (ClickHouse vector search), then answering with cited document titles.
+**What audience sees:** The agent calling the `agentic_rag_answer` MCP tool, which runs the **full self-correcting graph** server-side, then answering with cited document titles. Two linked traces land in Langfuse: the `LibreChat` orchestration trace (the tool call), and a separate `agentic-rag` trace that is scored **identically to Act 3** — `retrieval_relevance`, `groundedness`, and the managed `faithfulness` / `context-relevance` / `answer-relevance` judges.
 
 **Say:**
-> "This is the same ClickHouse-native retrieval — exposed as an MCP tool — driven by a no-code LibreChat agent instead of LangGraph. Same vector store, same observability. A developer gets the LangGraph service; an analyst gets a chat agent. Both land in Langfuse."
+> "This is the exact same graded pipeline as the LangGraph service — the same route→retrieve→grade→self-correct→generate→reflect loop — exposed as one MCP tool and driven by a no-code LibreChat agent. Because it runs the real graph, the LibreChat-driven answer gets the *same online scores* as the seeded run, not just a raw retrieval. A developer gets the LangGraph service; an analyst gets a chat agent; both are evaluated the same way."
 
-**Fallback:** If the tool doesn't appear, confirm `mcp-rag-retriever` is up and re-run `./scripts/seed-librechat-agents.sh`.
+**Fallback:** If the tool doesn't appear, confirm `mcp-rag-retriever` and `agentic-rag` are up and re-run `./scripts/seed-librechat-agents.sh`. If the `agentic-rag` trace has no scores, run `./scripts/seed-agentic-rag-evaluators.sh` once and re-ask (managed judges are `NEW`-scoped).
 
-> **Note:** Use a tool-triggering prompt like the one above — that's what makes the LibreChat trace rich (tool spans + reasoning loop). A generic "hello" yields a thin single-LLM-call trace. LibreChat traces via native LangGraph callbacks, so the tree shows internal node names (`RunnableSequence`, agent IDs) rather than the clean SDK spans from Act 3 — same data, noisier labels. Title generation is disabled, so each chat is one clean `AgentRun` trace.
+> **Note:** The graph runs in the `agentic-rag` service, so its clean SDK-named `agentic-rag` trace (route/retrieve/grade-relevance/generate/reflect-groundedness) is where the scores appear — the `LibreChat` trace itself stays thin (one tool call). To instead show LibreChat's *own* multi-step reasoning loop (tool spans, agent-ID nodes), point the agent at `retrieve_kb` — but that raw-retrieval path is **not** graded. Title generation is disabled, so each chat is one clean `LibreChat` trace.
 
 ---
 

--- a/docs/LANGFUSE_INTEGRATION.md
+++ b/docs/LANGFUSE_INTEGRATION.md
@@ -365,10 +365,12 @@ present or debug them.
 **How LibreChat instruments.** The Python demos (Text-to-SQL, Vector RAG, Agentic RAG)
 call the Langfuse SDK directly and build clean, intentionally named spans. LibreChat
 instead traces through its native `@librechat/agents` LangChain/LangGraph callbacks.
-That produces a deeper, machine-named tree — `AgentRun → LangGraph → agent_<id> →
+That produces a deeper, machine-named tree — `LibreChat → LangGraph → agent_<id> →
 agent=agent_<id> → RunnableSequence → prompt / generation → RunnableLambda`. The
 `Runnable*` spans and agent-ID node names are LangChain/LangGraph internals, not a bug.
-The `librechat` tag is added via a small `sed` patch in `librechat/entrypoint.sh`.
+The trace is renamed to `LibreChat` (LibreChat's hardcoded internal run name is
+`AgentRun`) and the `librechat` tag added via a small `sed` patch in
+`librechat/entrypoint.sh`.
 
 **Trace richness tracks tool use.** This is the key thing to understand:
 
@@ -388,8 +390,8 @@ but harmless.
 **Title generation is disabled.** `librechat.yaml` sets `endpoints.all.titleConvo:
 false`. With titling on, every chat also emits a separate `TitleRun` trace (LibreChat
 naming the thread) that clutters the trace list. Disabling keeps every trace a real
-`AgentRun`. To re-enable, set it to `true` and filter **Trace Name = AgentRun** in
-Langfuse to hide the `TitleRun` noise.
+`LibreChat` trace. To re-enable, set it to `true` and filter **Trace Name = LibreChat**
+in Langfuse to hide the `TitleRun` noise.
 
 ## MCP Server Integration (LibreChat Agents)
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -124,14 +124,14 @@ and answers. Then open Langfuse → the conversation you just had is itself a tr
 
 > **Reading LibreChat traces.** Pick a prompt that forces tool use (like the one above).
 > Trace richness is driven by tool calls: a tool-using query produces a 45–60
-> observation `AgentRun` with `TOOL` spans and multi-step reasoning; a generic
+> observation `LibreChat` trace with `TOOL` spans and multi-step reasoning; a generic
 > chit-chat prompt produces a thin ~10-observation trace (one LLM call wrapped in
 > LangGraph scaffolding) and a trivial graph — accurate, but underwhelming live.
 > Unlike the Python demos (which use the Langfuse SDK to build clean, named spans),
 > LibreChat traces via native LangChain/LangGraph callbacks, so you'll see internal
 > node names (`RunnableSequence`, agent IDs) — that's the integration, not a bug.
 > Conversation-title generation is disabled (`librechat.yaml` →
-> `endpoints.all.titleConvo: false`) so every trace is a real `AgentRun` rather than a
+> `endpoints.all.titleConvo: false`) so every trace is a real `LibreChat` trace rather than a
 > `TitleRun` naming call.
 
 ## 9. SQL analytics directly on trace data

--- a/librechat.yaml
+++ b/librechat.yaml
@@ -50,8 +50,9 @@ endpoints:
   # titleConvo: false disables LibreChat's automatic conversation-title generation.
   # Each titled chat would otherwise emit a separate "TitleRun" trace into Langfuse
   # (a small LLM call to name the thread) that clutters the trace list and looks like
-  # a junk agent run in a demo. Disabling keeps every Langfuse trace a real "AgentRun".
-  # To re-enable titles, set this to true (and optionally filter Trace Name = AgentRun
+  # a junk agent run in a demo. Disabling keeps every Langfuse trace a real "LibreChat"
+  # trace (renamed from LibreChat's internal "AgentRun" in librechat/entrypoint.sh).
+  # To re-enable titles, set this to true (and optionally filter Trace Name = LibreChat
   # in Langfuse to hide the TitleRun traces).
   all:
     titleConvo: false

--- a/librechat/entrypoint.sh
+++ b/librechat/entrypoint.sh
@@ -1,12 +1,15 @@
 #!/bin/sh
-# Add 'librechat' tag to Langfuse traces so they're filterable alongside
-# text-to-sql and vector-rag demo traces.
+# Rename LibreChat's Langfuse traces to "LibreChat" and tag them 'librechat' so
+# they read cleanly and are filterable alongside text-to-sql and vector-rag traces.
 #
-# LibreChat's @librechat/agents creates Langfuse CallbackHandlers without tags.
-# The LangGraph run config supports a 'tags' field that gets merged into trace tags.
-# This patches the controller files to include tags: ['librechat'] in the run config.
+# LibreChat's @librechat/agents creates Langfuse CallbackHandlers with a hardcoded
+# runName of 'AgentRun' and no tags. The LangGraph run config's 'runName' becomes
+# the Langfuse trace name, and 'tags' is merged into trace tags. This patches the
+# controller files to rename the run to 'LibreChat' and add tags: ['librechat'].
+# (No evaluator filters on the trace name — the managed judges key on tags /
+# observation names — so the rename does not affect scoring.)
 
-sed -i "s/runName: 'AgentRun',/runName: 'AgentRun', tags: ['librechat'],/g" \
+sed -i "s/runName: 'AgentRun',/runName: 'LibreChat', tags: ['librechat'],/g" \
     /app/api/server/controllers/agents/client.js \
     /app/api/server/controllers/agents/openai.js \
     /app/api/server/controllers/agents/responses.js \

--- a/mcp-rag-retriever/server.py
+++ b/mcp-rag-retriever/server.py
@@ -1,18 +1,29 @@
 """
-MCP server exposing ClickHouse-native vector retrieval as a tool.
+MCP server exposing ClickHouse-native vector retrieval as tools.
 
-Lets LibreChat agents (and any MCP client) run the SAME retrieval the LangGraph
-agentic-rag service uses — semantic search over the kb_chunks table backed by
-ClickHouse's native vector_similarity HNSW index.
+Lets LibreChat agents (and any MCP client) reach the SAME agentic-rag pipeline
+the standalone demo uses, in two granularities:
 
-Reuses the agentic-rag store/embeddings modules (mounted read-only at
-/agentic-rag) so there is a single source of truth for retrieval logic.
+  * retrieve_kb / list_documents — raw semantic search over the kb_chunks table
+    (ClickHouse native vector_similarity HNSW index). Reuses the agentic-rag
+    store/embeddings modules (mounted read-only at /agentic-rag) so there is a
+    single source of truth for retrieval logic.
+  * agentic_rag_answer — runs the FULL self-correcting LangGraph
+    (route -> retrieve -> grade -> self-correct -> generate -> reflect) by
+    calling the agentic-rag FastAPI service. This is what produces a fully-scored
+    `agentic-rag` Langfuse trace (retrieval_relevance, groundedness, and the
+    managed faithfulness / context-relevance / answer-relevance judges), so a
+    LibreChat-driven answer is evaluated identically to a seeded one.
 
 Transport: SSE on :8000 (matches the other mcp-clickhouse SSE servers), so
 LibreChat connects via  http://mcp-rag-retriever:8000/sse
 """
 
+import json
+import os
 import sys
+import urllib.error
+import urllib.request
 
 sys.path.insert(0, "/agentic-rag")
 
@@ -20,6 +31,9 @@ from mcp.server.fastmcp import FastMCP
 
 from clickhouse_store import ClickHouseVectorStore
 from embeddings import embed_query
+
+# Full agentic-rag graph lives in the `agentic-rag` service (FastAPI on :8000).
+AGENTIC_RAG_URL = os.getenv("AGENTIC_RAG_URL", "http://agentic-rag:8000")
 
 mcp = FastMCP("rag-retriever", host="0.0.0.0", port=8000)
 _store = ClickHouseVectorStore()
@@ -53,6 +67,50 @@ def list_documents() -> list:
         f"SELECT DISTINCT doc_title FROM {_store.config.qualified_table} ORDER BY doc_title"
     )
     return [row[0] for row in result.result_rows]
+
+
+@mcp.tool()
+def agentic_rag_answer(question: str, session_id: str = "") -> dict:
+    """Answer a knowledge-base question with the FULL self-correcting agentic-RAG graph.
+
+    Runs the complete LangGraph corrective-RAG pipeline in the agentic-rag
+    service — route -> retrieve -> grade -> self-correct (rewrite + re-retrieve)
+    -> generate -> reflect. Unlike `retrieve_kb` (which only returns raw chunks
+    for you to reason over yourself), this executes the graded, self-correcting
+    loop server-side and emits a fully-scored `agentic-rag` Langfuse trace
+    (retrieval_relevance, groundedness, faithfulness, context-relevance,
+    answer-relevance).
+
+    Use THIS tool to answer knowledge/concept/how-to questions; use `retrieve_kb`
+    / `list_documents` only when the user explicitly wants to inspect raw
+    retrieval.
+
+    Args:
+        question: The natural-language question to answer from the knowledge base.
+        session_id: Optional session id to group related turns in one Langfuse session.
+
+    Returns:
+        {question, answer, route, grounded, steps, session_id} from the graph,
+        or {error: ...} if the agentic-rag service is unreachable.
+    """
+    payload = json.dumps(
+        {"question": question, "session_id": session_id or None}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{AGENTIC_RAG_URL}/query",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        # The graph can self-correct (multiple LLM calls), so allow a generous timeout.
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        return {
+            "error": f"agentic-rag service unreachable at {AGENTIC_RAG_URL}: {e}. "
+            "Ensure the `agentic-rag` container is running (docker compose --profile demo up -d agentic-rag)."
+        }
 
 
 if __name__ == "__main__":

--- a/scripts/seed-librechat-agents.sh
+++ b/scripts/seed-librechat-agents.sh
@@ -471,16 +471,15 @@ create_agent \
     "Agentic RAG Assistant" \
     "Agentic RAG over a ClickHouse-native vector store with self-correction" \
     "$(cat <<'INST'
-You are an Agentic RAG assistant. You answer questions about ClickHouse, RAG, vector search, OpenTelemetry, and LLM observability by retrieving from a knowledge base stored in ClickHouse (native vector_similarity search) — and you can also query live ClickHouse demo datasets when a question needs real numbers.
+You are an Agentic RAG assistant. You answer questions about ClickHouse, RAG, vector search, OpenTelemetry, and LLM observability from a knowledge base stored in ClickHouse (native vector_similarity search) — and you can also query live ClickHouse demo datasets when a question needs real numbers.
 
-Follow a corrective-RAG (CRAG) loop, do NOT answer from memory:
-1. ROUTE: decide if the question needs the knowledge base (concepts/how-to) or live SQL (dataset numbers).
-2. RETRIEVE: call `retrieve_kb` with a focused query to get relevant chunks.
-3. GRADE: judge whether the retrieved chunks actually answer the question.
-4. SELF-CORRECT: if the chunks are weak or off-topic, rewrite the query (expand abbreviations, add synonyms, be specific) and call `retrieve_kb` again before answering. Use `list_documents` if you need to see what's available.
-5. TOOL USE: for questions about dataset numbers (taxi rides, github stars, stackoverflow, etc.), write and run a ClickHouse SELECT via the playground tools instead.
-6. ANSWER: respond using ONLY the retrieved context. Cite the document titles you used.
-7. REFLECT: before finishing, verify every claim is supported by the context; if not, retrieve more or state what's missing.
+Routing rule — decide first, then act, do NOT answer from memory:
+
+A. KNOWLEDGE / CONCEPT / HOW-TO questions (the common case): you MUST call `agentic_rag_answer`, passing the question verbatim. That tool runs the full self-correcting corrective-RAG graph server-side (route -> retrieve -> grade -> self-correct -> generate -> reflect) and returns a grounded, cited answer plus its route and grounded flags. Present the returned `answer` and mention the documents it cited. Do NOT hand-roll retrieval with `retrieve_kb` for these — `agentic_rag_answer` is the graded, evaluated path (it emits the retrieval_relevance / groundedness / faithfulness / context-relevance / answer-relevance scores).
+
+B. DATASET-NUMBER questions (taxi rides, github stars, stackoverflow counts, etc.): write and run a ClickHouse SELECT via the playground tools instead — these need live SQL, not the knowledge base.
+
+C. INSPECTION only: use `retrieve_kb` / `list_documents` when the user explicitly asks to see raw retrieved chunks or what documents exist — not to compose a normal answer.
 
 Be concise, accurate, and grounded. Never fabricate sources.
 INST


### PR DESCRIPTION
## What & why

Running agentic-rag **from LibreChat** produced a messy `AgentRun` trace with only `credential-leak`/`leak-type`, while the seeded `agentic-rag` trace was clean with online scores. Root cause: the LibreChat agent only called `retrieve_kb` (raw vector search) and let its own model reason — it never executed the agentic-rag LangGraph, so the in-graph self-grades (`retrieval_relevance`, `groundedness`) never ran and the managed judges skipped the trace (their filter needs observation `name=generate` + tag `agentic-rag`).

## Change

- **New `agentic_rag_answer` MCP tool** (`mcp-rag-retriever/server.py`) that proxies to the `agentic-rag` FastAPI `/query`, running the **full CRAG graph**. A LibreChat answer now emits a fully-scored `agentic-rag` trace identical to the seed path.
- **Agent instructions** (`scripts/seed-librechat-agents.sh`) now mandate `agentic_rag_answer` for KB questions (SQL playground for numbers; `retrieve_kb` only for raw inspection).
- **compose**: `AGENTIC_RAG_URL` env + `depends_on: agentic-rag`.
- **Rename** LibreChat's Langfuse trace `AgentRun → LibreChat` (one-line extension of the existing `entrypoint.sh` sed patch; no evaluator filters on trace name, so scoring is unaffected). Docs updated to match.
- **Docs**: new `demos/agentic-rag/DEMO_QUESTIONS.md` (question catalog + the reliable self-correction trigger that scores `retrieval_relevance` twice, 0.0→1.0).

## Verified end-to-end

A LibreChat-path run (via `agentic_rag_answer`) produced an `agentic-rag` trace with the full score set — `retrieval_relevance=1`, `groundedness=1`, `faithfulness`, `context-relevance`, `answer-relevance`, `credential-leak`/`leak-type`. The self-correction question yields two `retrieval_relevance` scores (0.0 then 1.0). Rename confirmed (`runName: 'LibreChat'`, no double-tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)