### PR TITLE
langfuse: fix self-hosted MCP 403 + resolve project names in traces MCP

### DIFF
--- a/.agents/skills/troubleshoot/SKILL.md
+++ b/.agents/skills/troubleshoot/SKILL.md
@@ -44,6 +44,7 @@ Diagnose before acting. Most problems resolve with a targeted fix plus an idempo
    |---|---|
    | 401s from SDK/CLI, traces silently missing | Shell-exported `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` override `.env`. `unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY` and retry. |
    | LibreChat agents have no MCP tools | MCP servers init async. Wait 30s, re-run `./scripts/seed-librechat-agents.sh` (idempotent). |
+   | *Prompt Engineer* / *LLM Ops* agent missing prompt tools, or `langfuse-prompts` MCP returns 403 | Self-hosted `/api/public/mcp` validates the `Host` header against `NEXTAUTH_URL` (`localhost:3001`) but LibreChat connects as `langfuse-web:3000`. Ensure `LANGFUSE_MCP_ALLOWED_HOSTS=langfuse-web:3000` is set on `langfuse-web` (needs langfuse image ≥ v3.18x; pinned to `v3.221.1`), then `docker compose --profile langfuse up -d langfuse-web`. |
    | LibreChat agent chat shows raw `<function_calls>` / `<invoke>` / `<tool_call>` XML as text | Agent's MCP tools didn't bind → Claude role-plays the call as text (and may hallucinate the results). See [Agent emits raw tool-call XML](#agent-emits-raw-tool-call-xml) below. |
    | Langfuse not ready after ~2 min | Slow first-boot migrations. Re-run `./setup.sh`. |
    | Traces arrive but no judge scores | Check LLM connection exists (Project Settings > LLM Connections) and `langfuse-worker` logs; evaluators need ~30–60s. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ should be ✓).
 |---|---|
 | `ANTHROPIC_API_KEY is not set and no terminal is available` | Re-run with the key: `ANTHROPIC_API_KEY=sk-ant-... ./setup.sh` |
 | Agents created without tools / "No MCP tools found" | MCP servers initialize async. Wait 30s, run `./scripts/seed-librechat-agents.sh` again (idempotent — it now re-syncs tool bindings on existing agents, not just new ones). |
