### PR TITLE
real-estate: support Langfuse Cloud as the observability backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# Environment files
+# Environment files (any .env variant may hold keys — never commit; templates stay tracked)
 .env
+.env.*
+!.env.example
 
 # Data directories
 data-node/

--- a/demos/real-estate/.env.example
+++ b/demos/real-estate/.env.example
@@ -4,7 +4,16 @@
 # Langfuse project the demo targets (create a project named "real-estate").
 LANGFUSE_PUBLIC_KEY=pk-lf-...
 LANGFUSE_SECRET_KEY=sk-lf-...
+
+# Self-hosted stack (default) — or point at Langfuse Cloud instead:
+#   https://cloud.langfuse.com (EU) / https://us.cloud.langfuse.com (US)
+# with that project's API keys (Settings > API Keys). Everything works the
+# same except managed LLM-as-a-Judge evaluators, which Cloud sets up in the
+# UI (seed_managed_evaluators.sh prints the exact steps).
 LANGFUSE_HOST=http://localhost:3001
+
+# Only if your (Cloud) project is NOT named "real-estate":
+# LANGFUSE_PROJECT_NAME=my-project-name
 
 # Anthropic — agent + LLM-as-a-Judge.
 ANTHROPIC_API_KEY=sk-ant-...

--- a/demos/real-estate/.env.example
+++ b/demos/real-estate/.env.example
@@ -15,6 +15,13 @@ LANGFUSE_HOST=http://localhost:3001
 # Only if your (Cloud) project is NOT named "real-estate":
 # LANGFUSE_PROJECT_NAME=my-project-name
 
+# Optional: ALSO send every trace + score to a second Langfuse (e.g. keep the
+# self-hosted stack as primary and mirror to Langfuse Cloud). Same trace ids
+# land on both. Prompts/datasets/experiments stay primary-only.
+# LANGFUSE_MIRROR_PUBLIC_KEY=pk-lf-...
+# LANGFUSE_MIRROR_SECRET_KEY=sk-lf-...
+# LANGFUSE_MIRROR_HOST=https://us.cloud.langfuse.com
+
 # Anthropic — agent + LLM-as-a-Judge.
 ANTHROPIC_API_KEY=sk-ant-...
 AGENT_MODEL=claude-sonnet-4-6

--- a/demos/real-estate/.env.example
+++ b/demos/real-estate/.env.example
@@ -15,9 +15,11 @@ LANGFUSE_HOST=http://localhost:3001
 # Only if your (Cloud) project is NOT named "real-estate":
 # LANGFUSE_PROJECT_NAME=my-project-name
 
-# Optional: ALSO send every trace + score to a second Langfuse (e.g. keep the
-# self-hosted stack as primary and mirror to Langfuse Cloud). Same trace ids
-# land on both. Prompts/datasets/experiments stay primary-only.
+# Optional: ALSO send every trace (live, portal and experiment spans) to a
+# second Langfuse — e.g. self-hosted primary + Langfuse Cloud mirror. Same
+# trace ids land on both. Live/portal scores are duplicated too; experiment
+# evaluation scores, prompts, datasets and managed evaluators stay
+# primary-only. Read from this file only (shell exports are ignored).
 # LANGFUSE_MIRROR_PUBLIC_KEY=pk-lf-...
 # LANGFUSE_MIRROR_SECRET_KEY=sk-lf-...
 # LANGFUSE_MIRROR_HOST=https://us.cloud.langfuse.com

--- a/demos/real-estate/README.md
+++ b/demos/real-estate/README.md
@@ -102,6 +102,19 @@ the Anthropic LLM connection via API, and prints the ~2-minute UI recipe for
 the two judges (Helpfulness/Relevance on tag `real-estate`) instead of seeding
 them into the local Postgres.
 
+**Switching targets:** keep one env file per backend (e.g. `.env.cloud`
+alongside your self-hosted `.env`, both gitignored) and copy the one you want
+into place: `cp .env.cloud .env`. Everything — scripts, portal, experiments —
+follows `.env`. Restart the portal after switching.
+
+**Or send to both at once:** set the three `LANGFUSE_MIRROR_*` variables in
+`.env` (see `.env.example`). Every span is then exported to the mirror as
+well — **same trace ids on both backends** (one extra OTLP exporter on the
+same tracer provider) — and every code/judge/user-feedback score is duplicated
+via the mirror's public API. Prompts, datasets, experiments and managed
+evaluators remain primary-only; the mirror is best-effort and never blocks the
+demo if it's unreachable.
+
 ---
 
 ## Run it

