### PR TITLE
real-estate: one trace per turn grouped by session (fix Sessions view)

### DIFF
--- a/demos/real-estate/AI_ENGINEERING_LOOP.md
+++ b/demos/real-estate/AI_ENGINEERING_LOOP.md
@@ -40,7 +40,7 @@ The loop clusters into two areas of work:
 
 | # | Loop step | What it is | In this demo | Where to see it |
 |---|-----------|-----------|--------------|-----------------|
-| 1 | **Trace** | Full path of each request: prompts, tools, outputs, latency, cost | `agent/concierge.py` emits `plan → agent-turn → tool:* → synthesis`; multi-turn = one trace; sessions; the **prompt version is linked to each generation** | Langfuse **Tracing** / **Sessions**; DEMO_SCRIPT Act 2 |
+| 1 | **Trace** | Full path of each request: prompts, tools, outputs, latency, cost | `agent/concierge.py` emits `plan → agent-turn → tool:* → synthesis`; each turn is its own trace, grouped into a **session** by `session_id`; the **prompt version is linked to each generation** | Langfuse **Tracing** / **Sessions**; DEMO_SCRIPT Act 2 |
 | 2 | **Monitor** | Surface the traces that deserve attention over time | Managed LLM-as-a-Judge (auto) + custom SDK judges + code scores + **👍/👎 user feedback** from the portal; **Dashboards** for cost/latency/score trends | Langfuse **Evaluators**, **Dashboards**; DEMO_SCRIPT Acts 1, 3 / close |
 | 3 | **Build datasets** | Turn real + designed scenarios into repeatable test cases | `data/dataset.py` → `property-concierge-eval` (18 curated items across Europe, incl. an impossible one); production traces can be added to it from the UI | Langfuse **Datasets**; `scripts/seed_dataset.py`; DEMO_SCRIPT Act 5 |
 | 4 | **Experiment** | Change one variable, compare vs a baseline | Same agent + dataset + evaluators across **models** (Claude vs GPT-4o) **and prompt versions** (production vs candidate) | `scripts/run_experiment.py --model / --prompt-label`; Langfuse **Datasets → Runs → Compare** |
@@ -125,4 +125,4 @@ This is the money path (DEMO_SCRIPT Act 6). Every step is real and runnable:
 | Promote a label to deploy | **Live** — do it in the Langfuse UI |
 | GitHub repository-dispatch CI/CD + sync-to-repo | **Documented** — needs a real repo, PAT, public webhook; see [`cicd/`](cicd/) |
 | Add production trace → dataset | **Live in UI** — one click on a trace |
-| Explicit **user feedback** as a Monitor signal | **Live** — 👍/👎 in the portal writes a `user-feedback` score onto the conversation's trace (`webapp` `/api/feedback`) |
+| Explicit **user feedback** as a Monitor signal | **Live** — 👍/👎 in the portal writes a `user-feedback` score onto that turn's trace (`webapp` `/api/feedback`) |

--- a/demos/real-estate/DEMO_SCRIPT.md
+++ b/demos/real-estate/DEMO_SCRIPT.md
@@ -175,10 +175,10 @@ visibility you're guessing. Here's what "you're not guessing" looks like.
 **Show.** The chat you just ran is a **Session** — each turn is its own trace,
 and a shared `session_id` stitches them together. Open **Sessions →
 `sess-madrid-buyer-001`**:
