### PR TITLE
docs: consultative SA demo scripts for the remaining four demos

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -8,12 +8,12 @@ Engineering loop, see [`../AI_ENGINEERING_LOOP.md`](../AI_ENGINEERING_LOOP.md).
 
 | Demo | What it shows | Best loop steps | Run |
 |------|---------------|-----------------|-----|
-| **[text-to-sql](text-to-sql/)** | NL → SQL over ClickHouse via MCP (LangChain) | Trace · Deploy (managed prompts) | `docker compose --profile demo run --rm text-to-sql python main.py` |
-| **[vector-rag](vector-rag/)** | RAG over ChromaDB (LangChain) | Trace · Evaluate · Deploy | `docker compose --profile demo run --rm vector-rag python main.py` |
+| **[text-to-sql](text-to-sql/)** | NL → SQL over ClickHouse via MCP (LangChain) | Trace · Deploy (managed prompts) | `docker compose --profile demo run --rm text-to-sql python main.py` · client script: [`DEMO_SCRIPT.md`](text-to-sql/DEMO_SCRIPT.md) |
+| **[vector-rag](vector-rag/)** | RAG over ChromaDB (LangChain) | Trace · Evaluate · Deploy | `docker compose --profile demo run --rm vector-rag python main.py` · client script: [`DEMO_SCRIPT.md`](vector-rag/DEMO_SCRIPT.md) |
 | **[agentic-rag](agentic-rag/)** | Self-correcting RAG on ClickHouse-native vectors (LangGraph) | Trace · Experiment · Deploy | see [`DEMO_SCRIPT.md`](agentic-rag/DEMO_SCRIPT.md) (client script) or [`../docs/AGENTIC_RAG_DEMO_RUNBOOK.md`](../docs/AGENTIC_RAG_DEMO_RUNBOOK.md) (deep reference) |
-| **[real-estate](real-estate/)** | Self-contained agentic concierge — the whole loop end-to-end in one place | ALL 5 + Deploy | `cd demos/real-estate && ./run_demo.sh` then `./run_portal.sh` |
-| **[brand-promo-multi-agent](brand-promo-multi-agent/)** | Multi-agent promo-planning assistant (LangGraph + CrewAI): synthetic history, online + offline evals, persona dashboards | Trace · Datasets · Experiment · Evaluate · Deploy | see [README](brand-promo-multi-agent/) |
-| **[langfuse-rls](langfuse-rls/)** | Attribute-based row-level-security prototype over Langfuse traces (Next.js): trace governance / access control | Governance (adjacent to the loop) | `cd demos/langfuse-rls && npm install && npm run dev` |
+| **[real-estate](real-estate/)** | Self-contained agentic concierge — the whole loop end-to-end in one place | ALL 5 + Deploy | `cd demos/real-estate && ./run_demo.sh` then `./run_portal.sh` · client script: [`DEMO_SCRIPT.md`](real-estate/DEMO_SCRIPT.md) |
+| **[brand-promo-multi-agent](brand-promo-multi-agent/)** | Multi-agent promo-planning assistant (LangGraph + CrewAI): synthetic history, online + offline evals, persona dashboards | Trace · Datasets · Experiment · Evaluate · Deploy | see [`DEMO_SCRIPT.md`](brand-promo-multi-agent/DEMO_SCRIPT.md) (client script) or [README](brand-promo-multi-agent/) |
+| **[langfuse-rls](langfuse-rls/)** | Attribute-based row-level-security prototype over Langfuse traces (Next.js): trace governance / access control | Governance (adjacent to the loop) | `cd demos/langfuse-rls && npm install && npm run dev` · client script: [`DEMO_SCRIPT.md`](langfuse-rls/DEMO_SCRIPT.md) |
 
 Each demo has its own README. **text-to-sql**, **vector-rag**, and **agentic-rag**
 run as containers in the root `docker-compose.yaml` (the `demo` profile) and share

--- a/demos/brand-promo-multi-agent/DEMO_SCRIPT.md
+++ b/demos/brand-promo-multi-agent/DEMO_SCRIPT.md
@@ -10,7 +10,7 @@ dataset with a certification gate** fit for CI.
 - **App:** PromoPlanner — `classify intent → research crew (3 agents + tools) →
   strategy crew (2 agents) → compliance checks → compose brief`
 - **Frameworks:** LangGraph (orchestration) + CrewAI (crews) — deliberately
-  multi-framework, because real estates are
+  multi-framework, because real agent estates are mixed
 - **Models, tiered by job:** Sonnet for research, **Opus for strategy**, Haiku
   on compliance, Opus as judge — cost-per-role is part of the story
 - **Observability backend:** Langfuse (`http://localhost:3001`), standalone
@@ -71,7 +71,10 @@ render; Prompts shows ~12 under `promo-planner/`; dataset
 `promo-planner-golden-v1` has 75 items; annotation queue has ~10 items; the
 Runs tab is non-empty. **Note:** the online evaluators and dashboards may need
 one-time manual creation in the UI — the seed scripts print exact checklists
-when the API can't create them.
+when the API can't create them. Creating the online judges in the UI requires
+an **Anthropic LLM Connection** in the demo's Langfuse project first
+(**Settings → LLM Connections**; the judge model is `claude-opus-4-7`) — add
+it before working through the evaluator checklist, or the judge setup fails.
 
 **Browser tabs ready:** Traces, the three dashboards (Executive / Ops /
 Engineer), Prompts, Datasets → Runs, Annotation Queues — plus a terminal.
@@ -438,12 +441,13 @@ prompt_override = os.getenv("PROMO_SYSTEM_PROMPT_OVERRIDE", "").strip()   # set 
 ## Reset / re-run
 
 ```bash
-uv run scripts/seed_all.py                    # re-seed everything (idempotent; dataset upserts by hash)
+uv run scripts/seed_all.py                    # re-seed everything (dataset upserts by hash; prompt seeding mints a new version each run)
 uv run scripts/generate_history.py            # append more synthetic history (--total N --seed 42)
 uv run scripts/run_live_demo.py play-all      # regenerate the 5 live traces
 uv run python scripts/run_experiment.py --run-name fresh --sample 10 --evaluators deterministic
 PYTHONPATH=. uv run --with pytest pytest tests/   # regression tests (evaluators, fault injection)
 ```
 
-No teardown script ships — "reset" is re-seeding (idempotent) or clearing the
-Langfuse project in the UI. Health check: `curl http://localhost:3001/api/public/health`.
+No teardown script ships — "reset" is re-seeding (safe to repeat, though each
+run adds prompt versions) or clearing the Langfuse project in the UI. Health
+check: `curl http://localhost:3001/api/public/health`.