--- a/demos/real-estate/README.md
+++ b/demos/real-estate/README.md
@@ -108,12 +108,16 @@ into place: `cp .env.cloud .env`. Everything — scripts, portal, experiments �
 follows `.env`. Restart the portal after switching.
 
 **Or send to both at once:** set the three `LANGFUSE_MIRROR_*` variables in
-`.env` (see `.env.example`). Every span is then exported to the mirror as
-well — **same trace ids on both backends** (one extra OTLP exporter on the
-same tracer provider) — and every code/judge/user-feedback score is duplicated
-via the mirror's public API. Prompts, datasets, experiments and managed
-evaluators remain primary-only; the mirror is best-effort and never blocks the
-demo if it's unreachable.
+`.env` (see `.env.example`; they are read from the file only, so stray shell
+exports can't silently enable mirroring). Every span — live traffic, portal,
+*and* experiment runs — is then exported to the mirror as well, with the
+**same trace ids on both backends** (one extra OTLP exporter on the same
+tracer provider). Scores are duplicated on the live-traffic and portal paths
+(code scores, SDK judges, user feedback); experiment evaluation scores,
+prompts, datasets, dataset-run linkage and managed evaluators exist only on
+the primary — so experiment traces show up on the mirror *without* scores or
+run linkage. The mirror is best-effort: if it's unreachable, the demo logs a
+warning and continues, adding at most ~3s to a turn.
 
 ---
 

--- a/demos/real-estate/README.md
+++ b/demos/real-estate/README.md
@@ -67,8 +67,8 @@ It then writes a grounded recommendation citing real listing ids.
 
 ## Setup
 
-Prerequisites: the Langfuse stack running on `localhost:3001` (this repo's main
-stack) and Python 3.11+. For the full feature set, the `real-estate` project
+Prerequisites: a Langfuse instance — this repo's main stack on `localhost:3001`
+(default) **or a Langfuse Cloud project** (see below) — and Python 3.11+. For the full feature set, the `real-estate` project
 needs, under **Settings → LLM Connections**, an **Anthropic** connection (powers
 the managed judges) and an **OpenAI** connection (optional; for the GPT run).
 
@@ -82,6 +82,25 @@ python3.11 -m venv .venv
 `OPEN_AI_API_KEY` (so the agent can run on GPT). `agent/config.py` **verifies at
 runtime** that the keys resolve to the `real-estate` project and refuses to run
 otherwise — so the demo can never silently pollute another project.
+
+### Using Langfuse Cloud instead
+
+The demo runs against a [Langfuse Cloud](https://cloud.langfuse.com) project
+just as well — no local Langfuse stack needed:
+
+1. Create a project (name it `real-estate`, or set `LANGFUSE_PROJECT_NAME` in
+   `.env` to whatever you named it) and grab its API keys.
+2. In `.env`, set `LANGFUSE_HOST=https://cloud.langfuse.com` (EU) or
+   `https://us.cloud.langfuse.com` (US) plus that project's keys.
+3. Run `./run_demo.sh` as usual.
+
+Everything seeds through the public API — prompts, dataset, live traffic,
+experiments, annotation queue, and all code/SDK-judge scores — identically to
+self-hosted. The one difference: **managed LLM-as-a-Judge evaluators** have no
+public API, so `seed_managed_evaluators.sh` detects the remote host, upserts
+the Anthropic LLM connection via API, and prints the ~2-minute UI recipe for
+the two judges (Helpfulness/Relevance on tag `real-estate`) instead of seeding
+them into the local Postgres.
 
 ---
 

--- a/demos/real-estate/agent/concierge.py
+++ b/demos/real-estate/agent/concierge.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional
 
 from langfuse import propagate_attributes
 
-from .config import get_langfuse, record_score, AGENT_MODEL, BASE_TAGS
+from .config import get_langfuse, record_score, flush_langfuse, AGENT_MODEL, BASE_TAGS
 from .catalog import LISTINGS
 from .tools import execute_tool
 from .llm import call_llm, tools_for, append_assistant, append_tool_results, provider_of
@@ -328,5 +328,5 @@ def run_turn(
                                      comment=s.comment)
 
     if not is_experiment:
-        lf.flush()
+        flush_langfuse(lf)
     return result

--- a/demos/real-estate/agent/concierge.py
+++ b/demos/real-estate/agent/concierge.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional
 
 from langfuse import propagate_attributes
 
-from .config import get_langfuse, AGENT_MODEL, BASE_TAGS
+from .config import get_langfuse, record_score, AGENT_MODEL, BASE_TAGS
 from .catalog import LISTINGS
 from .tools import execute_tool
 from .llm import call_llm, tools_for, append_assistant, append_tool_results, provider_of
@@ -323,9 +323,9 @@ def run_turn(
             if not is_experiment:
                 for s in run_code_evaluators(result):
                     if final_gen_id:
-                        lf.create_score(trace_id=trace_id, observation_id=final_gen_id,
-                                        name=s.name, value=s.value, data_type=s.data_type,
-                                        comment=s.comment)
+                        record_score(lf, trace_id=trace_id, observation_id=final_gen_id,
+                                     name=s.name, value=s.value, data_type=s.data_type,
+                                     comment=s.comment)
 
     if not is_experiment:
         lf.flush()

--- a/demos/real-estate/agent/config.py
+++ b/demos/real-estate/agent/config.py
@@ -49,8 +49,51 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY") or os.environ.get("OPEN_AI_API
 # Tags applied to every trace so the demo's traffic is easy to filter in the UI.
 BASE_TAGS = ["real-estate", "property-concierge"]
 
+# --- Optional trace mirror (e.g. self-hosted primary + Langfuse Cloud) -------
+# When all three are set, every span is ALSO exported to the mirror project
+# (same trace ids) and scores are duplicated via the mirror's public API.
+# Prompts, datasets, experiments and managed evaluators stay primary-only.
+MIRROR_PUBLIC_KEY = os.environ.get("LANGFUSE_MIRROR_PUBLIC_KEY")
+MIRROR_SECRET_KEY = os.environ.get("LANGFUSE_MIRROR_SECRET_KEY")
+MIRROR_HOST = os.environ.get("LANGFUSE_MIRROR_HOST")
+MIRROR_ENABLED = bool(MIRROR_PUBLIC_KEY and MIRROR_SECRET_KEY and MIRROR_HOST)
+
 _langfuse = None
 _anthropic = None
+_mirror_attached = False
+
+
+def _attach_mirror() -> None:
+    """Fan spans out to the mirror Langfuse via a second OTLP exporter.
+
+    The SDK's own LangfuseSpanProcessor filters spans by public key (so a
+    second Langfuse *client* would reject the primary's spans); a plain
+    BatchSpanProcessor on the same tracer provider exports everything —
+    identical spans, identical trace ids, on both backends.
+    """
+    global _mirror_attached
+    if _mirror_attached or not MIRROR_ENABLED:
+        return
+    import base64 as _b64
+
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    provider = _otel_trace.get_tracer_provider()
+    if not hasattr(provider, "add_span_processor"):
+        print(f"WARN: cannot attach Langfuse mirror ({MIRROR_HOST}): "
+              f"tracer provider {type(provider).__name__} is not the SDK provider.",
+              file=sys.stderr)
+        return
+    auth = _b64.b64encode(f"{MIRROR_PUBLIC_KEY}:{MIRROR_SECRET_KEY}".encode()).decode()
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(
+        endpoint=f"{MIRROR_HOST}/api/public/otel/v1/traces",
+        headers={"Authorization": f"Basic {auth}",
+                 "x-langfuse-public-key": MIRROR_PUBLIC_KEY},
+    )))
+    _mirror_attached = True
+    print(f"✓ Mirroring traces to {MIRROR_HOST}")
 
 
 def get_langfuse():
@@ -64,7 +107,44 @@ def get_langfuse():
             secret_key=LANGFUSE_SECRET_KEY,
             host=LANGFUSE_HOST,
         )