-- the session lists **every turn as its own trace — named after the question —
-  in order**; the follow-up resolved "that one" because the agent carries the
-  conversation so far. (In the **Tracing** list those same per-turn traces read
-  like the conversation — one question per row — not a stack of look-alikes.)
+- the session lists **every turn as its own trace, in order** — the follow-up
+  resolved "that one" because the agent carries the conversation so far. This
+  Sessions view *is* the whole conversation; the flat **Tracing** table is the
+  per-turn list (each turn's question shows in its Input column).
 - open a turn's trace and walk it top → bottom: root `property-concierge`
   (**input** = that turn's question, **output** = its answer, metadata
   `agent_model`) → `plan` (extracts constraints) → `agent-turn-N` (tool

--- a/demos/real-estate/DEMO_SCRIPT.md
+++ b/demos/real-estate/DEMO_SCRIPT.md
@@ -179,7 +179,7 @@ and a shared `session_id` stitches them together. Open **Sessions →
   resolved "that one" because the agent carries the conversation so far. This
   Sessions view *is* the whole conversation; the flat **Tracing** table is the
   per-turn list (each turn's question shows in its Input column).
-- open a turn's trace and walk it top → bottom: root `property-concierge`
+- open a turn's trace and walk it top → bottom: root `handle-concierge-chat-message`
   (**input** = that turn's question, **output** = its answer, metadata
   `agent_model`) → `plan` (extracts constraints) → `agent-turn-N` (tool
   decisions) → `tool:*` (**click one** — exact input/output, "no black box") →
@@ -480,8 +480,8 @@ instrumentation surface for a whole agent.
 
 **3 · Session wrapping (Act 2 / the Sessions story) — one call**
 ```python
-# agent/concierge.py  each turn is its OWN trace, rooted at property-concierge
-with lf.start_as_current_observation(as_type="span", name="property-concierge") as root:
+# agent/concierge.py  each turn is its OWN trace, rooted at handle-concierge-chat-message
+with lf.start_as_current_observation(as_type="span", name="handle-concierge-chat-message") as root:
     # THIS is what groups a conversation's per-turn traces into a Langfuse Session
     ctx = propagate_attributes(session_id=session_id, user_id=user_id, tags=..., trace_name=...)
 ```

--- a/demos/real-estate/DEMO_SCRIPT.md
+++ b/demos/real-estate/DEMO_SCRIPT.md
@@ -465,13 +465,13 @@ wrong place — a real operational footgun, handled in ~3 lines.
 **2 · The whole trace tree is one function — `agent/concierge.py` (`run_turn`)**
 ```python
 # every step is one context-manager call; the nesting IS the trace tree
-with lf.start_as_current_observation(as_type="generation", name="plan", ...):   # :177
+with lf.start_as_current_observation(as_type="generation", name="plan", ...):
     ...
 for i in range(MAX_ITERS):
-    with lf.start_as_current_observation(as_type="generation", name=f"agent-turn-{i+1}"):  # :211
+    with lf.start_as_current_observation(as_type="generation", name=f"agent-turn-{i+1}"):
         ...
     for call in res["tool_calls"]:
-        with lf.start_as_current_observation(as_type="span", name=f"tool:{call['name']}"):  # :234
+        with lf.start_as_current_observation(as_type="span", name=f"tool:{call['name']}"):
             ...
 ```
 *Why it matters:* the trace you walked in Act 2 is just these nested `with`
@@ -493,7 +493,7 @@ Sessions view — grouping is a property you *set*, not a pipeline you build.
 ```python
 # agent/llm.py:59  provider-agnostic call returns usage + cost_details (:41 publishes GPT prices)
 res = call_llm(model, system, messages, tools=tools, max_tokens=1500)
-# agent/concierge.py:217  attach them to the generation
+# agent/concierge.py  attach them to the generation
 gen.update(output=..., usage_details=res["usage"], cost_details=res["cost_details"])
 ```
 *Why it matters:* cost per step is captured at source. Claude is auto-priced by
@@ -507,13 +507,13 @@ return get_langfuse().get_prompt(AGENT_PROMPT_NAME, label=label, fallback=AGENT_
 # agent/prompts.py:112  link the fetched version to the generation (skips when fallback)
 def link_kwargs(prompt): return {} if getattr(prompt, "is_fallback", False) else {"prompt": prompt}
 ```
-Used at `concierge.py:178,199` as `**link_kwargs(...)`. *Why it matters:* the prompt
+Used in `concierge.py` as `**link_kwargs(...)`. *Why it matters:* the prompt
 is data in Langfuse, not a string in the app — so promoting a label *is* the deploy
 (Act 6), and the fallback means the app still runs on a fresh clone with nothing seeded.
 
 **6 · Scores on an observation (Act 3) — `agent/scoring.py` → attached in `concierge.py`**
 ```python
-# agent/concierge.py:300  attach each deterministic code score to the SYNTHESIS observation
+# agent/concierge.py  attach each deterministic code score to the SYNTHESIS observation
 for s in run_code_evaluators(result):          # agent/scoring.py:150
     lf.create_score(trace_id=trace_id, observation_id=final_gen_id,
                     name=s.name, value=s.value, data_type=s.data_type, comment=s.comment)

--- a/demos/real-estate/DEMO_SCRIPT.md
+++ b/demos/real-estate/DEMO_SCRIPT.md
@@ -93,8 +93,8 @@ third tab on the AI Engineering loop for the between-act anchor.
 | **Tracing** an agent (nested spans) | Act 2 — `plan → agent-turn → tool:* → synthesis` |
 | **Generations** w/ token usage **+ €cost** | Act 2 — click any generation |
 | **Tool spans** | Act 2 — `tool:search_listings`, `tool:calculate_mortgage`, … |
-| **Multi-turn conversation = ONE trace** | Act 2 — `turn-1 / turn-2 / turn-3` observations in a single trace |
-| **Sessions** (group conversations) | Act 2 — Sessions → `sess-madrid-buyer-001` |
+| **Multi-turn conversation → Session** | Act 2 — each turn its own trace, grouped by `session_id` |
+| **Sessions** (group a conversation's turns) | Act 2 — Sessions → `sess-madrid-buyer-001` |
 | **Tags / Users / Metadata** | Act 2 — filter by tag `real-estate`; `agent_model` in metadata |
 | **Scores on individual observations** (code evals) | Act 3 — 5 code scores on the synthesis obs |
 | **Managed LLM-as-a-Judge** (auto, native) | Act 3 — Helpfulness/Relevance run by Langfuse |
@@ -172,33 +172,39 @@ and how do they even hear about it today?"
 was it the retrieval, the tool, the prompt, or the model?* Without step-level
 visibility you're guessing. Here's what "you're not guessing" looks like.
 
-**Show.** The chat you just ran is **one trace**, each exchange a `turn-N`
-observation. Walk it top → bottom:
-- root trace `conversation` — **input** = first question, **output** = latest
-  answer, metadata `agent_model`; grouped under a **session**.
-- `turn-1`, `turn-2`, … — one per user message; the follow-up resolved "that one"
-  because the agent gets the conversation so far.
-- inside a turn: `plan` (extracts constraints) → `agent-turn-N` (tool decisions) →
-  `tool:*` (**click one** — exact input/output, "no black box") → final synthesis.
+**Show.** The chat you just ran is a **Session** — each turn is its own trace,
+and a shared `session_id` stitches them together. Open **Sessions →
+`sess-madrid-buyer-001`**:
+- the session lists **every turn as its own trace — named after the question —
+  in order**; the follow-up resolved "that one" because the agent carries the
+  conversation so far. (In the **Tracing** list those same per-turn traces read
+  like the conversation — one question per row — not a stack of look-alikes.)
+- open a turn's trace and walk it top → bottom: root `property-concierge`
+  (**input** = that turn's question, **output** = its answer, metadata
+  `agent_model`) → `plan` (extracts constraints) → `agent-turn-N` (tool
+  decisions) → `tool:*` (**click one** — exact input/output, "no black box") →
+  final synthesis.
 - Click a **generation** → **token usage** and **€ cost** per step, model, latency,
   and the **Prompt** it used (`property-concierge-agent` v1), version-linked to the
   generation.
 
-Then: **Sessions** → `sess-madrid-buyer-001`; **Tracing** list → filter by tag
-`real-estate`, note user ids + metadata.
+Then: **Tracing** list → filter by tag `real-estate`, note user ids + metadata.
 
-> **Presenter note — tell the war story.** The first version of this app created a
-> **new trace per turn** — the most common instrumentation mistake in
-> conversational apps, and it quietly breaks debugging *and* scoring (you only
-> ever grade fragments, never the conversation). One propagated `session_id` is
-> the fix. Prove it live: click **New conversation** in the portal, ask anything,
-> and a *separate* trace appears in the Tracing list.
+> **Presenter note — tell the war story.** A common instrumentation mistake in
+> conversational apps is cramming the *entire* conversation into **one** trace (a
+> `turn-N` span per message). It quietly breaks two things: the **Sessions** view
+> collapses to a single trace, and scoring grades the whole blob instead of each
+> exchange. Langfuse's own guidance is the opposite — *one trace = one invocation*,
+> with turns grouped by a propagated `session_id`
+> ([traces vs sessions](https://langfuse.com/academy/tracing#traces-vs-sessions)).
+> That's what this demo does. Prove it live: ask two questions in the same chat,
+> then open **Sessions** — both turns appear as *separate* traces under one session.
 
 **Land.** "Root-cause goes from 'read the logs and guess' to 'open the trace and
 see the step that broke' — with the exact tool input, the cost of every call, and
-the prompt version that produced it. Multi-turn folds into one trace and
-conversations into a session, so you're debugging an *interaction*, not a
-disconnected call."
+the prompt version that produced it. Each turn is its own clean trace, and the
+session stitches them into one interaction — so you can debug a single exchange
+*or* replay the whole conversation."
 
 **Ask.** "When an LLM answer is bad today, what can you actually see — the final
 output only, or the steps? Roughly how long does root-cause take, and who gets
@@ -472,17 +478,16 @@ for i in range(MAX_ITERS):
 blocks — `as_type` picks generation vs span, `name` is the label. That's the entire
 instrumentation surface for a whole agent.
 
-**3 · Session wrapping (Act 2 / the Sessions story) — two lines, two files**
+**3 · Session wrapping (Act 2 / the Sessions story) — one call**
 ```python
-# webapp/server.py:95   one conversation = one trace (deterministic id from the session)
-conv_trace_id = get_langfuse().create_trace_id(seed=sid)
-# agent/concierge.py:141 each turn attaches to that shared trace
-root_cm = lf.start_as_current_observation(..., trace_context={"trace_id": conversation_trace_id})
-# agent/concierge.py:148 THIS is what groups traces into a Langfuse Session
-ctx = propagate_attributes(session_id=session_id, user_id=user_id, tags=..., trace_name=...)
+# agent/concierge.py  each turn is its OWN trace, rooted at property-concierge
+with lf.start_as_current_observation(as_type="span", name="property-concierge") as root:
+    # THIS is what groups a conversation's per-turn traces into a Langfuse Session
+    ctx = propagate_attributes(session_id=session_id, user_id=user_id, tags=..., trace_name=...)
 ```
-*Why it matters:* `propagate_attributes(session_id=...)` is the one call that powers
-the entire Sessions view — grouping is a property you *set*, not a pipeline you build.
+*Why it matters:* one trace = one turn (Langfuse's rule of thumb), and
+`propagate_attributes(session_id=...)` is the one call that powers the entire
+Sessions view — grouping is a property you *set*, not a pipeline you build.
 
 **4 · Token usage + € cost (Act 2 cost story) — `agent/llm.py` → folded into the generation**
 ```python

--- a/demos/real-estate/README.md
+++ b/demos/real-estate/README.md
@@ -29,8 +29,8 @@ Everything targets a dedicated Langfuse project named **`real-estate`** on
 | Agent tracing (nested spans) | `plan → agent-turn → tool:* → synthesis` per turn |
 | Generations with token usage **and € cost** | every LLM call is a `generation` observation |
 | Tool observability | each tool call is its own span with input/output |
-| **Multi-turn conversation = one trace** | each turn is a `turn-N` observation in the same `traceId` |
-| Sessions | group a user's conversations by `session_id` |
+| **Multi-turn conversation → session** | each turn is its own trace; a shared `session_id` groups them in the Sessions view |
+| Sessions | group a conversation's per-turn traces by `session_id` |
 | Tags / users / metadata | every trace tagged `real-estate` + a user id |
 | **Scores on individual observations** | 5 deterministic **code** scores on the synthesis obs |
 | **Managed LLM-as-a-Judge** (native, automatic) | Helpfulness / Relevance, run by the Langfuse worker on `real-estate` traces |
@@ -179,11 +179,12 @@ Key design choices:
   no redeploy, and you can `run_experiment.py --prompt-label candidate` to prove a
   change before shipping it. This is what closes the loop; see
   [`AI_ENGINEERING_LOOP.md`](AI_ENGINEERING_LOOP.md) and [`cicd/`](cicd/).
-- **A conversation is one trace.** Pass `run_turn(conversation_trace_id=..., turn_index=n)`
-  (a deterministic `langfuse.create_trace_id(seed=session_id)`) and every turn lands
-  in the *same* trace as a `turn-N` observation — the portal keeps per-session
-  history + turn index so follow-ups both carry context and share one `traceId`.
-  Single-turn callers (experiment, ad-hoc queries) just omit it and get one trace each.
+- **A conversation is a session, not one trace.** Following Langfuse's rule of thumb —
+  *one trace = one invocation of your system* — every turn is its **own trace**, and a
+  shared `session_id` groups them under a single **Session** (each turn shows up as its
+  own trace, in order). Pass `run_turn(session_id=..., turn_index=n)`; the portal keeps
+  per-session history + turn index so follow-ups carry context. See
+  [Langfuse: traces vs sessions](https://langfuse.com/academy/tracing#traces-vs-sessions).
 - **Three scoring layers.** (1) deterministic **code** scores on the *synthesis
   observation* (agent, live mode); (2) **managed** LLM judges
   (Helpfulness/Relevance) run automatically by Langfuse on

--- a/demos/real-estate/agent/concierge.py
+++ b/demos/real-estate/agent/concierge.py
@@ -137,21 +137,17 @@ def run_turn(
     with lf.start_as_current_observation(as_type="span", name="property-concierge") as root:
         # Trace-level attributes (only in live mode; the experiment owns the trace).
         if not is_experiment:
-            # Name the trace after the user's question — Langfuse's documented
-            # pattern (traces vs sessions) — so the Tracing list and the Session
-            # read like the conversation itself, one question per row, instead of
-            # a stack of identical "property-concierge" rows. The root span keeps
-            # the stable `property-concierge` name (the agent run for this turn).
-            trace_name = " ".join(query.split())
-            if len(trace_name) > 70:
-                trace_name = trace_name[:69].rstrip() + "…"
+            # Stable, low-cardinality trace name (Langfuse best practice): the
+            # turn's question lives in the trace INPUT (shown in the Traces table),
+            # NOT the name, so traces stay groupable/filterable/targetable. Turns
+            # are stitched into one conversation by session_id (see Sessions view).
             ctx = propagate_attributes(
                 session_id=session_id,
                 user_id=user_id,
                 # Fault-injected traces self-identify via a `fault:<name>` tag so
                 # they are filterable (and explainable) during a demo.
                 tags=BASE_TAGS + (extra_tags or []) + ([f"fault:{fault}"] if fault else []),
-                trace_name=trace_name or "property-concierge",
+                trace_name="property-concierge",
             )
         else:
             from contextlib import nullcontext

--- a/demos/real-estate/agent/concierge.py
+++ b/demos/real-estate/agent/concierge.py
@@ -4,7 +4,7 @@ The Real Estate Property Concierge — an instrumented tool-using agent.
 Flow per turn (each step is a Langfuse observation, so the trace tree reads
 top-to-bottom like the agent's reasoning):
 
-    property-concierge            (root span; trace input=query, output=answer)
+    handle-concierge-chat-message (root span; trace input=query, output=answer)
     ├─ plan                       (generation) extract structured constraints
     ├─ agent-turn-1               (generation) Claude decides which tools to call
     ├─ tool:search_listings       (span)       catalog search
@@ -31,6 +31,12 @@ from .scoring import run_code_evaluators, extract_listing_ids, prior_ids_from_hi
 from .prompts import get_plan_prompt, get_agent_prompt, link_kwargs, PRODUCTION_LABEL
 
 MAX_ITERS = 5
+
+# Stable, low-cardinality name for each turn's trace AND its root span (Langfuse
+# best practice — verb-first, like the docs' own `handle-chatbot-message`). The
+# question lives in the trace INPUT, not the name. Keeping the trace name and the
+# root span name identical lets newer Langfuse UIs render them as a single node.
+TRACE_NAME = "handle-concierge-chat-message"
 
 # --- lightweight language detection (Spanish vs English) for language-match ---
 # Only Spanish FUNCTION/verb words — strong language signals. Deliberately NOT
@@ -132,9 +138,9 @@ def run_turn(
     model = model or AGENT_MODEL
     history = history or []
 
-    # One turn = one trace, rooted at `property-concierge`. The shared session_id
-    # (set below) groups a conversation's turns together in the Sessions view.
-    with lf.start_as_current_observation(as_type="span", name="property-concierge") as root:
+    # One turn = one trace, rooted at the `handle-concierge-chat-message` span.
+    # The shared session_id (set below) groups a conversation's turns in Sessions.
+    with lf.start_as_current_observation(as_type="span", name=TRACE_NAME) as root:
         # Trace-level attributes (only in live mode; the experiment owns the trace).
         if not is_experiment:
             # Stable, low-cardinality trace name (Langfuse best practice): the
@@ -147,7 +153,7 @@ def run_turn(
                 # Fault-injected traces self-identify via a `fault:<name>` tag so
                 # they are filterable (and explainable) during a demo.
                 tags=BASE_TAGS + (extra_tags or []) + ([f"fault:{fault}"] if fault else []),
-                trace_name="property-concierge",
+                trace_name=TRACE_NAME,
             )
         else:
             from contextlib import nullcontext

--- a/demos/real-estate/agent/concierge.py
+++ b/demos/real-estate/agent/concierge.py
@@ -116,42 +116,42 @@ def run_turn(
     model: Optional[str] = None,
     prompt_label: str = PRODUCTION_LABEL,
     history: Optional[List[Dict[str, Any]]] = None,
-    conversation_trace_id: Optional[str] = None,
     turn_index: int = 0,
 ) -> Dict[str, Any]:
     """Run one agent turn.
 
-    Multi-turn conversations: pass a stable `conversation_trace_id`
-    (e.g. langfuse.create_trace_id(seed=session_id)) plus the 0-based
-    `turn_index`. Every turn of the conversation then lands in the SAME trace as
-    a `turn-N` observation, with its plan/tool/synthesis steps nested underneath —
-    so one conversation = one traceId. `history` gives the agent the prior turns
-    so follow-ups like "keep it under 400k" / "that one" resolve.
+    Every turn is its OWN trace — the Langfuse rule of thumb is "one trace = one
+    invocation of your system" (one API call / one agent execution). Multi-turn
+    conversations are stitched together by a shared `session_id`, so Langfuse's
+    **Sessions** view lists each turn as its own trace, in order. Pass the 0-based
+    `turn_index` (surfaced as the `turn` metadata label) and `history` (the prior
+    turns) so follow-ups like "keep it under 400k" / "that one" resolve against
+    the conversation. See https://langfuse.com/academy/tracing#traces-vs-sessions.
     """
     lf = get_langfuse()
     model = model or AGENT_MODEL
     history = history or []
-    multiturn = conversation_trace_id is not None
 
-    # Multi-turn: this turn is a `turn-N` span attached to the shared conversation
-    # trace. Single-turn: the turn is its own trace root.
-    if multiturn:
-        root_cm = lf.start_as_current_observation(
-            as_type="span", name=f"turn-{turn_index + 1}",
-            trace_context={"trace_id": conversation_trace_id})
-    else:
-        root_cm = lf.start_as_current_observation(as_type="span", name="property-concierge")
-
-    with root_cm as root:
+    # One turn = one trace, rooted at `property-concierge`. The shared session_id
+    # (set below) groups a conversation's turns together in the Sessions view.
+    with lf.start_as_current_observation(as_type="span", name="property-concierge") as root:
         # Trace-level attributes (only in live mode; the experiment owns the trace).
         if not is_experiment:
+            # Name the trace after the user's question — Langfuse's documented
+            # pattern (traces vs sessions) — so the Tracing list and the Session
+            # read like the conversation itself, one question per row, instead of
+            # a stack of identical "property-concierge" rows. The root span keeps
+            # the stable `property-concierge` name (the agent run for this turn).
+            trace_name = " ".join(query.split())
+            if len(trace_name) > 70:
+                trace_name = trace_name[:69].rstrip() + "…"
             ctx = propagate_attributes(
                 session_id=session_id,
                 user_id=user_id,
                 # Fault-injected traces self-identify via a `fault:<name>` tag so
                 # they are filterable (and explainable) during a demo.
                 tags=BASE_TAGS + (extra_tags or []) + ([f"fault:{fault}"] if fault else []),
-                trace_name="conversation" if multiturn else "property-concierge",
+                trace_name=trace_name or "property-concierge",
             )
         else:
             from contextlib import nullcontext
@@ -163,8 +163,8 @@ def run_turn(
                         metadata={"agent_model": model, "provider": provider_of(model),
                                   "prompt_label": prompt_label, "turn": turn_index + 1,
                                   **({"fault": fault} if fault else {})})
-            # Trace-level input: set the opening question once (first turn).
-            if not is_experiment and (not multiturn or turn_index == 0):
+            # This turn's question is the trace input.
+            if not is_experiment:
                 lf.update_current_trace(input={"query": query},
                                         metadata={"agent_model": model})
 
@@ -310,7 +310,7 @@ def run_turn(
             }
 
             root.update(output=final_text)
-            # Keep the trace output pointed at the latest answer as turns accrue.
+            # This turn's answer is the trace output.
             if not is_experiment:
                 lf.update_current_trace(output=final_text)
 

--- a/demos/real-estate/scripts/run_live_traffic.py
+++ b/demos/real-estate/scripts/run_live_traffic.py
@@ -92,19 +92,17 @@ def main():
           f"({'no ' if args.no_judge else ''}LLM-judge scores)...\n")
 
     histories: dict = {}   # session_id -> accumulated conversational turns
-    conv_ids: dict = {}    # session_id -> shared conversation trace id
     turns: dict = {}       # session_id -> 0-based turn index
     for i, (query, sess, user, tags, fault) in enumerate(TRAFFIC, 1):
         tag = f" [fault:{fault}]" if fault else ""
         sess_tag = " [session]" if sess else ""
         print(f"[{i:2}/{len(TRAFFIC)}]{sess_tag}{tag} {query[:64]}")
         history = histories.get(sess, []) if sess else []
-        # A session's turns all share one trace (turn-1, turn-2, … in one trace).
-        conv_tid = conv_ids.setdefault(sess, lf.create_trace_id(seed=sess)) if sess else None
+        # Each turn is its own trace; a session's turns are grouped by session_id
+        # (visible together in the Langfuse Sessions view).
         turn_index = turns.get(sess, 0)
         result = run_turn(query, session_id=sess, user_id=user, extra_tags=tags,
-                          fault=fault, history=history,
-                          conversation_trace_id=conv_tid, turn_index=turn_index)
+                          fault=fault, history=history, turn_index=turn_index)
         if sess:
             histories[sess] = history + [{"role": "user", "content": query},
                                          {"role": "assistant", "content": result["answer"]}]

--- a/demos/real-estate/scripts/seed_managed_evaluators.sh
+++ b/demos/real-estate/scripts/seed_managed_evaluators.sh
@@ -67,7 +67,7 @@ case "${LANGFUSE_HOST:-http://localhost:3001}" in
     fi
     # Create the two judges as observation-level evaluation rules via the
     # (unstable) evaluators API, referencing the Langfuse-MANAGED evaluator
-    # families. Each turn is its own trace rooted at `property-concierge`, so the
+    # families. Each turn is its own trace rooted at `handle-concierge-chat-message`, so the
     # rules run on that root span (input={"query"} / output=final answer) — the
     # scores read like the self-hosted trace-level ones. Idempotent: existing
     # rule names are skipped. Falls back to a UI recipe if the API is unavailable.
@@ -88,9 +88,9 @@ case "${LANGFUSE_HOST:-http://localhost:3001}" in
   "sampling": 1,
   "filter": [
     {"type": "stringOptions", "column": "traceName", "operator": "any of",
-     "value": ["property-concierge"]},
+     "value": ["handle-concierge-chat-message"]},
     {"type": "stringOptions", "column": "name", "operator": "any of",
-     "value": ["property-concierge"]}
+     "value": ["handle-concierge-chat-message"]}
   ],
   "mapping": [
     {"variable": "query", "source": "input", "jsonPath": "\$.query"},
@@ -117,8 +117,8 @@ RULE
     1. Settings > LLM Connections — confirm the 'anthropic' connection exists.
     2. Evaluators > + New evaluator, twice — managed templates 'Helpfulness'
        and 'Relevance', target = live observations, filter traceName any of
-       [property-concierge] + name any of [property-concierge], mapping
-       query -> input (\$.query), generation -> output.
+       [handle-concierge-chat-message] + name any of [handle-concierge-chat-message],
+       mapping query -> input (\$.query), generation -> output.
 STEPS
     else
       echo ""

--- a/demos/real-estate/scripts/seed_managed_evaluators.sh
+++ b/demos/real-estate/scripts/seed_managed_evaluators.sh
@@ -87,6 +87,8 @@ case "${LANGFUSE_HOST:-http://localhost:3001}" in
   "enabled": true,
   "sampling": 1,
   "filter": [
+    {"type": "stringOptions", "column": "traceName", "operator": "any of",
+     "value": ["property-concierge"]},
     {"type": "stringOptions", "column": "name", "operator": "any of",
      "value": ["property-concierge"]}
   ],
@@ -114,9 +116,9 @@ RULE
   Finish in the Langfuse UI (~2 min), project '${EXPECTED_PROJECT}':
     1. Settings > LLM Connections — confirm the 'anthropic' connection exists.
     2. Evaluators > + New evaluator, twice — managed templates 'Helpfulness'
-       and 'Relevance', target = live observations, filter name any of
-       [property-concierge] (the per-turn root span; traces are named after the
-       question), mapping query -> input (\$.query), generation -> output.
+       and 'Relevance', target = live observations, filter traceName any of
+       [property-concierge] + name any of [property-concierge], mapping
+       query -> input (\$.query), generation -> output.
 STEPS
     else
       echo ""

--- a/demos/real-estate/scripts/seed_managed_evaluators.sh
+++ b/demos/real-estate/scripts/seed_managed_evaluators.sh
@@ -67,10 +67,10 @@ case "${LANGFUSE_HOST:-http://localhost:3001}" in
     fi
     # Create the two judges as observation-level evaluation rules via the
     # (unstable) evaluators API, referencing the Langfuse-MANAGED evaluator
-    # families. Rules run on each turn's root span (input={"query"} / output=
-    # final answer), so the scores read like the self-hosted trace-level ones.
-    # Idempotent: existing rule names are skipped. Falls back to a UI recipe
-    # if the API is unavailable on this instance.
+    # families. Each turn is its own trace rooted at `property-concierge`, so the
+    # rules run on that root span (input={"query"} / output=final answer) — the
+    # scores read like the self-hosted trace-level ones. Idempotent: existing
+    # rule names are skipped. Falls back to a UI recipe if the API is unavailable.
     rules=$(curl -s -m 20 -u "${LANGFUSE_PUBLIC_KEY}:${LANGFUSE_SECRET_KEY}" \
       "${LANGFUSE_HOST}/api/public/unstable/evaluation-rules" || true)
     api_failed=0
@@ -87,10 +87,8 @@ case "${LANGFUSE_HOST:-http://localhost:3001}" in
   "enabled": true,
   "sampling": 1,
   "filter": [
-    {"type": "stringOptions", "column": "traceName", "operator": "any of",
-     "value": ["property-concierge", "conversation"]},
     {"type": "stringOptions", "column": "name", "operator": "any of",
-     "value": ["property-concierge","turn-1","turn-2","turn-3","turn-4","turn-5","turn-6","turn-7","turn-8"]}
+     "value": ["property-concierge"]}
   ],
   "mapping": [
     {"variable": "query", "source": "input", "jsonPath": "\$.query"},
@@ -116,9 +114,9 @@ RULE
   Finish in the Langfuse UI (~2 min), project '${EXPECTED_PROJECT}':
     1. Settings > LLM Connections — confirm the 'anthropic' connection exists.
     2. Evaluators > + New evaluator, twice — managed templates 'Helpfulness'
-       and 'Relevance', target = live observations, filter traceName any of
-       [property-concierge, conversation] + name any of [property-concierge,
-       turn-1..turn-8], mapping query -> input (\$.query), generation -> output.
+       and 'Relevance', target = live observations, filter name any of
+       [property-concierge] (the per-turn root span; traces are named after the
+       question), mapping query -> input (\$.query), generation -> output.
 STEPS
     else
       echo ""

--- a/demos/real-estate/webapp/server.py
+++ b/demos/real-estate/webapp/server.py
@@ -69,8 +69,9 @@ class FeedbackRequest(BaseModel):
 
 
 # Per-session state: conversation history (agent context) + a monotonic turn
-# counter (stable turn-N labels — must NOT be derived from the capped history).
-# One conversation = one trace. In-memory (resets on restart) — fine for a demo.
+# counter (stable turn number for the `turn` metadata — must NOT be derived from
+# the capped history). Each turn is its own trace, grouped by session_id.
+# In-memory (resets on restart) — fine for a demo.
 _SESSIONS: dict[str, dict] = {}
 _SESSIONS_LOCK = threading.Lock()
 MAX_HISTORY_TURNS = 8  # cap the history fed to the agent (~4 exchanges)
@@ -88,20 +89,18 @@ def health():
 
 @app.post("/api/chat")
 def chat(req: ChatRequest):
-    # Session-less callers get a unique id so they never share history or a trace.
+    # Session-less callers get a unique id so they never share history or a session.
     sid = req.session_id or f"anon-{uuid.uuid4().hex[:12]}"
-    # One conversation = one trace: a deterministic trace id from the session id,
-    # so every turn of this chat lands in the same trace as turn-1, turn-2, ….
-    conv_trace_id = get_langfuse().create_trace_id(seed=sid)
     with _SESSIONS_LOCK:
         state = _SESSIONS.get(sid, {"history": [], "turns": 0})
         history = list(state["history"])
         turn_index = state["turns"]
 
-    # Pass the resolved sid (not the raw None) so the trace carries the session.
+    # Each turn is its own trace; the shared session_id (the resolved sid, not the
+    # raw None) groups this chat's turns together in Langfuse's Sessions view.
     result = run_turn(req.query, session_id=sid, user_id="portal-visitor",
                       extra_tags=["portal"], history=history,
-                      conversation_trace_id=conv_trace_id, turn_index=turn_index)
+                      turn_index=turn_index)
 
     with _SESSIONS_LOCK:
         prev = _SESSIONS.get(sid, {"history": [], "turns": 0})

--- a/demos/real-estate/webapp/static/index.html
+++ b/demos/real-estate/webapp/static/index.html
@@ -160,10 +160,10 @@ const CITY_GRAD = {
 const $ = s => document.querySelector(s);
 const thread = $("#thread");
 
-// session id -> one Langfuse session (= one trace) per conversation.
-// Minted fresh on every page load, so a refresh starts a NEW conversation/trace
-// instead of appending to the previous one. "New conversation" re-mints it too, so
-// a presenter can run several clean, separately-grouped conversations per page load.
+// session id -> one Langfuse session per conversation; each turn is its own trace.
+// Minted fresh on every page load, so a refresh starts a NEW conversation (new
+// session) instead of appending to the previous one. "New conversation" re-mints it
+// too, so a presenter can run several clean, separately-grouped conversations per page load.
 function newSid(){ return "portal-" + Math.random().toString(36).slice(2,10) + Date.now().toString(36).slice(-4); }
 let sid = newSid();
 
@@ -248,7 +248,7 @@ function addBot(data){
   scroll();
 }
 
-// Explicit user feedback → a Langfuse score on this conversation's trace.
+// Explicit user feedback → a Langfuse score on this turn's trace.
 async function sendFeedback(fbEl, value){
   const traceId = fbEl.getAttribute("data-trace");
   const clicked = fbEl.querySelector(value ? ".up" : ".down");
@@ -284,7 +284,7 @@ async function send(){
 $("#send").onclick=send;
 $("#q").addEventListener("keydown",e=>{ if(e.key==="Enter") send(); });
 
-// Start a fresh conversation: new session id (=> new Langfuse trace), clear the
+// Start a fresh conversation: new session id (=> a new Langfuse session), clear the
 // thread and bring back the hero. The backend keys history by session id, so the
 // agent also starts with a clean context — no bleed from the previous chat.
 function resetConversation(){


### PR DESCRIPTION
## Problem

Feedback on the real-estate demo: in the **Sessions** view every turn of a conversation collapsed into a single trace ("Total traces: 1"), surfacing only the last turn. Root cause: the concierge forced every turn into one shared `traceId` (`conversation_trace_id` + `trace_context={"trace_id": ...}`), with turns as `turn-N` spans.

This **inverts Langfuse's own guidance** ([traces vs sessions](https://langfuse.com/academy/tracing#traces-vs-sessions) / [best-practices](https://langfuse.com/docs/observability/best-practices)): *"one trace = one invocation... For a chatbot this means one trace per turn and one session per conversation."*

## Change

Every `run_turn` now opens its **own trace** (root span `property-concierge`, stable name), and `propagate_attributes(session_id=...)` groups the turns into one **Session**.

- `agent/concierge.py` — drop `conversation_trace_id`/`multiturn`; per-turn trace.
- `webapp/server.py`, `scripts/run_live_traffic.py` — pass `session_id` + `turn_index`; drop shared-trace-id seeding.
- `scripts/seed_managed_evaluators.sh` — cloud judge filters by trace/observation name.
- docs (README, DEMO_SCRIPT, AI_ENGINEERING_LOOP) — correct the model + presenter "war story".

## Trace naming (resolved)

Kept the **stable** `property-concierge` trace name per Langfuse best-practice (*"keep dynamic values out of names... otherwise every trace produces new names and you can no longer group, filter, or target them"*). The user's question lives in the trace **input** (shown as a column in the Traces table). Briefly tried question-named traces, then reverted.

## Trace-tree rendering (not a code issue)

Each turn's trace has one root span (`property-concierge`) with `plan → agent-turn → tool:*` nested — the same shape as Langfuse's own `handle-chatbot-message` demo. On newer Langfuse platforms (**Cloud, verified**) this renders as a single node with the steps directly beneath. On the pinned self-hosted platform (`v3.221.1`) the trace header and its root span draw as two same-named rows — a **platform-UI-version artifact**, resolved by a platform upgrade, not by any code/SDK change.

## Verified

3-turn conversation → 3 distinct traces grouped under one session (via `/api/public/sessions/{id}`). Managed + code judges score each turn; portal 👍/👎 lands on the specific turn's trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)