+| *Prompt Engineer* / *LLM Ops* agent has no prompt tools, or `langfuse-prompts` MCP 403s | Self-hosted `/api/public/mcp` rejects LibreChat's internal `Host: langfuse-web:3000` (validated against `NEXTAUTH_URL`). Ensure `LANGFUSE_MCP_ALLOWED_HOSTS=langfuse-web:3000` is set on `langfuse-web` (requires langfuse image ≥ v3.18x; pinned to `v3.221.1`), then `docker compose --profile langfuse up -d langfuse-web`. |
 | Agent chat shows raw `<function_calls>` / `<tool_call>` XML as text | Agent's MCP tools didn't bind, so Claude role-plays the call as text. Verify MCP is healthy, re-run `./scripts/seed-librechat-agents.sh`, then start a **new** conversation. Details: [troubleshoot skill](.agents/skills/troubleshoot/SKILL.md#agent-emits-raw-tool-call-xml). |
 | 401 errors from Langfuse CLI/scripts | Shell-exported keys override `.env`: `unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY` and retry. |
 | Langfuse not ready after 2 min | `docker compose --profile langfuse logs langfuse-web --tail 50` — usually slow first-boot migrations; re-run `./setup.sh`. |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -453,7 +453,7 @@ services:
 
   # Langfuse Worker (background processing)
   langfuse-worker:
-    image: langfuse/langfuse-worker:3
+    image: langfuse/langfuse-worker:3.221.1
     container_name: langfuse-worker
     restart: unless-stopped
     profiles:
@@ -472,7 +472,7 @@ services:
 
   # Langfuse Web (UI and API)
   langfuse-web:
-    image: langfuse/langfuse:3
+    image: langfuse/langfuse:3.221.1
     container_name: langfuse-web
     restart: unless-stopped
     profiles:
@@ -490,6 +490,12 @@ services:
       start_period: 60s
     environment:
       <<: *langfuse-common-env
+      # The self-hosted MCP server (/api/public/mcp) validates the incoming Host
+      # header against NEXTAUTH_URL (localhost:3001). LibreChat's langfuse-prompts
+      # MCP connects to http://langfuse-web:3000, so without allow-listing the
+      # internal host the endpoint returns 403 (per Langfuse docs → MCP Server →
+      # Self-Hosted, reverse-proxy note). Allow the Docker-internal host + port.
+      LANGFUSE_MCP_ALLOWED_HOSTS: langfuse-web:3000
 
   # ClickHouse MCP Server for Langfuse Traces
   # Enables natural language querying of Langfuse trace data via LibreChat agents

--- a/scripts/seed-clickhouse-project-dict.sh
+++ b/scripts/seed-clickhouse-project-dict.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# ==============================================================================
+# Seed ClickHouse Project-Name Dictionary
+# ==============================================================================
+# Creates the `langfuse_projects` ClickHouse dictionary, sourced live from the
+# Langfuse Postgres `projects` table, so the langfuse-traces MCP (which is
+# ClickHouse-only) can resolve project_id -> friendly name:
+#
+#     dictGet('default.langfuse_projects','name', project_id)
+#
+# Why: Langfuse's ClickHouse trace tables (traces/observations/scores) store only
+# `project_id` (an opaque cuid). The human-readable project name lives in Postgres,
+# which the ClickHouse MCP can't reach — so without this lookup, agents show raw IDs.
+#
+# Idempotent (CREATE DICTIONARY IF NOT EXISTS). Self-hosted only — cloud mode uses
+# Langfuse Cloud's managed ClickHouse, which is not reachable for DDL.
+#
+# Usage: ./scripts/seed-clickhouse-project-dict.sh
+# ==============================================================================
+set -e
+
+# Change to project root and source .env
+cd "$(dirname "$0")/.."
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+DEPLOY_MODE="${DEPLOY_MODE:-self-hosted}"
+if [ "$DEPLOY_MODE" = "cloud" ]; then
+    echo -e "${YELLOW}Cloud mode: skipping project-name dictionary (managed ClickHouse not reachable).${NC}"
+    exit 0
+fi
+
+CH_CONTAINER="langfuse-clickhouse"
+# NOTE: use the Langfuse-INTERNAL ClickHouse creds (fixed in docker-compose.yaml's
+# x-langfuse-common-env), NOT .env's CLICKHOUSE_* — those point at the public
+# ClickHouse Playground (demo@sql-clickhouse.clickhouse.com) used by the
+# clickhouse-playground MCP, and would fail auth against langfuse-clickhouse.
+CH_USER="langfuse"
+CH_PASS="langfuse123"
+
+# Postgres source (Langfuse compose defaults — see x-langfuse-common-env DATABASE_URL)
+PG_HOST="langfuse-postgres"
+PG_PORT="5432"
+PG_DB="langfuse"
+PG_USER="langfuse"
+PG_PASS="langfuse"
+
+ch() { docker exec "$CH_CONTAINER" clickhouse-client -u "$CH_USER" --password "$CH_PASS" "$@"; }
+
+# Wait for ClickHouse to accept queries
+echo -n "Waiting for ClickHouse (${CH_CONTAINER})..."
+for i in $(seq 1 30); do
+    if ch -q "SELECT 1" >/dev/null 2>&1; then
+        echo " ready"
+        break
+    fi
+    sleep 2
+    echo -n "."
+    if [ "$i" -eq 30 ]; then
+        echo ""
+        echo "ClickHouse not reachable — is the langfuse profile up? (docker compose --profile langfuse up -d)"
+        exit 1
+    fi
+done
+
+# Create the dictionary (idempotent). COMPLEX_KEY_HASHED is required for a String key.
+# LIFETIME keeps it in sync with Postgres (refresh every 5-10 min).
+ch -q "
+CREATE DICTIONARY IF NOT EXISTS default.langfuse_projects
+(
+    id String,
+    name String
+)
+PRIMARY KEY id
+SOURCE(POSTGRESQL(
+    host '${PG_HOST}' port ${PG_PORT}
+    user '${PG_USER}' password '${PG_PASS}'
+    db '${PG_DB}' table 'projects'
+))
+LAYOUT(COMPLEX_KEY_HASHED())
+LIFETIME(MIN 300 MAX 600);
+"
+
+# Verify (SELECT forces the dictionary to load from Postgres)
+COUNT=$(ch -q "SELECT count() FROM default.langfuse_projects" 2>/dev/null || echo "0")
+echo -e "${GREEN}✓${NC} langfuse_projects dictionary ready (${COUNT} project name(s) loaded)"
+echo "  Use in the langfuse-traces MCP: dictGet('default.langfuse_projects','name', project_id)"

--- a/scripts/seed-librechat-agents.sh
+++ b/scripts/seed-librechat-agents.sh
@@ -289,6 +289,16 @@ create_agent() {
             patch=$(echo "$patch" | jq --arg m "$desired_model" '. + {model: $m}')
             changes+=("model ${current_model} → ${desired_model}")
         fi
+
+        # Keep instructions in sync with this script (the source of truth) so text
+        # edits here propagate to already-created agents on re-run — otherwise an
+        # agent seeded before an instruction change keeps its stale system prompt.
+        local current_instructions
+        current_instructions=$(echo "$detail" | jq -r '.instructions // ""')
+        if [ "$current_instructions" != "$instructions" ]; then
+            patch=$(echo "$patch" | jq --arg i "$instructions" '. + {instructions: $i}')
+            changes+=("instructions updated")
+        fi
         # Re-sync tools only when the desired set differs from what's stored AND
         # every server the agent uses actually resolved its individual tools.
         # Skipping when incomplete guards against overwriting a healthy agent with
@@ -411,6 +421,17 @@ Key tables to explore:
 - observations: Individual LLM calls (generations) with model, tokens, cost, duration
 - scores: Evaluation scores (human or LLM-as-judge) linked to traces
 
+Resolving project names (IMPORTANT):
+- These tables store only project_id (an opaque ID), NOT the human-readable project name.
+- To show the friendly name, use the ClickHouse dictionary:
+      dictGet('default.langfuse_projects','name', project_id) AS project_name
+- ALWAYS display the friendly project name in your output, never the raw project_id. Example:
+      SELECT dictGet('default.langfuse_projects','name', project_id) AS project,
+             count() AS traces
+      FROM traces GROUP BY project_id ORDER BY traces DESC
+- If the dictionary is missing (dictGet errors), fall back to project_id and note that the
+  project-name dictionary has not been seeded (./scripts/seed-clickhouse-project-dict.sh).
+
 Common analyses:
 - Token usage and cost trends over time
 - Latency percentiles (p50, p95, p99) by model or service
@@ -460,6 +481,11 @@ You can help with:
 - Performance debugging: find slow traces, high-latency models, or error spikes
 - Prompt management: review current prompts, suggest iterations, track version performance
 - Data exploration: query any ClickHouse dataset for demos or analysis
+
+When querying Langfuse trace data in ClickHouse, note that the trace tables store only
+project_id (an opaque ID). To show the human-readable project name, resolve it with the
+dictionary: dictGet('default.langfuse_projects','name', project_id) AS project_name — always
+display the friendly name, not the raw project_id.
 
 Start by understanding what the user needs, then use the appropriate tools. You can combine data from multiple sources for comprehensive analysis.
 INST

--- a/setup.sh
+++ b/setup.sh
@@ -538,6 +538,25 @@ ensure_llm_judge_evaluators() {
 }
 
 #######################################
+# Provision the ClickHouse project-name dictionary (idempotent — lets the
+# langfuse-traces MCP resolve project_id -> friendly name; self-hosted only,
+# see scripts/seed-clickhouse-project-dict.sh)
+#######################################
+ensure_project_name_dict() {
+    if [ "$DEPLOY_MODE" = "cloud" ]; then
+        return 0
+    fi
+
+    header "Provisioning ClickHouse Project-Name Dictionary"
+
+    if "$SCRIPT_DIR/scripts/seed-clickhouse-project-dict.sh"; then
+        success "Project-name dictionary ready (friendly names in the langfuse-traces MCP)"
+    else
+        warn "Could not provision project-name dictionary — run ./scripts/seed-clickhouse-project-dict.sh manually"
+    fi
+}
+
+#######################################
 # Seed LibreChat agents (idempotent — skips existing agents, only
 # updating their model if it drifted from ANTHROPIC_MODEL)
 #######################################
@@ -827,6 +846,7 @@ main() {
     ensure_langfuse_llm_connection
     ensure_code_evaluators
     ensure_llm_judge_evaluators
+    ensure_project_name_dict
     ensure_librechat_agents
 
     if [ "$run_seed" = true ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,9 @@
 # ==============================================================================
 # LLM Observability Demo - Idempotent Setup
 # ==============================================================================
-# Safe to run multiple times. Never overwrites existing secrets or config.
+# Safe to run multiple times. Never overwrites your secrets or .env. NOTE:
+# pre-built demo agents ARE reconciled to their canonical definition (model,
+# MCP tools, instructions) on re-run — see ensure_librechat_agents below.
 #
 # Usage:
 #   ./setup.sh                    # Full setup (prompts for key if missing)
@@ -557,8 +559,9 @@ ensure_project_name_dict() {
 }
 
 #######################################
-# Seed LibreChat agents (idempotent — skips existing agents, only
-# updating their model if it drifted from ANTHROPIC_MODEL)
+# Seed LibreChat agents (idempotent — creates missing agents, and on re-run
+# reconciles an existing agent's model, MCP tool bindings, AND instructions to
+# their canonical definition in seed-librechat-agents.sh)
 #######################################
 ensure_librechat_agents() {
     header "Seeding LibreChat Agents"
@@ -824,7 +827,8 @@ main() {
             echo "  - Configures the Langfuse LLM connection (Playground + LLM-as-a-Judge)"
             echo "  - Creates 5 pre-configured LibreChat agents with MCP tools"
             echo "  - Detects and reuses already-running services"
-            echo "  - Never overwrites existing secrets or configuration"
+            echo "  - Never overwrites your secrets or .env"
+            echo "  - Reconciles pre-built demo agents (model, MCP tools, instructions) on re-run"
             echo ""
             exit 0
             ;;


### PR DESCRIPTION
## Summary

Two related fixes for the self-hosted LibreChat + Langfuse stack.

### 1. `langfuse-prompts` MCP was 403-ing LibreChat
The self-hosted `/api/public/mcp` endpoint validates the incoming `Host` header against `NEXTAUTH_URL` (`localhost:3001`), but LibreChat connects container-to-container as `http://langfuse-web:3000` — so every request was rejected with **403 "Access forbidden"** and the prompt-management tools silently never reached the agents. The spec's remedy, `LANGFUSE_MCP_ALLOWED_HOSTS`, did not exist in the previously pinned image (app v3.178).

- Pin `langfuse` (web) **and** `langfuse-worker` to **`v3.221.1`** (off the moving `:3` tag; they must match).
- Set `LANGFUSE_MCP_ALLOWED_HOSTS=langfuse-web:3000` on `langfuse-web`.

**Verified:** `Host: langfuse-web:3000` → **200** (was 403); LibreChat logs show `[MCP][langfuse-prompts] Initialized` with ~70 tools; Prompt Engineer / LLM Ops agents now bind their prompt tools.

### 2. Friendly project names in the `langfuse-traces` (ClickHouse-only) MCP
The ClickHouse trace tables store only `project_id` (an opaque cuid); the human-readable name lives in Postgres, which that MCP can't reach — so agents showed raw IDs.

- New idempotent **`scripts/seed-clickhouse-project-dict.sh`** creates a live ClickHouse dictionary sourced from Langfuse Postgres, so SQL can `dictGet('default.langfuse_projects','name', project_id)`. Self-hosted only; wired into `setup.sh` via `ensure_project_name_dict` so it survives `reset.sh`.
- Taught the two `langfuse-traces` agents (**LLM Observability Analyst**, **LLM Ops Assistant**) to resolve and display friendly names via the dictionary.
- `seed-librechat-agents.sh` now reconciles agent **instructions** on re-run (was model + tools only), so instruction edits reach already-created agents.

## Notes
- `seed-librechat-agents.sh` heredocs run under macOS **bash 3.2** where single quotes must balance even inside quoted heredocs — instruction text avoids apostrophes (e.g. "has not", not "hasn't").
- The dict seed script deliberately uses the Langfuse-internal ClickHouse creds (`langfuse`/`langfuse123`), **not** `.env`'s `CLICKHOUSE_*` (which point at the public ClickHouse Playground).

## Test plan
- [x] `curl` MCP endpoint with `Host: langfuse-web:3000` → 200
- [x] LibreChat initializes `langfuse-prompts` (76 MCP tools total)
- [x] `seed-clickhouse-project-dict.sh` → 7 names loaded; `dictGet` resolves
- [x] `seed-librechat-agents.sh` idempotent (0 changes on second run)
- [x] Langfuse data intact after the 3.178→3.221 migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)