+        _attach_mirror()
     return _langfuse
+
+
+def record_score(lf, **kwargs) -> None:
+    """create_score on the primary AND (best-effort) on the mirror.
+
+    Trace/observation ids are identical on both backends (same OTel spans),
+    so the same payload lands on the mirror via its public scores API.
+    """
+    lf.create_score(**kwargs)
+    if not MIRROR_ENABLED:
+        return
+    value = kwargs.get("value")
+    if isinstance(value, bool):  # public API wants 1/0 for BOOLEAN scores
+        value = 1 if value else 0
+    body = {
+        "traceId": kwargs.get("trace_id"),
+        "name": kwargs.get("name"),
+        "value": value,
+    }
+    if kwargs.get("observation_id"):
+        body["observationId"] = kwargs["observation_id"]
+    if kwargs.get("data_type"):
+        body["dataType"] = kwargs["data_type"]
+    if kwargs.get("comment"):
+        body["comment"] = kwargs["comment"]
+    try:
+        data = json.dumps(body).encode()
+        req = urllib.request.Request(
+            f"{MIRROR_HOST}/api/public/scores", data=data, method="POST",
+            headers={"Authorization": "Basic " + base64.b64encode(
+                f"{MIRROR_PUBLIC_KEY}:{MIRROR_SECRET_KEY}".encode()).decode(),
+                "Content-Type": "application/json"},
+        )
+        urllib.request.urlopen(req, timeout=10).read()
+    except Exception as e:  # mirror is best-effort; never break the demo
+        print(f"WARN: mirror score '{kwargs.get('name')}' failed: {e}", file=sys.stderr)
 
 
 def get_anthropic():