--- a/demos/brand-promo-multi-agent/DEMO_SCRIPT.md
+++ b/demos/brand-promo-multi-agent/DEMO_SCRIPT.md
@@ -1,0 +1,449 @@
+# PromoPlanner — Demo Script (multi-agent fleet observability + eval gates)
+
+A ready-to-run demo of a **multi-agent promo-planning assistant** for CPG /
+retail audiences — a LangGraph orchestrator delegating to **CrewAI crews**
+(research, strategy) and a deterministic compliance graph — observed in
+**Langfuse** at **fleet scale**: 50k traces of synthetic history, six agents,
+persona dashboards, online judges on live traffic, and an offline **golden
+dataset with a certification gate** fit for CI.
+
+- **App:** PromoPlanner — `classify intent → research crew (3 agents + tools) →
+  strategy crew (2 agents) → compliance checks → compose brief`
+- **Frameworks:** LangGraph (orchestration) + CrewAI (crews) — deliberately
+  multi-framework, because real estates are
+- **Models, tiered by job:** Sonnet for research, **Opus for strategy**, Haiku
+  on compliance, Opus as judge — cost-per-role is part of the story
+- **Observability backend:** Langfuse (`http://localhost:3001`), standalone
+  project — own `uv` env + `.env`
+- **Re-themeable:** every brand/region/retailer/query comes from
+  `demo.config.yaml` — rebrand it to the prospect in minutes
+- **Run length:** 25–30 min full; 10–12 min short path (Acts 1–3)
+
+> Everything lives in `demos/brand-promo-multi-agent/`. The deep reference is
+> [`docs/DEMO_RUNBOOK.md`](docs/DEMO_RUNBOOK.md) (60-min segment-by-segment) and
+> [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md); this script is the
+> customer-facing conversation layered on top.
+
+---
+
+## How to run this script
+
+It's written to be a **conversation, not a walkthrough**. Every act does three
+things: it **frames** a problem the audience already has, **shows** how the
+platform answers it, and **lands** the benefit — then hands a **question** back to
+the room. So each act carries four beats:
+
+- **Frame** — the problem, in their terms (say this *before* you touch the screen).
+- **Show** — the exact clicks / commands.
+- **Land** — the "so what": the benefit, not the feature.
+- **Ask** — an open question that invites them to map it to their own world.
+
+The short path is Acts 1–3 (scale → one trace → live catch). Acts 4–6 are for
+rooms that own evaluation, release gates, or human review.
+
+---
+
+## 0 · Pre-flight (do this BEFORE the meeting)
+
+Standalone demo — own dependencies, own `.env` (never the repo root one):
+
+```bash
+cd demos/brand-promo-multi-agent
+cp .env.example .env                      # ANTHROPIC_API_KEY + LANGFUSE_* keys
+cp demo.config.example.yaml demo.config.yaml
+uv sync
+uv run scripts/setup_langfuse_project.py  # self-hosted only; skip on Langfuse Cloud
+uv run scripts/seed_all.py                # prompts, score configs, dataset, dashboards, queue
+uv run scripts/generate_history.py        # 50k synthetic traces (several minutes)
+```
+
+Then rehearse the live pieces once (they're the same commands you'll run on
+stage):
+
+```bash
+uv run scripts/run_live_demo.py play-all                                        # the 5 scripted queries
+uv run python scripts/run_experiment.py --run-name rehearsal --sample 10 \
+  --evaluators deterministic                                                    # ~30s, no judge cost
+```
+
+**Checklist (from the runbook):** Traces list shows ~50k; the 3 dashboards
+render; Prompts shows ~12 under `promo-planner/`; dataset
+`promo-planner-golden-v1` has 75 items; annotation queue has ~10 items; the
+Runs tab is non-empty. **Note:** the online evaluators and dashboards may need
+one-time manual creation in the UI — the seed scripts print exact checklists
+when the API can't create them.
+
+**Browser tabs ready:** Traces, the three dashboards (Executive / Ops /
+Engineer), Prompts, Datasets → Runs, Annotation Queues — plus a terminal.
+
+> **Demo hygiene:** this demo's `.env` hard-overrides ambient `LANGFUSE_*` shell
+> vars (a footgun the container demos have) — but keep the habit: `unset
+> LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY` before any demo day.
+
+---
+
+## What each act proves
+
+| Capability | Where in the demo |
+|---|---|
+| **Fleet-scale observability** (50k traces, 6 agents) | Act 1 — Traces list + dashboards |
+| **Persona dashboards** (Exec / Ops / Engineer on the same data) | Act 1 |
+| **One multi-agent run as one trace** (crews, tools, nested graphs) | Act 2 — a `promo_planner_run` tree |
+| **Cost by model tier** (Sonnet research / Opus strategy / Haiku compliance) | Act 2 — per-span model + cost |
+| **Deterministic compliance gate, fail-closed** | Act 3 — `q2_compliance_catch` → REJECTED |
+| **Evals catch hallucinated facts** (free check + judge) | Act 3 — `q5` → `sku_validity`, factuality |
+| **Online judges on live traffic** (sampled) | Act 4 — Evaluators: factuality / tool-correctness / compliance |
+| **Golden dataset + experiment + certification gate** (CI-able) | Act 4 — `run_experiment.py --ci` |
+| **Prompt A/B on the dataset** | Act 5 — baseline vs `strategy-v2` runs |
+| **Human review queue** | Act 6 — ambiguous-factuality traces |
+| **Re-theme to the prospect** | Close — `demo.config.yaml` |
+
+---
+
+## Opening · Locate the pain (2 min, no screen yet)
+
+**Frame.** One agent is a demo; a *fleet* is an operation. The moment you have
+agents delegating to agents — likely across two frameworks, because that's how
+these estates actually grow — three people show up with three different
+questions: the exec asks *what is this costing per outcome*, ops asks *which
+agent is degrading*, and the engineer asks *which step in which handoff broke*.
+Most teams can answer none of them, because the handoffs happen in the dark.
+
+**Ask (these steer the session):**
+- "How many agents — or agent-shaped features — do you have live or planned? Do
+  any call each other?"
+- "When a multi-step run goes wrong today, can you tell *which* agent — or which
+  handoff — failed?"
+- "Who looks at your LLM ops data — engineers only, or do execs and ops want
+  their own view? What do they each ask for?"
+- "What has to be true before you'd let an agent's output ship without a human
+  reading it?"
+
+**Land.** "This demo is a promo-planning assistant for a consumer-brands
+company — one orchestrator, two crews of sub-agents, a compliance gate — with
+a year of fleet history behind it. Map what you just told me onto it: scale and
+personas first, then one run under the microscope, then the eval machinery that
+decides what ships."
+
+---
+
+## Act 1 · The fleet, not the demo (4 min)
+
+**Frame.** Observability tools all look great with twelve traces. Your decision
+needs the picture at *operational* scale — and per audience.
+
+**Show.** Langfuse → **Traces**: ~**50,000** runs across six agents
+(PromoPlanner plus five fleet agents), with sessions, users, tags, failure
+modes. Then the three **Dashboards**, one per persona:
+
+- **Executive — Agent Fleet:** cost and volume by agent, trend lines. "Cost per
+  *brief*, not cost per token."
+- **Ops — Agent Health:** error and failure-mode rates, latency, degradation by
+  agent.
+- **Engineer — PromoPlanner Deep Dive:** score histograms and drill-downs
+  filtered to the hero agent.
+
+**Land.** "Same data, three altitudes — nobody exports to a spreadsheet to brief
+the exec. And the reason fifty thousand traces filter and aggregate this fast is
+that Langfuse stores them in **ClickHouse** — this dashboard *is* an analytical
+database query, not a pre-baked report."
+
+**Ask.** "Which of these three screens gets looked at Monday morning in your
+org — and who's flying blind today?"
+
+---
+
+## Act 2 · One run under the microscope (5 min)
+
+**Frame.** The multi-agent debugging problem in one sentence: *five agents
+touched the answer — which one do you blame?* Here's a whole run as one tree.
+
+**Show.** Filter Traces to `promo_planner_run`, open a rich one (the seeded
+history has the fullest trees), and walk the delegation:
+
+- `classify_intent` — the orchestrator decides this is a full promo-planning
+  request (vs compliance-only, vs out-of-scope refusal).
+- **`research_crew`** — three CrewAI agents in sequence: `data_analyst` (calls
+  `tool.query_sales`, `tool.query_inventory`), `market_researcher`
+  (`tool.market_trends`), `historian` (past promos). Tool inputs/outputs are
+  right there in the spans.
+- **`strategy_crew`** — `promo_strategist` drafts options, `lift_estimator`
+  quantifies them. **Click a generation here and point at the model: Opus.**
+  Then a research span: Sonnet. "Expensive model only where the thinking is."
+- `compliance_agent` — a nested graph: `brand_check` → `regulatory_check` →
+  aggregate to APPROVED / CONDITIONAL / REJECTED.
+- `compose_brief` — the final 7-section campaign brief.
+
+**Land.** "One question in, one trace out — every delegation, every tool call,
+every model choice with its own cost. 'Which agent do I blame' becomes 'open the
+tree and look.' And because model tier is per-span data, *cost by role* is a
+chart, not an estimate — that's how you defend running Opus on strategy and
+Haiku on compliance."
+
+**Ask.** "In your multi-agent design, where would you spend the expensive model
+— and could you prove today that the cheap one is good enough everywhere else?"
+
+> **Presenter note — know your own trace.** Live runs attach the Langfuse
+> callback to the LangGraph layer, so they show the orchestrator nodes and its
+> generations; the CrewAI crews' *internal* spans are fully modeled in the
+> seeded history (which is why you demo the tree on a seeded trace). If someone
+> asks: instrumenting CrewAI's LLM layer (litellm) is a known integration gap
+> called out in the code — `research_crew.py:22` — and a fair "roadmap for this
+> demo" admission. Don't present a live trace as having depth it doesn't.
+
+---
+
+## Act 3 · The agent catches it live (4 min) — the money moment
+
+**Frame.** Multi-agent isn't the point; *controlled* multi-agent is. Two live
+runs: one where the system blocks a compliance violation, one where the evals
+catch a hallucination.
+
+**Show.** Run the scripted queries (they're real runs, not recordings):
+
+```bash
+uv run scripts/run_live_demo.py play q2_compliance_catch
+```
+
+A promo idea targeting **children under 12** goes in; the compliance graph
+flags it HIGH severity against the regulatory rules and the brief comes back
+**REJECTED**, with the specific rule cited. Open the fresh trace: the
+`compliance_agent` node shows the finding. Emphasize *how* it checks:
+deterministic rules — keyword/regex policy checks in plain Python, no LLM — and
+**fail-closed**: if a compliance tool errors, the status is ERROR, never a
+silent pass.
+
+```bash
+uv run scripts/run_live_demo.py play q5_hallucination_catch
+```
+
+The run surfaces **fabricated SKUs**. Two independent layers catch it: the free
+deterministic `sku_validity` check (regex against the real SKU catalog) and the
+`response_factuality` judge scoring low, rationale attached.
+
+**Land.** "The compliance gate is the shape regulated customers ask for:
+deterministic where the policy is mechanical, fail-closed on error, and the
+rejection is *in the trace* with the rule that fired. And the hallucination
+didn't reach a human downstream — a free check plus a sampled judge flagged it
+with an audit trail. Guardrails and evals aren't dashboards here; they're
+decisions."
+
+**Ask.** "What's your REJECTED-equivalent — the output that must never ship?
+Is that rule executable today, or is it a PDF someone's supposed to remember?"
+
+> **Fallback:** the fleet also has *ambient* realism — ~20% of runs carry
+> injected faults (tool timeouts, hallucinated SKUs, compliance rejections) so
+> the dashboards and failure-mode filters have something true to show. Fault
+> injection is **disabled automatically during experiments/CI** so golden-set
+> scores stay honest.
+
+---
+
+## Act 4 · The certification gate (5 min) — "what's allowed to ship"
+
+**Frame.** Everything so far watched production. The harder question is a
+release question: *this new prompt / model / agent version — is it allowed to
+ship?* That needs a fixed test set and a gate, not vibes. Software teams already
+have the mental model: golden dataset = test suite, experiment = test run,
+certification gate = the check that blocks the merge.
+
+**Show.** **Datasets → `promo-planner-golden-v1`** — 75 items, stratified by
+intent (plan-promo, compare-brands, compliance-only, edge cases, out-of-scope),
+each with expected outputs. Then run an experiment live (~30s, no judge cost):
+
+```bash
+uv run python scripts/run_experiment.py --run-name live-$(whoami) --sample 10 \
+  --evaluators deterministic
+```
+
+The terminal prints per-dimension scores — intent accuracy, tool-call match,
+compliance status match, SKU validity, brief sanity — and the
+**`certification_gate`: PASSED/FAILED** verdict (intent ≥ 0.85, compliance ≥
+0.90, factuality ≥ 0.80 when the judge runs). In the UI: **Datasets → Runs** →
+open the run → click a low-scoring item → its full trace, judge rationale in
+the score comment.
+
+Then the one flag that makes it CI:
+
+```bash
+uv run python scripts/run_experiment.py --run-name ci-check \
+  --evaluators deterministic --ci     # exit code 1 if the gate fails
+```
+
+**Land.** "That exit code is the whole story: the same gate a human reads in
+the terminal *blocks the pipeline* in CI. Judges add the semantic dimensions
+when you want them — sampled online at 10% on live traffic, in full on the
+golden set before a release. Every score drills to the exact run that produced
+it, so 'why did the gate fail' is a click, not an investigation."
+
+**Ask.** "What are your gate's three thresholds — and who gets to set them?
+If a release had been blocked by an eval last quarter, which incident would it
+have prevented?"
+
+---
+
+## Act 5 · A/B a prompt change on the same yardstick (3 min)
+
+**Frame.** Someone proposes a "better" strategy prompt — more margin
+discipline. Better by what measure?
+
+**Show.** Run the candidate against the same dataset and evaluators, labeled:
+
+```bash
+uv run python scripts/run_experiment.py --run-name strategy-v2 \
+  --label strategy-v2 --system-prompt-file prompts/strategy_v2.md --sample 10 \
+  --evaluators deterministic
+```
+
+**Datasets → Runs**: baseline and `strategy-v2` side by side, dimension by
+dimension. Same items, same evaluators, one variable.
+
+**Land.** "Prompt engineering becomes an experiment with a control group. Ship
+the candidate if the gate holds and the target metric moves; if a dimension
+regresses, you found out here — not from a customer."
+
+**Ask.** "What's the prompt change your team has been *afraid* to make? This is
+what makes it safe to try."
+
+---
+
+## Act 6 · The human layer (2 min)
+
+**Frame.** The judge scored some runs 0.6–0.8 on factuality — too low to trust,
+too high to discard. Exactly the traffic a human should see.
+
+**Show.** **Annotation Queues → PromoPlanner Human Review**: ~10 pre-routed
+ambiguous traces plus anything an experiment flagged (`--queue-failures` routes
+low scorers in automatically). Open one, apply the `human_brief_review` verdict
+(Approved / Needs Revision / Rejected) — it lands as a score on the trace, next
+to the automated ones.
+
+**Land.** "Humans review the *ambiguous slice*, not a random sample — and their
+verdicts accumulate into the calibration set that tells you whether the judge
+itself can be trusted."
+
+**Ask.** "Who would own this queue for you — and how big does the ambiguous
+slice have to get before today's process breaks?"
+
+---
+
+## Close · Make it theirs (1 min)
+
+Land three takeaways: **multi-agent, multi-framework work is observable as one
+tree, at fleet scale, per persona**; **quality is enforced, not admired** — a
+fail-closed compliance gate live, plus a certification gate with a CI exit
+code; **the same yardstick scores production (sampled judges) and releases
+(golden set)**. Then the kicker: open `demo.config.yaml` — brands, regions,
+retailers, regulators, demo queries. "This becomes *your* company's demo by
+editing this file — same fleet, your brands, your compliance rules. The repo is
+public; clone it and re-theme it."
+
+---
+
+## Under the hood — how it's instrumented (for the "show me the code" moment)
+
+All in `demos/brand-promo-multi-agent/src/`. The interesting part is how *both*
+frameworks land in one trace, and how the eval layers connect to the gate.
+
+**1 · One handler + reserved metadata keys — `src/observability.py`**
+```python
+# observability.py:48   make_observability_callbacks() → the whole tracing integration
+return [CallbackHandler()]                                       # :77
+# observability.py:80   make_observability_run_metadata() — v4 reserved keys
+md["langfuse_user_id"] = user_id   # + langfuse_session_id, langfuse_tags   :100
+```
+*Why it matters:* attach `{callbacks, metadata, tags}` once at the orchestrator
+root and LangGraph propagates it to every nested LLM call — session, user and
+tags with no per-node code.
+
+**2 · Tracing rides the graph config — `src/agents/orchestrator.py:275`**
+```python
+return _orchestrator.invoke(initial_state, config=config)   # config carries callbacks
+```
+
+**3 · The honest seam — CrewAI's LLM layer — `src/agents/research_crew.py:22`**
+```python
+del callbacks   # "LangChain callbacks do not attach to crewai.LLM" (litellm-based)
+```
+*Why it matters:* this is the Act 2 presenter note in source form — the CrewAI
+crews run under the orchestrator but their internal LLM calls aren't captured
+live; the seeded history models them explicitly. Good faith beats hand-waving
+when a sharp audience reads the trace.
+
+**4 · Fault injection with an off-switch — `src/tools/error_injection.py:35`**
+```python
+def maybe_inject(...):   # seeded RNG; ~20% of live/synthetic runs carry a fault
+    if os.getenv("PROMO_DISABLE_FAULT_INJECTION"): return None   # :44 — set by run_experiment.py
+```
+*Why it matters:* realism on the dashboards, honesty in the experiments — the
+gate never grades an injected failure.
+
+**5 · Judge + the gate — `src/evals/evaluators.py`**
+```python
+# evaluators.py:250  _call_judge → Opus, returns {score, rationale}; rationale → score comment
+# evaluators.py:465  promo_certification_gate: PASS iff every PRESENT dimension ≥ threshold
+```
+*Why it matters:* six deterministic evaluators are plain functions; four judges
+share one call path; the gate is ~60 readable lines — the thing that blocks CI
+is code your team can review.
+
+**6 · Prompt A/B mechanism — `src/agents/strategy_crew.py:39`**
+```python
+prompt_override = os.getenv("PROMO_SYSTEM_PROMPT_OVERRIDE", "").strip()   # set from --system-prompt-file
+```
+*Why it matters:* the Act 5 experiment changes exactly one variable, verifiably.
+
+> One-liner for the room: *"One callback at the orchestrator root, metadata for
+> attribution, evaluators as plain functions, and a gate that exits non-zero.
+> Everything you watched is those four things."*
+
+---
+
+## Talking points & objections
+
+- **"Is the 50k history real?"** It's seeded synthetic history — and say so
+  unprompted. It exists so you evaluate the platform at operational scale
+  (dashboards, filters, score distributions) instead of extrapolating from
+  twelve traces. The live runs in Act 3 are real end-to-end executions; the
+  failure-mode mix in the history matches the live fault-injection
+  distribution.
+- **"Two frameworks — gimmick or real?"** Real estates are mixed; that's the
+  point. LangGraph orchestrates, CrewAI runs the crews, one trace shows both —
+  and the one seam (CrewAI's internal LLM calls on live runs) is called out in
+  the code rather than papered over.
+- **"Our compliance rules are more complex than keywords."** Good — the
+  architecture is the point, not the regex: a deterministic, fail-closed gate
+  *inside the agent graph*, whose verdict and evidence land in the trace. Swap
+  the check functions for your policy engine; the observability doesn't change.
+- **"Judges are expensive."** Layered on purpose: six deterministic evaluators
+  run free on everything; judges run sampled (10%) online and in full only on
+  the 75-item golden set. A full judged experiment is ~$10–15 — a knowable,
+  boundable release cost.
+- **"Can this gate our actual CI?"** `--ci` exits non-zero on gate failure —
+  wire it into any pipeline today. The gate thresholds are flags, so the
+  quality bar is versioned config.
+- **"We're not in CPG."** Every domain artifact — brands, regions, retailers,
+  regulators, the demo queries — comes from `demo.config.yaml`. Re-theming to
+  your industry is an edit, not a rewrite.
+- **"Why is this standalone?"** It manages its own `uv` env and Langfuse
+  project so it can't disturb the shared stack — same pattern as the
+  real-estate demo. It points at the same local Langfuse.
+- **"Where does all this data live?"** Langfuse stores traces and scores in
+  **ClickHouse** — which is why the fleet-scale filtering and the persona
+  dashboards hold up, and why your observability data sits in an engine you can
+  also query directly.
+
+---
+
+## Reset / re-run
+
+```bash
+uv run scripts/seed_all.py                    # re-seed everything (idempotent; dataset upserts by hash)
+uv run scripts/generate_history.py            # append more synthetic history (--total N --seed 42)
+uv run scripts/run_live_demo.py play-all      # regenerate the 5 live traces
+uv run python scripts/run_experiment.py --run-name fresh --sample 10 --evaluators deterministic
+PYTHONPATH=. uv run --with pytest pytest tests/   # regression tests (evaluators, fault injection)
+```
+
+No teardown script ships — "reset" is re-seeding (idempotent) or clearing the
+Langfuse project in the UI. Health check: `curl http://localhost:3001/api/public/health`.

--- a/demos/langfuse-rls/DEMO_SCRIPT.md
+++ b/demos/langfuse-rls/DEMO_SCRIPT.md
@@ -1,0 +1,277 @@
+# Trace Governance (RLS) — Demo Script (simulated, ~10 min)
+
+> **DEMO ONLY — say this out loud, first.** Langfuse does **not** natively support
+> Row-Level Security on traces today. This app **simulates the proposed behavior
+> in the application layer** so a customer can *interact* with what trace-level
+> access control would feel like — and so we can advocate for it with concrete
+> requirements. Never present it as a Langfuse-native feature; with a
+> sophisticated audience that costs you the room.
+
+A **governance conversation with a working mock**, not a product walkthrough:
+three personas, one shared Langfuse project, and each persona sees a different
+filtered subset of the same 30 bank-flavored traces.
+
+- **App:** `http://localhost:3000` (Next.js, standalone — own `npm` + `.env`)
+- **Data:** 30 seeded traces in your local Langfuse (`http://localhost:3001`),
+  fetched via the public API and filtered by an in-app policy engine
+- **Personas:** Alice (executive, `ceo-only`) sees **30/30**, Bob (compliance,
+  `restricted`) sees **20/30**, Carol (analyst, `general`) sees **10/30**
+- **Run length:** 8–12 min — best as a **rider** on a broader Langfuse demo, or a
+  standalone discovery call with a regulated prospect
+
+> This is deliberately smaller than the other demo scripts in this repo: there is
+> one strong interaction (the persona switch) and a lot of strong *conversation*
+> (the gap analysis on the `/design` page). Let the conversation carry it.
+
+---
+
+## How to run this script
+
+Same conversational shape as the other scripts — each act **frames** a problem,
+**shows** the answer, **lands** the benefit, and hands an **ask** back to the
+room. Here the Ask beats matter even more than usual: this demo exists because a
+customer requirement has no native answer yet, so what you're really doing is
+qualifying *their* requirement precisely enough to feed the roadmap conversation.
+
+---
+
+## 0 · Pre-flight (do this BEFORE the meeting)
+
+Requires the Langfuse stack up on `:3001` and Node 18+.
+
+```bash
+cd demos/langfuse-rls
+npm install                      # one-time
+cp .env.example .env             # set LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY
+npm run seed                     # push the 30 fixture traces into Langfuse
+npm run dev                      # app on http://localhost:3000
+```
+
+Sanity-check the money numbers before the meeting — they're deterministic:
+
+```bash
+curl -s 'localhost:3000/api/traces?persona=alice' | jq '.visible | length'   # 30
+curl -s 'localhost:3000/api/traces?persona=bob'   | jq '.visible | length'   # 20
+curl -s 'localhost:3000/api/traces?persona=carol' | jq '.visible | length'   # 10
+```
+
+**Browser tabs ready:** the app (`:3000`) on the Demo tab, plus `/policies` and
+`/design` in adjacent tabs. Langfuse itself (`:3001`) in a fourth tab — you'll
+want it to show that *natively*, every project member sees everything.
+
+---
+
+## What each act proves
+
+| Point | Where |
+|---|---|
+| Langfuse RBAC controls **operations**, not **row visibility** | Opening — show any member sees all traces in Langfuse itself |
+| What trace-level RLS would feel like (persona → filtered view) | Act 1 — persona switch, 30 → 20 → 10 |
+| Policy is explainable: which rule allowed/denied each trace | Act 1 — the "hidden by RLS policy" banner, expanded |
+| A defensible policy model (clearance ceiling, default-deny) | Act 2 — `/policies` matrix + the removed team-override rule |
+| Honest gap analysis + the native path (ClickHouse push-down) | Act 3 — `/design` |
+
+---
+
+## Opening · Locate the pain (2 min, no screen yet)
+
+**Frame.** LLM traces are some of the most sensitive data a company produces:
+prompts carry customer PII, unreleased strategy, an exec's verbatim questions.
+Langfuse's roles (Owner/Admin/Member/Viewer) control what you can *do* — they
+don't control which *rows* you can see. **Every member of a project sees every
+trace in it.** For a bank putting exec-strategy, compliance, and analyst teams on
+one observability platform, that's not a nice-to-have gap; it's a deal blocker.
+This prototype came out of exactly that conversation.
+
+**Ask (these steer the session):**
+- "Who can see your LLM traces today — and is there anything in them that not
+  everyone should see?"
+- "How do you segregate sensitive data in your other platforms — per-team
+  workspaces, row-level policies, something else?"
+- "If you had to put three teams with different clearances on one trace store
+  tomorrow, what would you do?"
+
+**Land.** "Today the honest answer in Langfuse is *separate projects per
+sensitivity tier* — which works, but fragments your cross-team analytics and
+multiplies ops. Let me show you what we think the real answer should look like,
+as a working mock we built to pin the requirement down."
+
+---
+
+## Act 1 · One project, three clearances (3 min)
+
+**Frame.** Same data, different eyes. The requirement in one sentence: an
+analyst and an executive share the platform, but the analyst must never see the
+M&A traces.
+
+**Show.** Open the **Demo** tab (`:3000`). Three persona cards — Alice
+(executive / `ceo-only`), Bob (compliance / `restricted`), Carol (analyst /
+`general`). Click through them and watch the stat strip:
+
+- **Alice → 30/30.** Full visibility: board strategy, M&A, sanctions screening,
+  the lot.
+- **Bob → 20/30.** The `ceo-only` traces are gone; a red **"10 traces hidden by
+  RLS policy"** banner appears. **Expand it** — each hidden trace shows *which
+  rule* denied it.
+- **Carol → 10/30.** Only `general` traffic — churn analysis, credit-risk
+  summaries.
+
+Point at a visible trace card: classification and team badges, the actual
+prompt/response, and the **matched rule name** on the card.
+
+**Land.** "One project, one dataset, three views — and every allow/deny is
+*explainable*: the trace tells you which policy matched. That's the shape of the
+requirement. What you just saw is the behavior a native implementation should
+produce; here it's simulated so you can react to it."
+
+**Ask.** "Map your teams onto these three personas — who's your Alice, your Bob,
+your Carol? And is clearance the right axis for you, or is it team, region,
+customer, something else?"
+
+---
+
+## Act 2 · The policy model (2 min)
+
+**Frame.** Access control demos are easy to fake with an `if` statement. What
+makes this useful is that the policy model underneath is one you could defend to
+a security review.
+
+**Show.** The **Policies** tab: two rules —
+`allow-clearance-ge-classification` and `deny-default` — a clearance-rank table,
+and a live-computed **persona × classification access matrix**.
+
+Tell the design story: "An earlier revision had a third rule — *allow if same
+team*. We **removed** it, because it let a general-clearance analyst read
+`ceo-only` traces just because their team produced them. The model is now:
+**clearance is a hard ceiling; team can only narrow access, never widen it** —
+and anything without a matching allow rule is denied by default."
+
+**Land.** "That's attribute-based access control: subject attributes (clearance,
+team) evaluated against row attributes (classification, owner). It's the same
+model your other governed data stores use — which is exactly why it belongs at
+the platform layer, not in every app team's code."
+
+**Ask.** "Who would own these policies in your org — security, platform, each
+team? And what attributes would the real rules need — clearance, geography,
+customer tenant?"
+
+---
+
+## Act 3 · The honest architecture conversation (3–4 min)
+
+**Frame.** Now the part that makes this consultative instead of a magic trick:
+where this enforcement *actually runs*, and why that's not good enough for
+production.
+
+**Show.** The **Design** tab (`/design`). Walk three things:
+
+1. **The sequence diagram** — the app fetches *all* traces from the Langfuse API
+   server-side, filters in the app, returns the subset. Say it plainly: "the
+   filter runs *after* the data leaves the store. Anyone with the Langfuse API
+   key bypasses it entirely, and it degrades linearly with trace volume."
+2. **The gap analysis table** — app-layer enforcement, no push-down, no audit
+   log, exports not covered. "We wrote the holes down so nobody discovers them
+   for us."
+3. **The three horizons** — short term: separate projects per sensitivity tier
+   (works today); medium term: a filtering proxy like this one (bypassable,
+   doesn't scale); long term: **native RLS, enforced as a `WHERE` clause pushed
+   down into ClickHouse** so unauthorized rows never leave the database.
+
+**Land.** "The end-state is a ClickHouse story: Langfuse traces already live in
+ClickHouse, so row policies belong where the rows are — evaluated in the
+database, at query time, at analytical scale. This prototype is the requirements
+spec for that conversation, and your input sharpens it."
+
+**Ask.** "If native RLS landed, what would your policy actually look like — and
+what would you need alongside it: audit logs of denied access, export controls,
+per-tenant keys? What's the minimum that unblocks you?"
+
+---
+
+## Close · What to leave them with (1 min)
+
+Three sentences: **the gap is real** (roles ≠ row visibility, and traces are
+sensitive); **the requirement now has a concrete shape** (this mock, plus the
+design doc with the gaps named); **the path runs through ClickHouse** (native
+enforcement, push-down, one governed store for traces and analytics). The repo
+is public — the app, the policy engine, the seed data, and the full design doc
+are all in `demos/langfuse-rls/`; the `/design` page *is* the leave-behind.
+
+---
+
+## Under the hood — the whole mechanism (for the "show me" moment)
+
+The enforcement is deliberately small — that's the point; it's a spec, not a product.
+
+**1 · The one real gate — `lib/rls-policy.ts`**
+```ts
+// lib/rls-policy.ts:4   clearance is an ordered ladder
+const CLEARANCE_RANK = { "ceo-only": 2, "restricted": 1, "general": 0 };
+// lib/rls-policy.ts:17  evaluate(): allow iff subject clearance >= row classification,
+// no-metadata rows are public, everything else falls through to deny-default
+```
+*Why it matters:* the entire policy engine is a rank comparison plus
+default-deny — easy to review, easy to argue about, easy to hand to Langfuse
+engineering as a spec.
+
+**2 · The enforcement point (and the problem with it) — `app/api/traces/route.ts:11`**
+```ts
+const traces   = await listTraces();                 // fetch ALL traces from the Langfuse API
+const evaluated = evaluateBatch(persona, traces);    // filter in-process
+const visible   = evaluated.filter((t) => t._rls.allow);
+```
+*Why it matters:* this is the exact line that should not exist in a native
+implementation — it would become a `WHERE` clause evaluated inside ClickHouse
+before any row leaves the store.
+
+**3 · Subjects are attributes, not special cases — `lib/personas.ts:3`**
+```ts
+{ id: "alice", team: "executive",  clearance: "ceo-only"   },
+{ id: "bob",   team: "compliance", clearance: "restricted" },
+{ id: "carol", team: "analyst",    clearance: "general"    },
+```
+*Why it matters:* swap these for your customer's real teams/attributes and the
+demo becomes *their* requirement in ten minutes.
+
+**4 · The data path — `lib/langfuse-client.ts:44`**
+```ts
+// paginated fetch of ${host}/api/public/traces with Basic auth (pk:sk), 60s cache
+```
+*Why it matters:* everything rides the public Langfuse API — no forked Langfuse,
+no direct ClickHouse access. The prototype changes nothing about the stack it
+critiques.
+
+---
+
+## Talking points & objections
+
+- **"So Langfuse can do this?"** No — and say so before they ask. Native Langfuse
+  RBAC is role-based per project; all members see all traces. This simulates the
+  *proposed* row-level behavior. That candor is what makes the rest credible.
+- **"Can't we just use this proxy in production?"** Not as-is: it's bypassable by
+  anyone holding the API keys, it fetches everything and filters in the app, and
+  there's no audit trail. It's a requirements artifact, not a control.
+- **"What do we do *today*?"** Separate Langfuse projects per sensitivity tier —
+  real isolation now, at the cost of fragmented analytics and duplicated ops.
+  Self-hosting keeps all tiers in your own tenant either way.
+- **"Why is ClickHouse the answer here?"** Traces are stored in ClickHouse
+  already; row policies enforced at the database mean unauthorized rows never
+  leave the store, the same policy governs UI and API, and it holds up at
+  analytical scale — none of which an app-layer filter can promise.
+- **"Is anyone actually asking for this?"** Yes — this prototype exists because a
+  global bank flagged trace-level access control as a blocker, and Langfuse
+  engineering pointed to attribute-based RBAC/RLS as the long-term direction.
+  Customer requirements with concrete specs are what move that roadmap.
+
+---
+
+## Reset / re-run
+
+```bash
+npm run seed          # re-push the 30 fixture traces (idempotent for the demo's purposes)
+npm run dev           # app on :3000
+bash scripts/verify.sh   # trace count + classification distribution via langfuse-cli
+```
+
+If the app shows an empty state, Langfuse isn't reachable on `:3001` or the
+`.env` keys are wrong — fix `.env`, reseed, refresh.

--- a/demos/text-to-sql/DEMO_SCRIPT.md
+++ b/demos/text-to-sql/DEMO_SCRIPT.md
@@ -242,8 +242,10 @@ docker compose --profile tools run --rm test-scenarios
 
 In Langfuse, filter Traces by tag `test-scenario`: scenarios tagged
 `relevance-test` / `hallucination-test` / `control` get scored by the managed
-**Relevance / Correctness / Hallucination** judges (configured once in the UI,
-no app code). The deliberately-bad scenarios score low — the judges *catch* them.
+**Relevance / Correctness / Hallucination** judges (provisioned once — in this
+self-hosted stack by `scripts/seed-llm-judge-evaluators.sh`, or in the
+Evaluators UI on Langfuse Cloud — no app code either way). The
+deliberately-bad scenarios score low — the judges *catch* them.
 
 **Land.** "Two layers, deliberately: deterministic code for the mechanical
 policies at 100% coverage, LLM judges for the semantic questions on a sample.

--- a/demos/text-to-sql/DEMO_SCRIPT.md
+++ b/demos/text-to-sql/DEMO_SCRIPT.md
@@ -1,0 +1,371 @@
+# Text-to-SQL — Demo Script (guardrails + prompt deploys on a data assistant)
+
+A ready-to-run demo of a **natural-language data assistant** over ClickHouse's
+public datasets (via MCP), built on LangChain and fully traced to **Langfuse**.
+Its two signature beats: a **deterministic SQL-safety guardrail** that scores
+every response at ingest, and **prompt management** — the pipeline's two prompts
+live in Langfuse and ship by label, no redeploy.
+
+- **App:** a two-stage LangChain pipeline (`analyze → retrieve context → respond`),
+  CLI batch + interactive modes (container in the root `docker-compose.yaml`)
+- **Data context:** the ClickHouse public playground (`sql.clickhouse.com`,
+  24-dataset catalog) reached through the **`mcp-clickhouse`** server
+- **Observability backend:** Langfuse (`http://localhost:3001`), trace name `text-to-sql`
+- **Model:** `claude-sonnet-4-6` (both stages)
+- **Run length:** 12–15 min full; ~5 min short path (Acts 1–2)
+
+> The pipeline, config, and instrumentation live in `demos/text-to-sql/`; the
+> guardrail is `evaluators/sql-safety-guard.ts`, seeded into Langfuse by
+> `scripts/seed-code-evaluators.sh`. For the loop framing shared by all the
+> demos, see [`../../AI_ENGINEERING_LOOP.md`](../../AI_ENGINEERING_LOOP.md).
+
+> **Honesty note (know this before you present):** the pipeline *reasons over*
+> the dataset catalog and often drafts SQL in its answers, but it does **not
+> execute** queries against ClickHouse — the MCP step retrieves the database
+> catalog as context. There is also **no HTTP endpoint**; port 8002 is mapped but
+> nothing listens. Demo it as what it is: a traced NL-analysis assistant with a
+> SQL-policy guardrail. If asked "does it run the SQL?" — "not in this demo; the
+> guardrail is exactly the layer you'd want *before* you let it."
+
+---
+
+## How to run this script
+
+It's written to be a **conversation, not a walkthrough**. Every act does three
+things: it **frames** a problem the audience already has, **shows** how the
+platform answers it, and **lands** the benefit — then hands a **question** back to
+the room. So each act carries four beats:
+
+- **Frame** — the problem, in their terms (say this *before* you touch the screen).
+- **Show** — the exact clicks / commands.
+- **Land** — the "so what": the benefit, not the feature.
+- **Ask** — an open question that invites them to map it to their own world.
+
+Don't rush the **Ask** — the answers tell you which acts to go deep on. The short
+path is Acts 1–2; add Acts 3–4 when there's appetite.
+
+---
+
+## 0 · Pre-flight (do this BEFORE the meeting)
+
+```bash
+# CRITICAL: clear leaked Langfuse keys — exported shell vars override .env and 401 silently.
+unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY
+
+# Stack up (Langfuse + mcp-clickhouse), .env needs ANTHROPIC_API_KEY + Langfuse keys
+docker compose --profile langfuse up -d
+docker compose --profile demo build text-to-sql
+
+# Seed the managed prompts (NOT covered by setup.sh — the Deploy act needs this)
+python scripts/seed-app-prompts.py
+
+# Seed the code evaluators (setup.sh does this; run it if scores are missing)
+./scripts/seed-code-evaluators.sh
+
+# Generate fresh traces (10 questions, ~2 min; scores land ~30s after)
+docker compose run --rm text-to-sql python main.py
+```
+
+**Browser tabs ready:** Langfuse Traces filtered to name `text-to-sql`
+(`:3001`, `demo@example.com` / `demodemo1!`), the **Prompts** tab, and a
+terminal for the interactive guardrail moment in Act 2.
+
+---
+
+## What each act proves
+
+| Capability | Where in the demo |
+|---|---|
+| **Tracing a multi-stage LangChain pipeline** (2 generations + a manual span) | Act 1 — `query_analysis` → `retrieve-context` → `response_generation` |
+| **Token usage + cost per stage** | Act 1 — click either generation |
+| **MCP tool step traced next to LLM steps** | Act 1 — the `retrieve-context` span |
+| **Deterministic guardrail scores on 100% of traffic** | Act 2 — `sql-risk`, `sql-read-only`, `credential-leak` |
+| **Evals catch a policy violation live** | Act 2 — ask for a DELETE, watch `sql-risk = destructive` |
+| **Prompt management** (versioned, fetched by label, linked to generations) | Act 3 — `text-to-sql-analysis` / `-response` |
+| **Ship a prompt change with no redeploy** | Act 3 — edit → re-run → new version on the trace |
+| **LLM-as-a-Judge at stack level** (test scenarios) | Act 4 — 40 tagged scenarios scored by managed judges |
+
+---
+
+## Opening · Locate the pain (2 min, no screen yet)
+
+**Frame.** Every data team is being asked for the same feature right now: *"let
+people ask questions in English."* The two things that keep it from shipping are
+trust problems, not model problems. One: **what SQL is the model writing against
+your warehouse** — is anything checking it's read-only, bounded, sane? Two: the
+behavior lives in prompts, and **every prompt tweak is a code deploy**, so the
+thing you tune most ships the slowest.
+
+**Ask (these steer the session):**
+- "Is anyone here building — or being asked for — a natural-language interface
+  over your data? What's blocking it from production?"
+- "If an LLM writes SQL in your environment today, what stands between it and a
+  `DROP TABLE`?"
+- "When you tweak a prompt, what does shipping that look like — PR, review,
+  deploy? How long?"
+
+**Land.** "Small demo, two sharp answers: a **policy check that scores every
+response the moment it's ingested** — for free, no LLM judge needed — and
+**prompts that ship by label** instead of by deploy. Both on a pipeline you can
+read in one file."
+
+---
+
+## Act 1 · One question, whole pipeline (4 min)
+
+**Frame.** An NL-over-data answer is never one LLM call — it's *understand the
+question → figure out what data applies → compose the answer*. When it's wrong,
+you need to know which stage lied.
+
+**Show.** Run the batch (or one question in `--interactive`):
+
+```bash
+docker compose run --rm text-to-sql python main.py
+```
+
+Questions like *"What are the most expensive areas for property in London?"*
+stream by. In Langfuse → **Traces**, open the newest `text-to-sql` trace
+(tags `text-to-sql`, `demo`) and walk it top → bottom:
+
+- **Generation 1** — metadata `purpose: query_analysis`: the model decides which
+  of the 24 public datasets answer the question (`uk`, `nyc_taxi`,
+  `stackoverflow`, …).
+- **`retrieve-context`** — a plain span around the **MCP call** to
+  `mcp-clickhouse`: the live database catalog fetched as context. Non-LLM steps
+  sit in the same tree as LLM steps.
+- **Generation 2** — `purpose: response_generation`: the final answer, composed
+  from question + analysis + context.
+- Click either generation → **token usage, cost, latency, model** — and the
+  **Prompt** panel showing which prompt version produced it (that's Act 3's
+  setup — point at it now, cash it in later).
+
+**Land.** "Three steps, one trace, each with its own cost and its own
+input/output. When an answer is off, you can see *which stage* drifted — the
+dataset choice or the composition — instead of rereading one blob of logs. And
+the MCP step proves this isn't LLM-only tracing: tool calls land in the same
+tree."
+
+**Ask.** "How many stages would your version of this have — schema lookup,
+generation, execution, formatting? Can you see them separately today?"
+
+> **Fallback:** if `retrieve-context` shows `[MCP unavailable: …]`, the pipeline
+> still answered — graceful degradation is itself worth ten seconds of stage
+> time. Check `mcp-clickhouse` is up afterwards.
+
+---
+
+## Act 2 · The SQL safety net (4 min) — the money moment
+
+**Frame.** You cannot put an LLM near a warehouse on vibes. But you also can't
+afford an LLM judge on 100% of traffic just to check a policy that's mechanical:
+*read-only, bounded, no secrets*. Mechanical policies deserve mechanical
+enforcement — deterministic code, every trace, zero marginal cost.
+
+**Show.** On the trace from Act 1, open **Scores**. Every generation carries:
+
+- `sql-present` / `sql-read-only` / **`sql-risk`** (categorical:
+  `safe` / `missing-limit` / `destructive` / `no-sql`) — from the
+  `sql-safety-guard` code evaluator
+- `credential-leak` / `leak-type` — from `credential-leak-guard`, scanning for
+  key-shaped strings (`sk-…`, `AKIA…`, connection strings) on **every** app in
+  the stack
+- `output-present` / `structure-clean` / `response-length` — structural checks
+  (truncation, leaked `{placeholders}`, broken code fences)
+
+Now trip the guardrail live:
+
+```bash
+docker compose run --rm text-to-sql python main.py --interactive
+# then ask:  Write a query to delete all old taxi trips
+```
+
+~30 seconds later, refresh the trace: **`sql-risk = destructive`**,
+`sql-read-only = false`, with a comment quoting the offending statement. Filter
+the Traces list by that score — that's your standing "SQL policy violations"
+view, ready to alert on.
+
+**Land.** "That check is a small TypeScript function running inside Langfuse at
+ingest — deterministic, free, on 100% of traffic, typically scored within 30
+seconds. Nobody eyeballs screenshots; the policy is *enforced as data* you can
+filter, chart, and page on. And because it's code, your security team can read
+exactly what it checks."
+
+**Ask.** "What's your SQL policy in one sentence — read-only? row limits?
+schema allowlist? Who owns it, and where is it written down today?"
+
+---
+
+## Act 3 · Ship a prompt without a deploy (3 min)
+
+**Frame.** Both stages of this pipeline are driven by prompts — and prompts are
+the highest-churn artifact in any LLM app. If changing one means a code deploy,
+iteration speed is capped by your release train.
+
+**Show.** **Prompts** tab → `text-to-sql-analysis` and `text-to-sql-response`,
+each with a `production` label. The app fetches them **by label at startup**,
+with a hard-coded fallback so a fresh clone still runs.
+
+Edit `text-to-sql-response` in the UI — something visible, e.g. *"End every
+answer with one suggested follow-up question."* — save as a new version, move
+the `production` label to it. Re-run:
+
+```bash
+docker compose run --rm text-to-sql python main.py
+```
+
+The behavior changes, and on the new trace the generation links to **v2** of the
+prompt — quality, cost, and version travel together.
+
+**Land.** "The prompt is data, not code. Promote a label and the next run serves
+it — no image rebuild, no deploy, and a version-stamped audit trail on every
+generation. Gate that promotion behind an eval run in CI and you've got a
+release process for prompts; the reference pipeline for that lives in this
+repo's real-estate demo (`demos/real-estate/cicd/`)."
+
+**Ask.** "Who should be *allowed* to change a prompt in your org — only
+engineers? Would a PM ship prompt changes if it didn't need a deploy?"
+
+---
+
+## Act 4 · Optional — judges at stack level (3 min)
+
+**Frame.** Regex catches policy violations; it can't tell you an answer was
+*irrelevant* or *hallucinated*. That's the LLM-as-a-Judge layer — shown here on
+the stack's evaluation harness rather than live traffic.
+
+**Show.** Run the 40 synthetic test scenarios and let the managed judges score
+them:
+
+```bash
+docker compose --profile tools run --rm test-scenarios
+```
+
+In Langfuse, filter Traces by tag `test-scenario`: scenarios tagged
+`relevance-test` / `hallucination-test` / `control` get scored by the managed
+**Relevance / Correctness / Hallucination** judges (configured once in the UI,
+no app code). The deliberately-bad scenarios score low — the judges *catch* them.
+
+**Land.** "Two layers, deliberately: deterministic code for the mechanical
+policies at 100% coverage, LLM judges for the semantic questions on a sample.
+The judges here are scoped to the test harness; pointing one at live
+`text-to-sql` traffic is a two-minute change in the Evaluators UI."
+
+**Ask.** "For your data assistant, what would 'wrong' mean — wrong table, stale
+number, made-up column? Which of those are mechanical checks, and which need a
+judge?"
+
+---
+
+## Close (1 min)
+
+Three takeaways: **every stage of the pipeline is visible** (LLM and tool steps
+alike, with cost); **policy is enforced as free deterministic scores** on all
+traffic — the SQL guardrail went red live; **prompts ship by label**, not by
+deploy. Then hand them the asset: the repo is public — the pipeline is
+`demos/text-to-sql/` (about three files), the guardrail is ~100 lines of
+TypeScript in `evaluators/`. "Clone it, swap the catalog for your schema, and
+the guardrail for your policy."
+
+---
+
+## Under the hood — how it's instrumented (for the "show me the code" moment)
+
+Everything lives in `demos/text-to-sql/`; the guardrail in `evaluators/`. The
+integration is deliberately the *low-touch* end of the spectrum — LangChain's
+callback does the heavy lifting (contrast `demos/real-estate/`, which hand-builds
+its trace tree).
+
+**1 · Zero-config client, graceful when keys are absent — `langfuse_config.py`**
+```python
+# langfuse_config.py:16   tracing turns on only when both keys exist
+LANGFUSE_ENABLED = bool(os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY"))
+# langfuse_config.py:38   v3 client straight from env
+from langfuse import get_client
+client = get_client()
+```
+*Why it matters:* no keys → the app still runs, just untraced. Every wrapper in
+this file degrades to a no-op on error — tracing can never take the app down.
+
+**2 · One callback instruments both chains — `langfuse_config.py:163`**
+```python
+from langfuse.langchain import CallbackHandler
+handler = CallbackHandler()          # passed as config={"callbacks": [handler]}
+```
+*Why it matters:* the two generations in Act 1 cost zero instrumentation code —
+the LangChain integration emits them, with model, usage, and cost attached.
+
+**3 · Trace name + tags by context propagation — `langfuse_config.py:120`**
+```python
+with propagate_attributes(trace_name="text-to-sql", tags=["text-to-sql", "demo"]):
+    ...   # everything invoked inside lands on one named, tagged trace
+```
+
+**4 · A manual span for the non-LangChain step — `sql_pipeline.py:118`**
+```python
+with langfuse_span("retrieve-context"):          # langfuse_config.py:143
+    context = self.mcp.get_context_for_question(question)
+```
+*Why it matters:* the MCP call isn't a LangChain runnable, so it gets a plain
+SDK span — auto and manual instrumentation compose in one tree.
+
+**5 · Prompt fetched by label, linked to the generation — `sql_pipeline.py:21`**
+```python
+lf_prompt = get_managed_prompt(name)              # get_prompt(name, label="production")  :62
+tmpl = ChatPromptTemplate.from_template(lf_prompt.get_langchain_prompt())
+tmpl.metadata = {"langfuse_prompt": lf_prompt}    # THIS line links version → generation
+```
+*Why it matters:* that one metadata assignment is the whole Act 3 story — the
+callback sees it and stamps the prompt version on every generation.
+
+**6 · The guardrail itself — `evaluators/sql-safety-guard.ts`**
+```ts
+// :55  destructive statements → sql-risk = "destructive"
+/\b(DROP|DELETE|TRUNCATE|ALTER|INSERT|UPDATE|GRANT|REVOKE|...)\b/i
+// :82  SELECT without LIMIT → "missing-limit"
+```
+*Why it matters:* the Act 2 money moment is ~100 lines of reviewable TypeScript
+running inside Langfuse at ingest — no service to run, no LLM to pay.
+
+> One-liner for the room: *"One callback handler, one manual span, one metadata
+> line for prompt-linking — and the guardrail is a TypeScript function inside
+> Langfuse. That's the whole integration."*
+
+---
+
+## Talking points & objections
+
+- **"Does it actually execute the SQL?"** Not in this demo — it reasons over the
+  live catalog (via MCP) and drafts SQL in its answers. That's deliberate for a
+  public-playground demo; the guardrail is the layer you'd require *before*
+  execution, and it's already scoring every response.
+- **"Regex for SQL safety — really?"** For the mechanical policy, yes — it's
+  deterministic, auditable, free, and runs on everything. It's a *layer*, not
+  the whole answer: semantic quality is the judges' job (Act 4), and real
+  execution would add a parser-based check. Defense in depth, cheapest layer
+  first.
+- **"Why is there no `user_id`/session on these traces?"** The batch demo
+  doesn't set them; the SDK plumbing is present (`langfuse_config.py`). The
+  real-estate and agentic-rag demos show sessions/users fully wired.
+- **"Can the judges score live traffic, not just test scenarios?"** Yes — the
+  managed judges are scoped by tag/trace-name filters; pointing one at
+  `text-to-sql` is a UI change. They're scoped to the test harness here to keep
+  the demo's costs deterministic.
+- **"What's MCP buying us?"** A standard way to hand tools (here: the ClickHouse
+  catalog) to any client — the same `mcp-clickhouse` server also powers the
+  LibreChat agents in this stack. And the span proves tool calls trace like
+  everything else.
+- **"Where does the trace data live?"** Langfuse stores it in **ClickHouse** —
+  which is why score filters and dashboards stay fast, and why your traces sit
+  in an engine you can also query directly with SQL.
+
+---
+
+## Reset / re-run
+
+```bash
+docker compose run --rm text-to-sql python main.py                # fresh traces (scores ~30s later)
+docker compose run --rm text-to-sql python main.py --interactive # guardrail money moment
+python scripts/seed-app-prompts.py                                # re-seed prompts (idempotent)
+./scripts/seed-code-evaluators.sh                                 # re-seed evaluators
+./scripts/seed-demo-data.sh                                       # full seed (text-to-sql + vector-rag + scenarios)
+```

--- a/demos/text-to-sql/DEMO_SCRIPT.md
+++ b/demos/text-to-sql/DEMO_SCRIPT.md
@@ -8,8 +8,9 @@ live in Langfuse and ship by label, no redeploy.
 
 - **App:** a two-stage LangChain pipeline (`analyze → retrieve context → respond`),
   CLI batch + interactive modes (container in the root `docker-compose.yaml`)
-- **Data context:** the ClickHouse public playground (`sql.clickhouse.com`,
-  24-dataset catalog) reached through the **`mcp-clickhouse`** server
+- **Data context:** the ClickHouse public playground (`sql.clickhouse.com`) —
+  a 24-dataset catalog the analysis stage reasons over, plus live context
+  fetched through the **`mcp-clickhouse`** server
 - **Observability backend:** Langfuse (`http://localhost:3001`), trace name `text-to-sql`
 - **Model:** `claude-sonnet-4-6` (both stages)
 - **Run length:** 12–15 min full; ~5 min short path (Acts 1–2)
@@ -241,7 +242,7 @@ docker compose --profile tools run --rm test-scenarios
 ```
 
 In Langfuse, filter Traces by tag `test-scenario`: scenarios tagged
-`relevance-test` / `hallucination-test` / `control` get scored by the managed
+`relevance-test` / `coherence-test` / `hallucination-test` / `control` get scored by the managed
 **Relevance / Correctness / Hallucination** judges (provisioned once — in this
 self-hosted stack by `scripts/seed-llm-judge-evaluators.sh`, or in the
 Evaluators UI on Langfuse Cloud — no app code either way). The
@@ -305,7 +306,7 @@ with propagate_attributes(trace_name="text-to-sql", tags=["text-to-sql", "demo"]
 **4 · A manual span for the non-LangChain step — `sql_pipeline.py:118`**
 ```python
 with langfuse_span("retrieve-context"):          # langfuse_config.py:143
-    context = self.mcp.get_context_for_question(question)
+    self._context = mcp.get_context_for_question(question, analysis)
 ```
 *Why it matters:* the MCP call isn't a LangChain runnable, so it gets a plain
 SDK span — auto and manual instrumentation compose in one tree.

--- a/demos/vector-rag/DEMO_SCRIPT.md
+++ b/demos/vector-rag/DEMO_SCRIPT.md
@@ -7,7 +7,7 @@ deliberately the *naive baseline*: the shape most teams' first RAG takes. Use it
 to teach the fundamentals in fifteen minutes, and to set up the pivot to the
 self-correcting [`agentic-rag`](../agentic-rag/DEMO_SCRIPT.md) demo.
 
-- **App:** embed → retrieve (top-3) → generate, over a 9-document knowledge base
+- **App:** embed → retrieve (top-3) → generate, over a 10-document knowledge base
   (ClickHouse & LLM-observability topics), CLI batch + interactive
 - **Vector store:** ChromaDB **in-process** (re-indexed each run — zero extra infra)
 - **Models:** `all-MiniLM-L6-v2` embeddings (local, CPU) + `claude-sonnet-4-6`
@@ -109,7 +109,7 @@ watch what the *minimum* integration — one callback handler — buys.
 docker compose --profile demo run --rm vector-rag python main.py
 ```
 
-It indexes the 9-doc corpus (watch `Indexed N chunks from 9 documents` — chunked
+It indexes the 10-doc corpus (watch `Indexed N chunks from 10 documents` — chunked
 at 500 chars, embedded locally, in-memory), then answers 10 questions like
 *"How does ClickHouse handle high-cardinality data?"* and *"What are vector
 embeddings and how are they used?"*.
@@ -307,7 +307,7 @@ LANGFUSE_ENABLED = bool(PUBLIC_KEY and SECRET_KEY)   # no keys → app runs untr
 ## Talking points & objections
 
 - **"ChromaDB in production?"** Here it's the deliberately-simple choice: in-
-  process, re-indexed per run, zero infra — right for a 9-doc teaching demo. The
+  process, re-indexed per run, zero infra — right for a 10-doc teaching demo. The
   production-shaped answer is the agentic-rag demo: **ClickHouse-native HNSW**,
   where vectors live in the same engine as your analytics and your traces, and
   hybrid vector+SQL+text queries are one statement.

--- a/demos/vector-rag/DEMO_SCRIPT.md
+++ b/demos/vector-rag/DEMO_SCRIPT.md
@@ -259,7 +259,7 @@ and `demos/real-estate/agent/` (fully manual tree).
 
 **1 · Managed prompt with fallback + version linking — `rag_pipeline.py:26`**
 ```python
-lf_prompt = get_managed_prompt("vector-rag-generation")   # get_prompt(name, label="production")
+lf_prompt = get_managed_prompt(name)   # name="vector-rag-generation" at the :117 call site; label="production"
 tmpl = ChatPromptTemplate.from_template(lf_prompt.get_langchain_prompt())
 tmpl.metadata = {"langfuse_prompt": lf_prompt}   # THIS links prompt version → generation
 ```

--- a/demos/vector-rag/DEMO_SCRIPT.md
+++ b/demos/vector-rag/DEMO_SCRIPT.md
@@ -1,0 +1,345 @@
+# Vector RAG — Demo Script (the honest baseline: naive RAG, fully traced)
+
+A ready-to-run demo of a **textbook single-shot RAG pipeline** — ChromaDB
+in-process, LangChain, Claude — fully traced to **Langfuse**, with its
+generation prompt **managed in Langfuse and shipped by label**. This is
+deliberately the *naive baseline*: the shape most teams' first RAG takes. Use it
+to teach the fundamentals in fifteen minutes, and to set up the pivot to the
+self-correcting [`agentic-rag`](../agentic-rag/DEMO_SCRIPT.md) demo.
+
+- **App:** embed → retrieve (top-3) → generate, over a 9-document knowledge base
+  (ClickHouse & LLM-observability topics), CLI batch + interactive
+- **Vector store:** ChromaDB **in-process** (re-indexed each run — zero extra infra)
+- **Models:** `all-MiniLM-L6-v2` embeddings (local, CPU) + `claude-sonnet-4-6`
+- **Observability backend:** Langfuse (`http://localhost:3001`), trace name `vector-rag`
+- **Run length:** 10–12 min full; ~5 min short path (Acts 1–2)
+
+> Positioning in one line: **this demo is where RAG conversations start; the
+> agentic-rag demo is where they end.** If the audience is already past "what is
+> RAG," skip straight to [`../agentic-rag/DEMO_SCRIPT.md`](../agentic-rag/DEMO_SCRIPT.md).
+
+---
+
+## How to run this script
+
+It's written to be a **conversation, not a walkthrough**. Every act does three
+things: it **frames** a problem the audience already has, **shows** how the
+platform answers it, and **lands** the benefit — then hands a **question** back to
+the room. So each act carries four beats:
+
+- **Frame** — the problem, in their terms (say this *before* you touch the screen).
+- **Show** — the exact clicks / commands.
+- **Land** — the "so what": the benefit, not the feature.
+- **Ask** — an open question that invites them to map it to their own world.
+
+The short path is Acts 1–2. Act 4 is the designed hand-off to agentic-rag —
+if that demo is on the agenda, treat this whole script as its opening act.
+
+---
+
+## 0 · Pre-flight (do this BEFORE the meeting)
+
+```bash
+# CRITICAL: clear leaked Langfuse keys — exported shell vars override .env and 401 silently.
+unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY
+
+# Stack up; .env needs ANTHROPIC_API_KEY + Langfuse keys
+docker compose --profile langfuse up -d
+docker compose --profile demo build vector-rag
+
+# Seed the managed prompt (NOT covered by setup.sh — Act 2 needs this)
+python scripts/seed-app-prompts.py
+
+# Seed code evaluators if scores are missing (setup.sh normally does this)
+./scripts/seed-code-evaluators.sh
+
+# Fresh traces (10 questions; FIRST run also downloads the embedding model — do it now, not live)
+docker compose --profile demo run --rm vector-rag python main.py
+```
+
+**Browser tabs ready:** Langfuse Traces filtered to name `vector-rag` (`:3001`,
+`demo@example.com` / `demodemo1!`), the **Prompts** tab open on
+`vector-rag-generation`, and a terminal for interactive mode.
+
+---
+
+## What each act proves
+
+| Capability | Where in the demo |
+|---|---|
+| **RAG pipeline traced end-to-end** (LangChain auto-instrumentation) | Act 1 — the `vector-rag` trace |
+| **Token usage + cost per answer** | Act 1 — click the generation |
+| **Prompt management** (fetch by label, fallback, version linked) | Act 2 — `vector-rag-generation` |
+| **Ship a prompt change with no redeploy** | Act 2 — edit → re-run → v2 on the trace |
+| **Structural + credential guardrails on every generation** | Act 3 — `structure-clean`, `credential-leak` |
+| **The limits of naive RAG** (and why they're invisible without evals) | Act 4 — out-of-corpus question + the gap list |
+
+---
+
+## Opening · Locate the pain (2 min, no screen yet)
+
+**Frame.** Every team's first RAG looks like this app: one vector lookup, stuff
+the chunks into a prompt, answer. It demos brilliantly and ships fast. The
+problems arrive later, and they're all *visibility* problems: you can't see what
+was retrieved, you can't measure whether answers stayed grounded, and the prompt
+you tune weekly is hardcoded next to the business logic.
+
+**Ask (these steer the session):**
+- "Where is your team on RAG — evaluating, prototype, production?"
+- "For the RAG you have: can you see what the retriever actually returned for a
+  given bad answer?"
+- "How do you change your RAG prompt today, and how do you know the change
+  helped?"
+
+**Land.** "I'll show the baseline honestly — a naive pipeline, instrumented the
+cheap way — what that buys you (full traces, cost, managed prompts, free
+guardrails), and exactly where it runs out of road. Then, if you want, the
+self-correcting version that fixes what this one can't."
+
+---
+
+## Act 1 · The pipeline on glass (3 min)
+
+**Frame.** Instrumentation effort is the first objection to observability. So
+watch what the *minimum* integration — one callback handler — buys.
+
+**Show.** Run it:
+
+```bash
+docker compose --profile demo run --rm vector-rag python main.py
+```
+
+It indexes the 9-doc corpus (watch `Indexed N chunks from 9 documents` — chunked
+at 500 chars, embedded locally, in-memory), then answers 10 questions like
+*"How does ClickHouse handle high-cardinality data?"* and *"What are vector
+embeddings and how are they used?"*.
+
+In Langfuse → **Traces**, open a `vector-rag` trace (tags `vector-rag`, `demo`):
+
+- The LangChain chain appears automatically — prompt template → **ChatAnthropic
+  generation** → output parser, with metadata `purpose: rag_generation`.
+- Click the generation: **input shows the retrieved context** (three chunks,
+  `---`-separated, each traceable to its source doc by title) above the
+  question; output is the answer; **tokens, cost, latency, model** on the right.
+- Point at the **Prompt** panel: the generation is stamped with the exact
+  version of `vector-rag-generation` that produced it — Act 2's setup.
+
+**Land.** "One callback handler in the code — that's the integration — and every
+answer is inspectable: what context the model was given, what it cost, which
+prompt version shaped it. When someone reports a bad answer, you open the trace
+and read the actual chunks instead of guessing what the retriever did."
+
+**Ask.** "Today, when your RAG answers wrong, can you reconstruct what the model
+actually saw? How long does that take?"
+
+> **Presenter note — one honest limitation, said out loud:** the retrieval call
+> here happens *outside* the instrumented chain, so it isn't a first-class span —
+> you see its *output* (the context in the generation input), not a timed,
+> scored retrieval step. That's typical of minimum-effort instrumentation, and
+> it's the first thing the agentic-rag demo fixes (typed `retriever` spans,
+> graded and scored). Naming this yourself builds more trust than hoping nobody
+> asks.
+
+---
+
+## Act 2 · Ship a prompt without a deploy (4 min) — the money moment
+
+**Frame.** The prompt is the most-tuned artifact in any RAG system — grounding
+rules, tone, format, refusal behavior all live there. In most stacks it's a
+string in the repo, so every tweak rides the release train.
+
+**Show.** **Prompts** tab → `vector-rag-generation`, label `production`. The app
+fetches it by label at startup and falls back to an identical inline template if
+Langfuse is unreachable — a fresh clone always runs.
+
+Edit it live in the UI — a visible change, e.g. add *"Answer in exactly three
+bullet points."* — save as v2, move the `production` label. Re-run:
+
+```bash
+docker compose --profile demo run --rm vector-rag python main.py
+```
+
+Answers restructure themselves. Open a new trace: the generation now links to
+**v2**. Flip between v1- and v2-linked traces — behavior, cost, and version
+travel together.
+
+**Land.** "No rebuild, no redeploy — promote a label and the next run serves the
+new prompt, and every generation is stamped with the version that produced it.
+That turns 'someone changed the prompt and quality moved' from archaeology into
+a filter. Version-linked traces are also what make prompt A/B tests honest —
+the full compare-and-promote workflow is in this repo's real-estate demo."
+
+**Ask.** "Who tunes your prompts — and how many of their ideas die waiting for a
+deploy window? What would they try this week if shipping one were a label
+promotion?"
+
+---
+
+## Act 3 · Free guardrails on every answer (2 min)
+
+**Frame.** Before you ever pay for an LLM judge, there's a class of quality
+checks that are mechanical: did it answer at all, did it truncate mid-sentence,
+did it leak a template placeholder or a credential? Those should cost nothing
+and run on everything.
+
+**Show.** On any trace, open **Scores**:
+
+- `output-present`, `structure-clean`, `response-length` — from the
+  `response-structure-check` code evaluator (catches empty outputs, unclosed
+  code fences, leaked `{context}` placeholders, mid-sentence truncation)
+- `credential-leak` / `leak-type` — from `credential-leak-guard`, scanning every
+  generation stack-wide for key-shaped strings
+
+These run **inside Langfuse at ingest** — deterministic TypeScript, 100% of
+traffic, typically scored within 30 seconds, no LLM cost.
+
+**Land.** "`response-length` alone gives you drift detection for free — chart it
+and you'll see a bad prompt change or a truncation bug the day it ships.
+Semantic checks (relevance, hallucination) are the LLM-judge layer; adding a
+managed judge scoped to `vector-rag` traces is a two-minute UI change. Cheap
+mechanical layer first, judges where they earn their cost."
+
+**Ask.** "What's your equivalent of `structure-clean` — the mechanical 'this
+answer is broken' signal you wish fired automatically?"
+
+---
+
+## Act 4 · Where naive RAG runs out of road (3 min) — the hand-off
+
+**Frame.** Now the honest part. This pipeline retrieves once and *hopes*. It has
+no idea whether the retrieval was any good — and neither do you, unless you're
+looking.
+
+**Show.** Interactive mode, one out-of-corpus question:
+
+```bash
+docker compose --profile demo run --rm vector-rag python main.py --interactive
+# ask:  How do I configure Kubernetes ingress?
+```
+
+The retriever dutifully returns the three *least-unrelated* chunks — top-k
+always returns k — and the prompt's grounding instruction is the only thing
+standing between those chunks and a confident wrong answer. Open the trace and
+show the mismatched context in the generation input: *"the retrieval failed,
+silently; nothing measured it, nothing retried."*
+
+Name the gaps as a list — each one is an agentic-rag feature: no retrieval
+grading (is this context relevant?), no query rewrite and retry, no groundedness
+check on the answer, no retrieval score to filter or alert on.
+
+**Land.** "That's the ceiling of retrieve-and-stuff: failures are silent and
+per-query. The fix isn't a bigger model — it's a *loop* that grades its own
+retrieval and corrects itself, with each grade logged as a score. That's the
+agentic-rag demo: same stack, ClickHouse-native vectors instead of a bolt-on
+store, and every decision you just couldn't see becomes a scored, graphed step."
+
+**Ask.** "Of those gaps, which one bites you first — silent retrieval misses, or
+not being able to prove groundedness? That tells us where to go next."
+
+---
+
+## Close (1 min)
+
+Three takeaways: **a one-callback integration made the whole pipeline
+inspectable** (context, cost, prompt version per answer); **the prompt ships by
+label**, not by deploy; **free deterministic guardrails score every answer at
+ingest**. And one honest one: naive RAG's failures are silent — which is the
+reason the self-correcting version exists one directory over. The repo is
+public: `demos/vector-rag/` is four small files — clone it, swap
+`documents.py` for your corpus, and it's your prototype.
+
+---
+
+## Under the hood — how it's instrumented (for the "show me the code" moment)
+
+All of it lives in `demos/vector-rag/` — this is the *minimum-effort* end of the
+instrumentation ladder (one callback + context propagation), which is exactly
+its teaching value. Contrast `demos/agentic-rag/graph.py` (typed observations)
+and `demos/real-estate/agent/` (fully manual tree).
+
+**1 · Managed prompt with fallback + version linking — `rag_pipeline.py:26`**
+```python
+lf_prompt = get_managed_prompt("vector-rag-generation")   # get_prompt(name, label="production")
+tmpl = ChatPromptTemplate.from_template(lf_prompt.get_langchain_prompt())
+tmpl.metadata = {"langfuse_prompt": lf_prompt}   # THIS links prompt version → generation
+```
+*Why it matters:* one metadata line is the entire Act 2 story; the identical
+inline fallback (`rag_pipeline.py:118`) is why a fresh clone runs unseeded.
+
+**2 · The chain, tagged with intent — `rag_pipeline.py:133`**
+```python
+(self.response_prompt | self.llm | StrOutputParser())
+    .with_config({"metadata": {"purpose": "rag_generation"}})
+```
+
+**3 · Retrieval: top-3, concatenated — `rag_pipeline.py:137`**
+```python
+docs = self.retriever.invoke(question)                       # Chroma similarity, k=3
+self._context = "\n\n---\n\n".join(d.page_content for d in docs)
+```
+*Why it matters:* note it's invoked *outside* the callback-instrumented chain —
+the Act 1 presenter note, in one line. The context still lands in the trace via
+the generation's input.
+
+**4 · The whole Langfuse integration — `langfuse_config.py:140`**
+```python
+from langfuse.langchain import CallbackHandler
+handler = CallbackHandler()      # passed per-query as callbacks=[handler]
+```
+
+**5 · Trace name + tags by propagation — `langfuse_config.py:120`**
+```python
+with propagate_attributes(trace_name="vector-rag", tags=["vector-rag", "demo"]):
+    ...
+```
+
+**6 · Graceful degradation — `langfuse_config.py:16`**
+```python
+LANGFUSE_ENABLED = bool(PUBLIC_KEY and SECRET_KEY)   # no keys → app runs untraced
+```
+
+> One-liner for the room: *"A callback handler, a context manager for the trace
+> name, and one metadata line to link the prompt version. That's the entire
+> integration — everything you saw fell out of those."*
+
+---
+
+## Talking points & objections
+
+- **"ChromaDB in production?"** Here it's the deliberately-simple choice: in-
+  process, re-indexed per run, zero infra — right for a 9-doc teaching demo. The
+  production-shaped answer is the agentic-rag demo: **ClickHouse-native HNSW**,
+  where vectors live in the same engine as your analytics and your traces, and
+  hybrid vector+SQL+text queries are one statement.
+- **"Where's the retrieval span?"** Named honestly in Act 1: minimum-effort
+  instrumentation traces the chain, and this retriever runs outside it. The
+  context is still captured on the generation. Typed, scored retrieval steps are
+  the agentic-rag demo.
+- **"Can judges score this automatically?"** Yes — managed LLM-as-a-Judge
+  evaluators are scoped by trace name/tags in the UI; the stack's default judges
+  are scoped to its test harness, so add one targeting `vector-rag` (two
+  minutes) to score relevance/hallucination on live traffic.
+- **"Why local embeddings?"** `all-MiniLM-L6-v2` runs on CPU in-container — no
+  embedding API cost or key, and the model caches in a Docker volume after
+  first run. Swap in any embedding endpoint if you'd rather.
+- **"Framework lock-in?"** It's LangChain + the Langfuse callback here, but the
+  sibling demos show the same platform over LangGraph, CrewAI, and plain-Python
+  SDK instrumentation. The traces land the same either way.
+- **"Where does trace data live?"** Langfuse stores it in **ClickHouse** — fast
+  score filters and dashboards, and your traces sit in an engine you can query
+  with SQL yourself.
+
+---
+
+## Reset / re-run
+
+```bash
+docker compose --profile demo run --rm vector-rag python main.py                 # fresh traces
+docker compose --profile demo run --rm vector-rag python main.py --interactive  # Act 4 moment
+python scripts/seed-app-prompts.py                                              # re-seed prompt (idempotent)
+docker compose --profile demo build vector-rag                                  # after code edits
+```
+
+The corpus re-indexes in-memory on every run — there's no vector-store state to
+reset. First run after a wipe re-downloads the embedding model (cached in the
+`vector-rag-models` volume thereafter).

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,11 +17,14 @@ Pick your path by what you're trying to do.
 | [**SA Field Guide**](SA_FIELD_GUIDE.md) | **Start here** — demo selection, talk track, prep checklist, objection handling |
 | [Property Concierge Demo Script](../demos/real-estate/DEMO_SCRIPT.md) | Consultative script for the real-estate app — the full AI Engineering loop, benefit-led Frame→Show→Land→Ask flow + "show me the code" appendix |
 | [Agentic RAG Demo Script](../demos/agentic-rag/DEMO_SCRIPT.md) | Consultative script for the self-correcting RAG app — ClickHouse-native vectors + Langfuse graph, same flow + code appendix |
+| [Text-to-SQL Demo Script](../demos/text-to-sql/DEMO_SCRIPT.md) | Consultative script for the NL-data-assistant demo — SQL-safety guardrail + prompt deploys by label, same flow + code appendix |
+| [Vector RAG Demo Script](../demos/vector-rag/DEMO_SCRIPT.md) | Consultative script for the naive-RAG baseline — tracing, managed prompts, free guardrails, and the designed hand-off to agentic-rag |
+| [Brand-Promo Demo Script](../demos/brand-promo-multi-agent/DEMO_SCRIPT.md) | Consultative script for the multi-agent (LangGraph + CrewAI) fleet demo — 50k-trace scale, persona dashboards, certification gate |
 | [Use Case Catalog](USE_CASES.md) | 10 capabilities, each with a 2-minute demo path; quick-tour combos |
 | [Langfuse Demo Runbook](LANGFUSE_DEMO_RUNBOOK.md) | 45-min screen-by-screen platform demo script with full talk tracks |
 | [Agentic RAG Demo Runbook](AGENTIC_RAG_DEMO_RUNBOOK.md) | Deep screen-by-screen reference + fallbacks (pairs with the co-located [demo script](../demos/agentic-rag/DEMO_SCRIPT.md)) |
-| [Brand-Promo Multi-Agent Runbook](../demos/brand-promo-multi-agent/docs/DEMO_RUNBOOK.md) | Multi-agent (LangGraph + CrewAI) promo-planning demo — synthetic history, online + offline evals, persona dashboards |
-| [Langfuse RLS Demo](../demos/langfuse-rls/README.md) | Attribute-based row-level-security prototype over Langfuse traces (Next.js) — trace governance / access control (loop-adjacent) |
+| [Brand-Promo Multi-Agent Runbook](../demos/brand-promo-multi-agent/docs/DEMO_RUNBOOK.md) | Deep 60-min segment-by-segment reference (pairs with the co-located [demo script](../demos/brand-promo-multi-agent/DEMO_SCRIPT.md)) |
+| [Langfuse RLS Demo Script](../demos/langfuse-rls/DEMO_SCRIPT.md) | Short (~10 min) governance-conversation script for the row-level-security **prototype** over Langfuse traces — simulated feature, loop-adjacent |
 | [Dashboard (LLM Observatory)](DASHBOARD.md) | The "your data is just ClickHouse tables" 5-min demo beat |
 
 ## I want to learn from it


### PR DESCRIPTION
## Summary

Extends the consultative demo-script format (established for real-estate in #38 and refined in #40) to the four demos that didn't have one, so every demo in `demos/` now ships a client-facing `DEMO_SCRIPT.md`:

- **`demos/text-to-sql/DEMO_SCRIPT.md`** — SQL-safety guardrail money moment (`sql-risk = destructive` live) + prompt deploys by label. Honest framing: no HTTP endpoint on :8002, and the pipeline reasons over the catalog but does not execute SQL.
- **`demos/vector-rag/DEMO_SCRIPT.md`** — positioned as the naive-RAG baseline: one-callback tracing, edit-the-prompt-in-UI beat, free structural guardrails, and a designed hand-off act to agentic-rag.
- **`demos/brand-promo-multi-agent/DEMO_SCRIPT.md`** — fleet scale (50k traces, persona dashboards), cost-by-model-tier trace walk, live compliance/hallucination catches, certification gate with `--ci` exit code, prompt A/B, annotation queue. Presenter note on the live-vs-synthetic CrewAI span gap.
- **`demos/langfuse-rls/DEMO_SCRIPT.md`** — deliberately short (~10 min) governance conversation; leads with the DEMO-ONLY/simulated framing.

Each script carries the shared structure: pre-flight, "what each act proves" table, act-by-act conversation beats, a "show me the code" appendix with verified `file:line` references, objection handling, and reset commands.

Also cross-links all scripts from `demos/README.md` (run column) and `docs/README.md` ("I want to present it").

## Test plan

- [x] All relative markdown links in the new/edited files resolve to existing files
- [x] All `file:line` code-appendix references spot-checked against source
- [x] Commands verified against each demo's actual entry points (no dead curl endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)