### PR TITLE
real-estate: provision Cloud managed judges via the unstable evaluators API

### DIFF
--- a/demos/real-estate/README.md
+++ b/demos/real-estate/README.md
@@ -96,11 +96,15 @@ just as well — no local Langfuse stack needed:
 
 Everything seeds through the public API — prompts, dataset, live traffic,
 experiments, annotation queue, and all code/SDK-judge scores — identically to
-self-hosted. The one difference: **managed LLM-as-a-Judge evaluators** have no
-public API, so `seed_managed_evaluators.sh` detects the remote host, upserts
-the Anthropic LLM connection via API, and prints the ~2-minute UI recipe for
-the two judges (Helpfulness/Relevance on tag `real-estate`) instead of seeding
-them into the local Postgres.
+self-hosted. **Managed LLM-as-a-Judge evaluators** are provisioned too:
+`seed_managed_evaluators.sh` detects the remote host, upserts the Anthropic
+LLM connection, and creates the two judges (Helpfulness/Relevance) as
+observation-level evaluation rules via the
+[unstable evaluators API](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge#api),
+referencing the Langfuse-managed evaluator families. They score **new**
+traffic automatically (allow a few minutes); to score traces ingested before
+the rules existed, use the UI backfill: Traces table → select → Actions →
+Evaluate. If the API is unavailable, the script prints the manual UI recipe.
 
 **Switching targets:** keep one env file per backend (e.g. `.env.cloud`
 alongside your self-hosted `.env`, both gitignored) and copy the one you want

--- a/demos/real-estate/agent/config.py
+++ b/demos/real-estate/agent/config.py
@@ -107,7 +107,11 @@ def _attach_mirror() -> None:
     _mirror_processor = BatchSpanProcessor(OTLPSpanExporter(
         endpoint=f"{MIRROR_HOST}/api/public/otel/v1/traces",
         headers={"Authorization": f"Basic {auth}",
-                 "x-langfuse-public-key": MIRROR_PUBLIC_KEY},
+                 "x-langfuse-public-key": MIRROR_PUBLIC_KEY,
+                 # Observation-level (new-model) evaluators only execute in
+                 # real time on v4-ingested data; without this header the
+                 # mirror's traces render fine but judges never fire.
+                 "x-langfuse-ingestion-version": "4"},
     ))
     provider.add_span_processor(_mirror_processor)
     # The Langfuse client's flush()/atexit only cover ITS OWN processor —

--- a/demos/real-estate/scripts/seed_managed_evaluators.sh
+++ b/demos/real-estate/scripts/seed_managed_evaluators.sh
@@ -65,19 +65,66 @@ case "${LANGFUSE_HOST:-http://localhost:3001}" in
     else
       warn "ANTHROPIC_API_KEY not set — add the connection in Settings > LLM Connections"
     fi
-    cat <<STEPS
+    # Create the two judges as observation-level evaluation rules via the
+    # (unstable) evaluators API, referencing the Langfuse-MANAGED evaluator
+    # families. Rules run on each turn's root span (input={"query"} / output=
+    # final answer), so the scores read like the self-hosted trace-level ones.
+    # Idempotent: existing rule names are skipped. Falls back to a UI recipe
+    # if the API is unavailable on this instance.
+    rules=$(curl -s -m 20 -u "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" \
+      "${LANGFUSE_HOST}/api/public/unstable/evaluation-rules" || true)
+    api_failed=0
+    for judge in Helpfulness Relevance; do
+      if printf '%s' "$rules" | grep -q "\"name\":\"${judge}\""; then
+        green "${judge} rule already present"
+        continue
+      fi
+      body=$(cat <<RULE
+{
+  "name": "${judge}",
+  "evaluator": {"name": "${judge}", "scope": "managed"},
+  "target": "observation",
+  "enabled": true,
+  "sampling": 1,
+  "filter": [
+    {"type": "stringOptions", "column": "traceName", "operator": "any of",
+     "value": ["property-concierge", "conversation"]},
+    {"type": "stringOptions", "column": "name", "operator": "any of",
+     "value": ["property-concierge","turn-1","turn-2","turn-3","turn-4","turn-5","turn-6","turn-7","turn-8"]}
+  ],
+  "mapping": [
+    {"variable": "query", "source": "input", "jsonPath": "\$.query"},
+    {"variable": "generation", "source": "output"}
+  ]
+}
+RULE
+)
+      code=$(curl -s -m 20 -o /tmp/lf-rule.json -w '%{http_code}' -X POST \
+        -u "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" \
+        -H 'Content-Type: application/json' \
+        "${LANGFUSE_HOST}/api/public/unstable/evaluation-rules" -d "$body") || code="000"
+      if [ "$code" = "200" ] || [ "$code" = "201" ]; then
+        green "${judge} (managed judge, observation-level) created via API"
+      else
+        warn "${judge} rule failed (HTTP ${code}) — set it up in the UI (see below)"
+        api_failed=1
+      fi
+    done
+    if [ "$api_failed" = "1" ]; then
+      cat <<STEPS
 
   Finish in the Langfuse UI (~2 min), project '${EXPECTED_PROJECT}':
     1. Settings > LLM Connections — confirm the 'anthropic' connection exists.
-    2. Evaluators (Evals) > Default evaluation model — pick ${EVAL_MODEL}.
-    3. Evaluators > + New evaluator, twice — templates 'Helpfulness' and 'Relevance':
-         target        = live tracing data (New + Existing traces)
-         filter        = tag 'real-estate'
-         variable map  = query -> trace input, generation -> trace output
-         sampling      = 100%
-  Everything else (prompts, datasets, traffic, experiments, annotation queue,
-  code + SDK judge scores) seeds via the public API — no UI steps needed.
+    2. Evaluators > + New evaluator, twice — managed templates 'Helpfulness'
+       and 'Relevance', target = live observations, filter traceName any of
+       [property-concierge, conversation] + name any of [property-concierge,
+       turn-1..turn-8], mapping query -> input (\$.query), generation -> output.
 STEPS
+    else
+      echo ""
+      echo "  Judges score NEW traffic automatically (allow a few minutes)."
+      echo "  To score EXISTING traces: Traces table > select > Actions > Evaluate."
+    fi
     exit 0
     ;;
 esac


### PR DESCRIPTION
## Summary

Follow-up to #44. The user spotted that Langfuse now ships an (unstable) public API for evaluator management — https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge#api — which supersedes the "managed evaluators have no public API" premise behind the Cloud branch of `seed_managed_evaluators.sh`.

- **Auto-provision the judges on Cloud**: the remote branch now creates `Helpfulness` and `Relevance` as observation-level evaluation rules via `POST /api/public/unstable/evaluation-rules`, referencing the **Langfuse-managed** evaluator families. Rules run once per turn on the root span (`query` → input `$.query`, `generation` → output), scoped by `traceName`/`name` (observation-level filters expose no trace tags). Idempotent by rule name; graceful fallback to a UI recipe if the API is absent.
- **Mirror ingestion header**: the mirror OTLP exporter now sends `x-langfuse-ingestion-version: 4` — the new observation-level eval engine executes in real time on v4-ingested data.
- **README**: Cloud section updated (auto-provisioned judges, execution lag, UI backfill for traces ingested before the rules existed).

## Verification (against us.cloud.langfuse.com)

- Rules created via API and shown `active`; deleted one and re-ran the seeder — recreated (create + idempotency paths both exercised).
- Judges scored fresh mirrored traces (`bad30df9`, `207f76fc`) — scores land on the root span with names matching self-hosted (`Helpfulness`/`Relevance`).
- Self-hosted DB-seeding path untouched and re-verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)