--- a/demos/real-estate/agent/config.py
+++ b/demos/real-estate/agent/config.py
@@ -2,8 +2,10 @@
 Shared configuration for the Real Estate Property Concierge demo.
 
 Key-isolation is the #1 landmine: this demo targets a *dedicated* Langfuse
-project ("real-estate"). If the surrounding shell has other LANGFUSE_* keys
-exported, every trace/dataset/score would silently land in the wrong project.
+project ("real-estate" by default; override with LANGFUSE_PROJECT_NAME, e.g.
+for a Langfuse Cloud project named differently). If the surrounding shell has
+other LANGFUSE_* keys exported, every trace/dataset/score would silently land
+in the wrong project.
 
 To prevent that we:
   1. Load this folder's .env explicitly.
@@ -20,7 +22,9 @@ import urllib.error
 import json
 from pathlib import Path
 
-from dotenv import load_dotenv
+import threading
+
+from dotenv import load_dotenv, dotenv_values
 
 # --- Load this folder's .env (overriding any inherited shell values) ---
 _ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
@@ -50,18 +54,29 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY") or os.environ.get("OPEN_AI_API
 BASE_TAGS = ["real-estate", "property-concierge"]
 
 # --- Optional trace mirror (e.g. self-hosted primary + Langfuse Cloud) -------
-# When all three are set, every span is ALSO exported to the mirror project
-# (same trace ids) and scores are duplicated via the mirror's public API.
-# Prompts, datasets, experiments and managed evaluators stay primary-only.
-MIRROR_PUBLIC_KEY = os.environ.get("LANGFUSE_MIRROR_PUBLIC_KEY")
-MIRROR_SECRET_KEY = os.environ.get("LANGFUSE_MIRROR_SECRET_KEY")
-MIRROR_HOST = os.environ.get("LANGFUSE_MIRROR_HOST")
+# When all three are set, every span — live, portal AND experiment — is ALSO
+# exported to the mirror project with the same trace ids. Scores are duplicated
+# only on the live-traffic/portal paths (via record_score below); experiment
+# evaluation scores, prompts, datasets, dataset runs and managed evaluators
+# exist only on the primary, so experiment traces appear on the mirror without
+# scores or run linkage.
+# Read STRICTLY from this folder's .env (never the shell environment): the
+# primary keys' shell-override landmine applies here too, and a stale
+# shell-exported LANGFUSE_MIRROR_* must not silently enable mirroring.
+_env_file = dotenv_values(_ENV_PATH)
+MIRROR_PUBLIC_KEY = _env_file.get("LANGFUSE_MIRROR_PUBLIC_KEY")
+MIRROR_SECRET_KEY = _env_file.get("LANGFUSE_MIRROR_SECRET_KEY")
+MIRROR_HOST = (_env_file.get("LANGFUSE_MIRROR_HOST") or "").rstrip("/") or None
 MIRROR_ENABLED = bool(MIRROR_PUBLIC_KEY and MIRROR_SECRET_KEY and MIRROR_HOST)
 
 _langfuse = None
 _anthropic = None
 _mirror_attached = False
 _mirror_processor = None
+# The portal serves sync FastAPI handlers from a thread pool; without a lock,
+# two cold-start requests could each attach a mirror processor (spans then
+# mirrored twice, one processor orphaned from flush/atexit).
+_langfuse_lock = threading.Lock()
 
 
 def _attach_mirror() -> None:
@@ -105,24 +120,29 @@ def _attach_mirror() -> None:
 
 
 def flush_langfuse(lf=None) -> None:
-    """Flush the primary client AND the mirror processor (if attached)."""
+    """Flush the primary client AND the mirror processor (if attached).
+
+    The mirror flush is capped at 3s so an unreachable mirror adds at most a
+    short delay to a turn/feedback request instead of hanging it.
+    """
     (lf or get_langfuse()).flush()
     if _mirror_processor is not None:
-        _mirror_processor.force_flush(10_000)
+        _mirror_processor.force_flush(3_000)
 
 
 def get_langfuse():
     """Return a singleton Langfuse client bound to the real-estate project keys."""
     global _langfuse
-    if _langfuse is None:
-        from langfuse import Langfuse
+    with _langfuse_lock:
+        if _langfuse is None:
+            from langfuse import Langfuse
 
-        _langfuse = Langfuse(
-            public_key=LANGFUSE_PUBLIC_KEY,
-            secret_key=LANGFUSE_SECRET_KEY,
-            host=LANGFUSE_HOST,
-        )
-        _attach_mirror()
+            _langfuse = Langfuse(
+                public_key=LANGFUSE_PUBLIC_KEY,
+                secret_key=LANGFUSE_SECRET_KEY,
+                host=LANGFUSE_HOST,
+            )
+            _attach_mirror()
     return _langfuse
 
 

--- a/demos/real-estate/agent/config.py
+++ b/demos/real-estate/agent/config.py
@@ -35,7 +35,9 @@ os.environ["LANGFUSE_PUBLIC_KEY"] = LANGFUSE_PUBLIC_KEY
 os.environ["LANGFUSE_SECRET_KEY"] = LANGFUSE_SECRET_KEY
 os.environ["LANGFUSE_HOST"] = LANGFUSE_HOST
 
-EXPECTED_PROJECT = "real-estate"
+# Override with LANGFUSE_PROJECT_NAME when targeting e.g. a Langfuse Cloud
+# project that isn't named "real-estate".
+EXPECTED_PROJECT = os.environ.get("LANGFUSE_PROJECT_NAME", "real-estate")
 
 AGENT_MODEL = os.environ.get("AGENT_MODEL", "claude-sonnet-4-6")
 JUDGE_MODEL = os.environ.get("JUDGE_MODEL", "claude-sonnet-4-6")

--- a/demos/real-estate/agent/config.py
+++ b/demos/real-estate/agent/config.py
@@ -61,6 +61,7 @@ MIRROR_ENABLED = bool(MIRROR_PUBLIC_KEY and MIRROR_SECRET_KEY and MIRROR_HOST)
 _langfuse = None
 _anthropic = None
 _mirror_attached = False
+_mirror_processor = None
 
 
 def _attach_mirror() -> None:
@@ -87,13 +88,27 @@ def _attach_mirror() -> None:
               file=sys.stderr)
         return
     auth = _b64.b64encode(f"{MIRROR_PUBLIC_KEY}:{MIRROR_SECRET_KEY}".encode()).decode()
-    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(
+    global _mirror_processor
+    _mirror_processor = BatchSpanProcessor(OTLPSpanExporter(
         endpoint=f"{MIRROR_HOST}/api/public/otel/v1/traces",
         headers={"Authorization": f"Basic {auth}",
                  "x-langfuse-public-key": MIRROR_PUBLIC_KEY},
-    )))
+    ))
+    provider.add_span_processor(_mirror_processor)
+    # The Langfuse client's flush()/atexit only cover ITS OWN processor —
+    # without these two hooks, short-lived scripts exit before the mirror
+    # batch exports and the mirrored trace is silently lost.
+    import atexit
+    atexit.register(_mirror_processor.shutdown)
     _mirror_attached = True
     print(f"✓ Mirroring traces to {MIRROR_HOST}")
+
+
+def flush_langfuse(lf=None) -> None:
+    """Flush the primary client AND the mirror processor (if attached)."""
+    (lf or get_langfuse()).flush()
+    if _mirror_processor is not None:
+        _mirror_processor.force_flush(10_000)
 
 
 def get_langfuse():

--- a/demos/real-estate/run_demo.sh
+++ b/demos/real-estate/run_demo.sh
@@ -32,7 +32,7 @@ echo -e "\n[2/7] Seeding evaluation dataset (18 items)…"
 $PY scripts/seed_dataset.py
 
 echo -e "\n[3/7] Provisioning managed LLM-as-a-Judge evaluators (Anthropic)…"
-./scripts/seed_managed_evaluators.sh || echo "  (managed evaluators step skipped — check Docker/Postgres)"
+./scripts/seed_managed_evaluators.sh || echo "  (managed evaluators step skipped — self-hosted: check Docker/Postgres; cloud: see steps above)"
 
 echo -e "\n[4/7] Generating live traffic (traces + code scores + a session)…"
 $PY scripts/run_live_traffic.py $JUDGE_FLAG
@@ -57,7 +57,9 @@ else
   fi
 fi
 
-echo -e "\n✓ Done. Open Langfuse (http://localhost:3001) → project 'real-estate'."
+LF_HOST=$(grep -E '^LANGFUSE_HOST=' .env 2>/dev/null | tail -1 | cut -d= -f2-)
+LF_PROJECT=$(grep -E '^LANGFUSE_PROJECT_NAME=' .env 2>/dev/null | tail -1 | cut -d= -f2-)
+echo -e "\n✓ Done. Open Langfuse (${LF_HOST:-http://localhost:3001}) → project '${LF_PROJECT:-real-estate}'."
 echo "  Prompts, Evaluators, Datasets > Runs (compare Claude vs gpt-4o, production vs candidate),"
 echo "  Annotation Queues, Tracing."
 echo "  Then start the portal:  ./run_portal.sh   → http://localhost:8080"

--- a/demos/real-estate/scripts/run_live_traffic.py
+++ b/demos/real-estate/scripts/run_live_traffic.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from agent.config import get_langfuse, verify_project
+from agent.config import get_langfuse, record_score, verify_project
 from agent.concierge import run_turn
 from agent.scoring import judge_groundedness, judge_tone
 
@@ -115,9 +115,9 @@ def main():
             # turn of a conversation gets its own groundedness/tone (not the trace).
             for judge in COMPLEMENTARY_JUDGES:
                 s = judge(result)
-                lf.create_score(trace_id=result["trace_id"],
-                                observation_id=result.get("final_generation_id"),
-                                name=s.name, value=s.value, data_type=s.data_type, comment=s.comment)
+                record_score(lf, trace_id=result["trace_id"],
+                             observation_id=result.get("final_generation_id"),
+                             name=s.name, value=s.value, data_type=s.data_type, comment=s.comment)
         shown = ", ".join(result["listings_shown"]) or "(none)"
         print(f"        -> tools={result['tools_called']} shown={shown} trace={result['trace_id'][:12]}")
 

--- a/demos/real-estate/scripts/run_live_traffic.py
+++ b/demos/real-estate/scripts/run_live_traffic.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from agent.config import get_langfuse, record_score, verify_project
+from agent.config import get_langfuse, record_score, flush_langfuse, verify_project
 from agent.concierge import run_turn
 from agent.scoring import judge_groundedness, judge_tone
 
@@ -121,7 +121,7 @@ def main():
         shown = ", ".join(result["listings_shown"]) or "(none)"
         print(f"        -> tools={result['tools_called']} shown={shown} trace={result['trace_id'][:12]}")
 
-    lf.flush()
+    flush_langfuse(lf)
     print("\n✓ Live traffic complete. Managed judges (Helpfulness/Relevance) "
           "score these automatically within ~1 min.")
     print("  View: Langfuse UI > Tracing (filter tag 'real-estate'); Sessions > sess-madrid-buyer-001")

--- a/demos/real-estate/scripts/seed_managed_evaluators.sh
+++ b/demos/real-estate/scripts/seed_managed_evaluators.sh
@@ -22,6 +22,47 @@ EVAL_MODEL="${MANAGED_EVAL_MODEL:-claude-sonnet-4-6}"
 green(){ printf '  \033[0;32m✓\033[0m %s\n' "$1"; }
 warn(){  printf '  \033[1;33m⚠\033[0m %s\n' "$1"; }
 
+EXPECTED_PROJECT="${LANGFUSE_PROJECT_NAME:-real-estate}"
+
+# ---- Langfuse Cloud / remote host: no direct DB access ----------------------
+# job_configurations have no public API, so on Cloud the two judges are set up
+# in the UI. We still provision what the API allows (the Anthropic LLM
+# connection) and print the exact remaining steps. Exit 0 so run_demo.sh flows.
+case "${LANGFUSE_HOST:-http://localhost:3001}" in
+  http://localhost*|http://127.0.0.1*) ;;  # self-hosted: fall through to DB seeding
+  *)
+    echo "Remote Langfuse host detected (${LANGFUSE_HOST}) — managed evaluators can't be DB-seeded."
+    if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+      code=$(curl -s -o /tmp/lf-llmconn.json -w '%{http_code}' -X PUT \
+        -u "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" \
+        -H 'Content-Type: application/json' \
+        "${LANGFUSE_HOST}/api/public/llm-connections" \
+        -d "{\"provider\":\"anthropic\",\"adapter\":\"anthropic\",\"secretKey\":\"${ANTHROPIC_API_KEY}\"}")
+      if [ "$code" = "200" ] || [ "$code" = "201" ]; then
+        green "Anthropic LLM connection upserted via API"
+      else
+        warn "Could not upsert LLM connection (HTTP ${code}) — add it in Settings > LLM Connections"
+      fi
+    else
+      warn "ANTHROPIC_API_KEY not set — add the connection in Settings > LLM Connections"
+    fi
+    cat <<STEPS
+
+  Finish in the Langfuse UI (~2 min), project '${EXPECTED_PROJECT}':
+    1. Settings > LLM Connections — confirm the 'anthropic' connection exists.
+    2. Evaluators (Evals) > Default evaluation model — pick ${EVAL_MODEL}.
+    3. Evaluators > + New evaluator, twice — templates 'Helpfulness' and 'Relevance':
+         target        = live tracing data (New + Existing traces)
+         filter        = tag 'real-estate'
+         variable map  = query -> trace input, generation -> trace output
+         sampling      = 100%
+  Everything else (prompts, datasets, traffic, experiments, annotation queue,
+  code + SDK judge scores) seeds via the public API — no UI steps needed.
+STEPS
+    exit 0
+    ;;
+esac
+
 docker ps --format '{{.Names}}' | grep -q "^${PG_CONTAINER}$" \
   || { echo "Postgres container ${PG_CONTAINER} not running."; exit 1; }
 
@@ -29,7 +70,6 @@ q(){ docker exec -i "$PG_CONTAINER" sh -c 'psql -v ON_ERROR_STOP=1 -q -t -A -U "
 # Escape single quotes for safe interpolation into SQL string literals.
 sql_esc(){ printf "%s" "$1" | sed "s/'/''/g"; }
 
-EXPECTED_PROJECT="real-estate"
 PK_ESC=$(sql_esc "${LANGFUSE_PUBLIC_KEY}")
 PROJECT_ID=$(echo "SELECT project_id FROM api_keys WHERE public_key='${PK_ESC}' LIMIT 1;" | q)
 [ -n "$PROJECT_ID" ] || { echo "Could not resolve project for the configured public key."; exit 1; }

--- a/demos/real-estate/scripts/seed_managed_evaluators.sh
+++ b/demos/real-estate/scripts/seed_managed_evaluators.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
-# Provision Langfuse-managed LLM-as-a-Judge evaluators for the 'real-estate'
-# project so they run AUTOMATICALLY on live traffic (visible under Evaluators).
+# Provision Langfuse-managed LLM-as-a-Judge evaluators for the demo's project
+# (default 'real-estate', override via LANGFUSE_PROJECT_NAME) so they run
+# AUTOMATICALLY on live traffic (visible under Evaluators).
 #
 # These are Langfuse-native evaluators (not the client-side judges the demo also
 # ships): the Langfuse worker runs them on new traces tagged 'real-estate' using
 # the Anthropic LLM connection you configured, and writes scores back.
 #
-# There is no public REST API for managed evaluators in this Langfuse version,
-# so — like this repo's other evaluator seeders — we insert directly into the
-# Langfuse Postgres. Idempotent.
+# Two modes:
+#   self-hosted (localhost) — managed evaluators have no public REST API, so
+#     like this repo's other evaluator seeders we insert directly into the
+#     Langfuse Postgres. Idempotent.
+#   remote / Langfuse Cloud — no DB access: upsert the LLM connection via the
+#     public API and print the short UI recipe for the judges.
 #
 # Usage:  ./scripts/seed_managed_evaluators.sh
 set -euo pipefail
@@ -29,15 +33,30 @@ EXPECTED_PROJECT="${LANGFUSE_PROJECT_NAME:-real-estate}"
 # in the UI. We still provision what the API allows (the Anthropic LLM
 # connection) and print the exact remaining steps. Exit 0 so run_demo.sh flows.
 case "${LANGFUSE_HOST:-http://localhost:3001}" in
-  http://localhost*|http://127.0.0.1*) ;;  # self-hosted: fall through to DB seeding
+  http://localhost*|https://localhost*|http://127.0.0.1*|https://127.0.0.1*)
+    ;;  # self-hosted: fall through to DB seeding
   *)
     echo "Remote Langfuse host detected (${LANGFUSE_HOST}) — managed evaluators can't be DB-seeded."
+    # Key-isolation guard (mirrors config.verify_project): resolve the keys'
+    # project via the public API and refuse to write anywhere unexpected —
+    # the PUT below uploads a real Anthropic secret. `|| true` guards keep
+    # set -e from killing the script before the fallback guidance prints.
+    projects=$(curl -s -u "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" \
+      "${LANGFUSE_HOST}/api/public/projects" || true)
+    if ! printf '%s' "$projects" | grep -Eq "\"name\":[[:space:]]*\"${EXPECTED_PROJECT}\""; then
+      echo "Refusing: keys do not resolve to project '${EXPECTED_PROJECT}' on ${LANGFUSE_HOST}."
+      echo "  API response: ${projects:-<no response — host unreachable?>}"
+      exit 1
+    fi
+    green "Project verified: ${EXPECTED_PROJECT} @ ${LANGFUSE_HOST}"
     if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+      json_esc(){ printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
       code=$(curl -s -o /tmp/lf-llmconn.json -w '%{http_code}' -X PUT \
         -u "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" \
         -H 'Content-Type: application/json' \
         "${LANGFUSE_HOST}/api/public/llm-connections" \
-        -d "{\"provider\":\"anthropic\",\"adapter\":\"anthropic\",\"secretKey\":\"${ANTHROPIC_API_KEY}\"}")
+        -d "{\"provider\":\"anthropic\",\"adapter\":\"anthropic\",\"secretKey\":\"$(json_esc "${ANTHROPIC_API_KEY}")\"}") \
+        || code="000"
       if [ "$code" = "200" ] || [ "$code" = "201" ]; then
         green "Anthropic LLM connection upserted via API"
       else
@@ -75,7 +94,7 @@ PROJECT_ID=$(echo "SELECT project_id FROM api_keys WHERE public_key='${PK_ESC}' 
 [ -n "$PROJECT_ID" ] || { echo "Could not resolve project for the configured public key."; exit 1; }
 
 # Key-isolation guard (mirrors config.verify_project): refuse to write to any
-# project other than 'real-estate' so a stale/wrong shell key can't pollute another.
+# project other than the expected one so a stale/wrong shell key can't pollute another.
 PID_ESC=$(sql_esc "${PROJECT_ID}")
 PROJECT_NAME=$(echo "SELECT name FROM projects WHERE id='${PID_ESC}' LIMIT 1;" | q)
 if [ "$PROJECT_NAME" != "$EXPECTED_PROJECT" ]; then

--- a/demos/real-estate/webapp/server.py
+++ b/demos/real-estate/webapp/server.py
@@ -24,8 +24,8 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from agent.config import (get_langfuse, verify_project, langfuse_api,
-                          LANGFUSE_HOST, AGENT_MODEL)
+from agent.config import (get_langfuse, record_score, verify_project,
+                          langfuse_api, LANGFUSE_HOST, AGENT_MODEL)
 from agent.concierge import run_turn
 from agent.catalog import get_listing
 
@@ -140,7 +140,8 @@ def feedback(req: FeedbackRequest):
         raise HTTPException(status_code=400, detail="trace_id is required")
     lf = get_langfuse()
     value = 1 if req.value else 0
-    lf.create_score(
+    record_score(
+        lf,
         trace_id=req.trace_id,
         name="user-feedback",
         value=value,

--- a/demos/real-estate/webapp/server.py
+++ b/demos/real-estate/webapp/server.py
@@ -24,8 +24,8 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from agent.config import (get_langfuse, record_score, verify_project,
-                          langfuse_api, LANGFUSE_HOST, AGENT_MODEL)
+from agent.config import (get_langfuse, record_score, flush_langfuse,
+                          verify_project, langfuse_api, LANGFUSE_HOST, AGENT_MODEL)
 from agent.concierge import run_turn
 from agent.catalog import get_listing
 
@@ -148,7 +148,7 @@ def feedback(req: FeedbackRequest):
         data_type="NUMERIC",
         comment=req.comment or ("👍 helpful" if value else "👎 not helpful"),
     )
-    lf.flush()
+    flush_langfuse(lf)
     return {"ok": True, "trace_id": req.trace_id, "value": value}
 
 


### PR DESCRIPTION
## Summary

The real-estate demo can now hook into a **Langfuse Cloud** instance instead of the local self-hosted stack: set `LANGFUSE_HOST=https://cloud.langfuse.com` (or `https://us.cloud.langfuse.com`) plus that project's API keys in `demos/real-estate/.env`, and run the demo as usual.

Everything already flows through the public API (prompts, dataset, live traffic, experiments, annotation queue, code/SDK-judge scores), so the changes are the last mile:

- **`seed_managed_evaluators.sh`** — managed judges are seeded via direct Postgres access, which doesn't exist on Cloud (and `job_configurations` have no public API). On a remote host the script now upserts the Anthropic LLM connection via `PUT /api/public/llm-connections` and prints the exact ~2-minute UI recipe for the two judges (Helpfulness/Relevance, tag `real-estate`, trace input/output mapping), exiting 0 so `run_demo.sh` continues. The self-hosted DB path is unchanged.
- **`agent/config.py`** — the key-isolation guard's expected project name is now overridable via `LANGFUSE_PROJECT_NAME` (default `real-estate`) for Cloud projects named differently.
- **`run_demo.sh`** — the final "open Langfuse" line reads host/project from `.env` instead of hardcoding `localhost:3001`.
- **`.env.example` + `README.md`** — document the Cloud option.

## Verification

- Cloud branch exercised against real `cloud.langfuse.com` with placeholder keys: remote host detected, LLM-connection endpoint confirmed present (401 auth-fail → graceful warn), UI recipe printed, exit 0.
- Self-hosted path re-run against the local stack: judges re-seeded green (idempotent).
- `bash -n` on both scripts; `agent.config` import verified with the default project name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)