### PR TITLE
demos: add support-triage-parallel (Pattern 3 — parallelization)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,14 @@ LITELLM_UPSTREAM_MODEL=anthropic/claude-sonnet-4-6
 # Dedicated ClickHouse (26.3) for the Agentic RAG native vector store
 CLICKHOUSE_VECTORS_HTTP_PORT=8125
 
+# Support Triage Parallel demo (Pattern #3 — parallelization)
+SUPPORT_TRIAGE_PORT=8008
+VOTE_SAMPLES=5
+VOTE_TEMPERATURE=0.9
+VOTE_STRATEGY=result-signature   # result-signature | majority-exact | judge-consensus
+BRANCH_MODEL=claude-haiku-4-5
+JUDGE_MODEL=claude-opus-4-7
+
 # Dashboard Settings
 DASHBOARD_CACHE_TTL=60
 

--- a/.env.example
+++ b/.env.example
@@ -108,7 +108,7 @@ LITELLM_UPSTREAM_MODEL=anthropic/claude-sonnet-4-6
 CLICKHOUSE_VECTORS_HTTP_PORT=8125
 
 # Support Triage Parallel demo (Pattern #3 — parallelization)
-SUPPORT_TRIAGE_PORT=8008
+SUPPORT_TRIAGE_PORT=8009
 VOTE_SAMPLES=5
 VOTE_TEMPERATURE=0.9
 VOTE_STRATEGY=result-signature   # result-signature | majority-exact | judge-consensus

--- a/AI_ENGINEERING_LOOP.md
+++ b/AI_ENGINEERING_LOOP.md
@@ -31,6 +31,7 @@ it across the whole stack.
 | `demos/text-to-sql/` | NL → SQL over ClickHouse via MCP | LangChain + Langfuse `CallbackHandler` |
 | `demos/vector-rag/` | RAG over ChromaDB | LangChain + Langfuse `CallbackHandler` |
 | `demos/agentic-rag/` | Self-correcting RAG on ClickHouse-native vectors | LangGraph + Langfuse SDK |
+| `demos/support-triage-parallel/` | Parallel ticket triage — sectioning fan-out + best-of-N SQL voting (Pattern #3) | Anthropic API (asyncio) + Langfuse SDK |
 | `librechat/` | Shared chat frontend | LibreChat native Langfuse tracing |
 | `demos/real-estate/` | Self-contained agentic concierge — the loop shown end-to-end in one place | Langfuse SDK |
 | `demos/brand-promo-multi-agent/` | Multi-agent promo-planning assistant (standalone): synthetic history, online + offline evals, persona dashboards | LangGraph + CrewAI + Langfuse `CallbackHandler` |
@@ -45,6 +46,28 @@ it across the whole stack.
 | 4 | **Experiment** | `scripts/run-experiments.py` — compare **models / datasets** on the eval sets | **prompt-variant** experiments: `demos/real-estate/` + `agentic-rag` |
 | 5 | **Evaluate** | Deterministic **code evaluators** (`evaluators/*.ts`, seeded by `scripts/seed-code-evaluators.sh`) + **LLM-as-a-Judge** (`scripts/seed-llm-judge-evaluators.sh`) | human **annotation** queue in `demos/real-estate/` |
 | ⟳ | **Deploy** | **Prompt management by label** — apps fetch prompts from Langfuse at runtime with a local fallback: `agentic-rag` (`scripts/seed-langfuse-prompt.py`), `text-to-sql` + `vector-rag` (`scripts/seed-app-prompts.py`). Promote a label to ship a prompt with no redeploy. | **GitHub CI/CD** reference for gated prompt deploys in `demos/real-estate/cicd/` |
+
+## Parallelization demo — the loop on a fan-out (`demos/support-triage-parallel/`)
+
+Pattern #3 exercises every loop step around a concurrent fan-out:
+
+- **Trace** — 4 sectioning branches + 5 voting samples land as **sibling
+  observations** under one `triage-support-ticket` trace; the Timeline shows them
+  overlapping (parallel) vs a staircase (`--sequential`). The `tally-votes`
+  aggregator carries the literal vote tally in metadata.
+- **Monitor** — parallelization multiplies spend ~N×; a **cost-per-trace** Monitor
+  (Metrics API `sum totalCost` by `traceName`) bounds it, and a `level=WARNING`
+  count Monitor tracks dropped branches.
+- **Datasets / Experiment** — `scripts/run_experiment.py` compares the three
+  aggregation strategies (result-signature / majority-exact / judge-consensus) on
+  `support-triage/sql-voting`, branches held fixed — a run-level
+  `voting_accuracy_rate` decides the winner (`--ci` gates at 0.8).
+- **Evaluate** — runtime scores `consensus_confidence` (trace), `sql_validity_rate`
+  (span), `policy_flagged` (guard span); plus the deterministic
+  `consensus-margin-guard` code evaluator and the independent `correlated-vote-risk`
+  managed judge (`scripts/seed-support-triage-evaluators.sh`).
+- **Deploy** — 7 managed prompts fetched by `label=production` with local
+  fallbacks (`scripts/seed_prompts.py`); the SQL voter ships v1 + v2.
 
 ## The Deploy node across the stack
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,6 +1,6 @@
 # Demos
 
-Seven independently runnable demos, each building on the same ClickHouse-backed
+Eight independently runnable demos, each building on the same ClickHouse-backed
 Langfuse stack. The container demos share the platform at the repo root
 (`docker-compose.yaml`, `setup.sh`, `scripts/`, `evaluators/`, `mcp-*/`); the
 standalone demos bring their own toolchain. For how they map to the AI
@@ -11,14 +11,15 @@ Engineering loop, see [`../AI_ENGINEERING_LOOP.md`](../AI_ENGINEERING_LOOP.md).
 | **[text-to-sql](text-to-sql/)** | NL → SQL over ClickHouse via MCP (LangChain) | Trace · Deploy (managed prompts) | `docker compose --profile demo run --rm text-to-sql python main.py` · client script: [`DEMO_SCRIPT.md`](text-to-sql/DEMO_SCRIPT.md) |
 | **[vector-rag](vector-rag/)** | RAG over ChromaDB (LangChain) | Trace · Evaluate · Deploy | `docker compose --profile demo run --rm vector-rag python main.py` · client script: [`DEMO_SCRIPT.md`](vector-rag/DEMO_SCRIPT.md) |
 | **[agentic-rag](agentic-rag/)** | Self-correcting RAG on ClickHouse-native vectors (LangGraph) | Trace · Experiment · Deploy | see [`DEMO_SCRIPT.md`](agentic-rag/DEMO_SCRIPT.md) (client script) or [`../docs/AGENTIC_RAG_DEMO_RUNBOOK.md`](../docs/AGENTIC_RAG_DEMO_RUNBOOK.md) (deep reference) |
+| **[support-triage-parallel](support-triage-parallel/)** | Parallel ticket triage: 4-branch sectioning + best-of-N SQL voting (Anthropic API, asyncio) | Trace · Monitor · Experiment · Evaluate | `docker compose --profile demo run --rm support-triage-parallel python main.py` · client script: [`DEMO_SCRIPT.md`](support-triage-parallel/DEMO_SCRIPT.md) |
 | **[litellm-gateway](litellm-gateway/)** | LiteLLM AI gateway with centralized Langfuse OTLP tracing | Trace · Gateway | `./demos/litellm-gateway/run_demo.sh` · client script: [`DEMO_SCRIPT.md`](litellm-gateway/DEMO_SCRIPT.md) |
 | **[real-estate](real-estate/)** | Self-contained agentic concierge — the whole loop end-to-end in one place | ALL 5 + Deploy | `cd demos/real-estate && ./run_demo.sh` then `./run_portal.sh` · client script: [`DEMO_SCRIPT.md`](real-estate/DEMO_SCRIPT.md) |
 | **[brand-promo-multi-agent](brand-promo-multi-agent/)** | Multi-agent promo-planning assistant (LangGraph + CrewAI): synthetic history, online + offline evals, persona dashboards | Trace · Datasets · Experiment · Evaluate · Deploy | see [`DEMO_SCRIPT.md`](brand-promo-multi-agent/DEMO_SCRIPT.md) (client script) or [README](brand-promo-multi-agent/) |
 | **[langfuse-rls](langfuse-rls/)** | Attribute-based row-level-security prototype over Langfuse traces (Next.js): trace governance / access control | Governance (adjacent to the loop) | `cd demos/langfuse-rls && npm install && npm run dev` · client script: [`DEMO_SCRIPT.md`](langfuse-rls/DEMO_SCRIPT.md) |
 
 Each demo has its own README. **text-to-sql**, **vector-rag**, **agentic-rag**,
-and **litellm-gateway** run as containers in the root `docker-compose.yaml`
-(the `demo` profile). LiteLLM can use a dedicated Langfuse project through
+**support-triage-parallel**, and **litellm-gateway** run as containers in the
+root `docker-compose.yaml` (the `demo` profile). LiteLLM can use a dedicated Langfuse project through
 local `LITELLM_LANGFUSE_*` credentials; see the
 [gateway operations guide](../docs/LITELLM_GATEWAY_DEMO.md). **real-estate**
 (Python, own `.venv` + `.env`),

--- a/demos/support-triage-parallel/DEMO_SCRIPT.md
+++ b/demos/support-triage-parallel/DEMO_SCRIPT.md
@@ -1,0 +1,439 @@
+# Support Triage Parallel — Demo Script (Parallelization on ClickHouse + Langfuse)
+
+A ready-to-run demo of **Pattern #3 (parallelization)** in one trace: a support
+ticket fans out into **4 concurrent analysis branches** (*sectioning*) and its
+embedded data question is answered by **5 SQL samples majority-voted by
+ClickHouse** (*voting*). Every branch is a sibling observation in **Langfuse**;
+the vote tally is metadata; consensus is a score.
+
+- **Fan-out engine:** raw Anthropic async API + `asyncio.gather` (`triage_pipeline.py`, `sql_voting.py`)
+- **Vote counter:** the ClickHouse public playground (`sql.clickhouse.com`) — candidates are *executed*, not string-matched (`ch_validator.py`)
+- **Observability backend:** Langfuse (`http://localhost:3001`), trace tag `support-triage-parallel`
+- **Run length:** ~15–20 min full; Acts 1–3 = 8-min short path
+
+> All code lives in `demos/support-triage-parallel/`. The trace shape and env
+> knobs are in [`README.md`](README.md).
+
+---
+
+## How to run this script
+
+It's a **conversation, not a walkthrough**. Every act does four things:
+
+- **Frame** — the problem, in their terms (say this *before* you touch the screen).
+- **Show** — the exact clicks / commands.
+- **Land** — the "so what": the benefit, not the feature.
+- **Ask** — an open question that maps it to their world.
+
+The short path is Acts 1–3; add 4–7 when there's appetite. Don't rush the **Ask**.
+
+---
+
+## 0 · Pre-flight (do this BEFORE the meeting)
+
+```bash
+# CRITICAL: clear leaked Langfuse keys — exported shell vars override .env and 401 silently.
+unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY
+
+# Langfuse (+ its ClickHouse) up; build the demo image.
+docker compose --profile langfuse up -d
+docker compose --profile demo build support-triage-parallel
+
+# Deploy node + datasets + evaluators (idempotent):
+python demos/support-triage-parallel/scripts/seed_all.py       # 7 prompts + 2 datasets
+./scripts/seed-support-triage-evaluators.sh                    # managed judge: correlated-vote-risk
+./scripts/seed-code-evaluators.sh                              # (re)seeds consensus-margin-guard
+
+# Pre-run the TIE trace and PIN it (never hunt for a split vote live):
+FAULT= docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-002
+#   → confirm the step log shows "tie_break=True"; open that trace in Langfuse and pin the tab.
+#   If needed later, filter Traces by score consensus_confidence < 1.
+
+# Create the two Monitors (Langfuse → Monitors → New) — settings in Act 5.
+```
+
+**Browser tabs ready:** Langfuse Traces (`:3001`, `demo@example.com` / `demodemo1!`),
+the pinned TCK-002 tie trace, a terminal, and Langfuse → Dashboards.
+
+> **Tip:** for a snappier fault demo (Act 7) export `BRANCH_TIMEOUT_S=8` so the
+> dropped branch resolves in ~8s instead of 30s.
+
+---
+
+## What each act proves
+
+| Capability | Where in the demo |
+|---|---|
+| **Parallel = latency of the slowest branch** | Act 1 — `--sequential` vs default wall-clock |
+| **Sibling branches under one parent** (typed obs, Timeline overlap) | Act 2 — Langfuse Timeline |
+| **Guardrail-as-a-branch** (`policy_flagged` span score) | Act 2 — `branch-policy-guard` |
+| **Vote tally as queryable metadata** (`votes`, `margin`, `tie_break_used`) | Act 3 — `tally-votes` |
+| **Consensus as a score** (`consensus_confidence`) | Act 3 — trace score |
+| **ClickHouse arbitrates semantic SQL equivalence** | Act 4 — `explain-candidate` tool spans |
+| **N× cost, visible and bounded** | Act 5 — cost-per-trace Monitor |
+| **Aggregation strategy is a testable variable** | Act 6 — Experiment (3 strategies) |
+| **Graceful degradation on branch failure** | Act 7 — `FAULT=slow-branch` |
+
+---
+
+## Opening · Locate the pain (2 min, no screen)
+
+**Frame.** When one LLM call isn't good enough, teams retry by hand or ship the
+doubt. There are two cheaper answers: **split the task** so each consideration
+gets a focused call, or **ask five times and count hands**. Both cost more —
+the question is whether you can *see* that cost and whether the disagreement
+becomes something you can act on.
+
+**Ask (these steer the session):**
+- "Where does a single model call's uncertainty actually hurt you today — a
+  classification, a generated query, a moderation decision?"
+- "When you're unsure a single answer is right, what do you do — retry, escalate,
+  or just ship it?"
+- "Do you fold everything into one big prompt, or split concerns? How do you know
+  which is better?"
+
+**Land.** "I'll show a triage app that does both — four focused branches in
+parallel, then five SQL samples that ClickHouse itself votes on — and every bit
+of it is a queryable number in Langfuse: the overlap in the timeline, the vote
+tally, the consensus confidence, and the cost."
+
+> **Coming from the text-to-sql demo?** Pivot line: *"There, one model wrote one
+> query and we hoped. Here, five samples compete and the database decides the
+> winner — and we get a confidence score for free."*
+
+---
+
+## Act 1 · Sequential vs parallel wall-clock (5 min)
+
+**Frame.** The first assumption to test: does splitting a task actually buy you
+anything, or is it just more calls? Two things: latency, and prompt quality.
+
+**Show.** Run the same ticket sequentially, then in parallel:
+```bash
+docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-001 --sequential
+docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-001
+```
+Read the step log line: `fan-out 4/4 branches (...) | Xs wall / Ys sum`. Sequential:
+wall ≈ sum. Parallel: **wall ≈ the slowest single branch**, roughly ¼ of the sum.
+
+**Land.** "Sectioning buys two things at once. **Latency** — the wall-clock
+collapses to the slowest branch, not the sum. And **quality** — four narrow Haiku
+prompts (summary, sentiment, category, a policy screen) each beat one omnibus
+prompt that tries to do everything, because each call keeps its full attention on
+one job. The guardrail is its own branch, so screening the ticket doesn't slow the
+answer down."
+
+**Ask.** "How many of your LLM steps are genuinely independent — could run at the
+same time — versus truly sequential? And are you asking one prompt to do three
+jobs anywhere?"
+
+> **Fallback:** if the API is slow/rate-limited, the *ratio* (wall ≪ sum) still
+> holds even if absolute numbers wobble; re-run once.
+
+---
+
+## Act 2 · The trace: siblings under one parent (6 min)
+
+**Frame.** A timing line in a terminal is nice for you; it doesn't scale. Can you
+*see* the parallelism across thousands of runs — which branches ran, how they
+overlapped, what each decided?
+
+**Show.** Langfuse → **Traces** → `triage-support-ticket` (the TCK-001 run) →
+**Timeline**. Four `branch-*` observations start together and **overlap in time**
+— the single most convincing "this is parallel" visual.
+
+- Open `branch-policy-guard` → it's a typed **guardrail** observation with its own
+  **`policy_flagged`** score (0 on a clean ticket).
+- Note the branch names are low-cardinality (`branch-summary`, not
+  `branch-summary-1`) — the run detail lives in metadata (`branch: "summary"`).
+- Open `synthesize-triage-brief` → its **input** is the labeled branch outputs;
+  the nested `synthesis-llm` generation links its `production` prompt.
+
+Now open the **`--sequential`** run's trace: identical tree, but the branches form
+a **staircase** — no overlap. Same code, one flag.
+
+**Land.** "The typing is what makes Langfuse draw this as an agent graph instead
+of a flat log, and the overlap is the proof that we're actually running
+concurrently. The guardrail is a first-class branch with its own score — a policy
+screen you can chart and alert on, that never slows the primary answer."
+
+**Ask.** "If every parallel step were a labeled, timed, independently-scored span,
+what would you look at first — the slow branch, the failed one, or the guardrail?"
+
+> **Fallback:** empty Timeline = trace still ingesting (async worker); wait ~20s
+> and refresh, or open a slightly older `triage-support-ticket` trace.
+
+---
+
+## Act 3 · The vote tally — the money shot (6 min)
+
+**Frame.** Voting is the other half of parallelization: ask the same question five
+times and count. The interesting part isn't the answer — it's the **disagreement**,
+and whether you can turn it into a number you'd gate a decision on.
+
+**Show.** Open the pinned **TCK-002** trace (the ambiguous "most active repos"
+ticket) → `vote-sql` → note the **5 `vote-candidate` generations, all the same
+name**, with `sample_index: 0..4` in metadata. Then open **`tally-votes`**:
+
+- **metadata** is a literal tally: `votes {sig-…: 2, sig-…: 2, sig-…: 1}`,
+  `invalid`, `winner`, `margin`, **`tie_break_used: true`**.
+- **input** holds every candidate (SQL + validity + signature) — one place.
+- The **`tie-break-judge`** child (Opus) is present *because the vote split*.
+- The trace carries a **`consensus_confidence`** score (e.g. 0.4 — "2 of 5 valid
+  samples agreed").
+
+Contrast with the pinned **TCK-001** trace: a clean **5–0**, `consensus_confidence
+= 1.0`, no judge child.
+
+**Land.** "Disagreement between samples is now a queryable number in ClickHouse.
+A 5–0 is trustworthy; a 2–2–1 tells you the *question* was ambiguous, not the
+model — and the tie-break judge only fires when it needs to. You can filter every
+run by confidence, chart it over time, and gate on it."
+
+**Ask.** "What decision in your world would you gate on `consensus_confidence <
+0.6` — auto-approve above it, route to a human below it?"
+
+> **Fallback:** voting uses temperature 0.9, so the exact split varies. TCK-002 is
+> *designed* to split; if a live run comes back clean, use your pre-pinned tie
+> trace (that's why we pinned it in pre-flight).
+
+---
+
+## Act 4 · ClickHouse counts the votes (4 min)
+
+**Frame.** How do you decide two SQL answers are "the same"? String comparison
+can't: `GROUP BY 1` and `GROUP BY borough` are identical in meaning and different
+as text. So don't compare strings — compare *results*.
+
+**Show.** In the TCK-002 trace open **`validate-candidates`** → the **5
+`explain-candidate` tool spans** (`EXPLAIN` against `sql.clickhouse.com`; invalid
+ones are `level=WARNING`) and the **`sql_validity_rate`** span score. Explain the
+default `result-signature` strategy: each valid candidate is *executed* and its
+sorted result set is hashed — semantically-equal queries land on the **same
+signature** and vote together.
+
+**Land.** "The database is the vote counter. Two queries that compute the same
+answer by different SQL vote together because ClickHouse ran them and the rows
+matched — string-match voting can't see that. And it's the *same engine* that
+stores these very traces: vectors, business data, observability, and now the vote
+arbiter, all ClickHouse."
+
+**Ask.** "Where do you compare 'are these two answers equivalent?' today — and are
+you doing it on text when you should be doing it on results?"
+
+> **Fallback:** if the playground is unreachable, candidates fail closed
+> (`sql_validity_rate` drops); mention that safety posture and move on — the
+> concept stands on the trace you already have.
+
+---
+
+## Act 5 · The cost of confidence (Monitor) (3 min)
+
+**Frame.** Every one of these wins costs money — parallelization multiplies spend
+~N×. The failure mode isn't the pattern; it's *not seeing* the bill until it
+arrives. Someone bumps `VOTE_SAMPLES` to 10 and cost silently doubles.
+
+**Show.** Langfuse → **Dashboards** → the "Parallelization economics" dashboard
+(cost/trace, observation-count/trace, avg `consensus_confidence`, avg
+`sql_validity_rate`). Then **Monitors**:
+
+1. **`triage-cost-per-trace`** — dataSource `Traces`, filter
+   `name = triage-support-ticket`, metric `sum totalCost`, threshold ≈ 1.5× your
+   measured budget for 4 Haiku branches + 5 Sonnet samples + synthesis (+ occasional Opus).
+2. **`triage-branch-failures`** — dataSource `Observations`, filter
+   `level = WARNING` + the trace name, metric `count`.
+
+Then prove it fires:
+```bash
+VOTE_SAMPLES=9 docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-001
+```
+Watch cost/trace jump. The Metrics API behind the Monitor:
+```bash
+curl -s -H "Authorization: Basic $(echo -n $LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY | base64)" -G \
+  --data-urlencode 'query={"view":"observations",
+    "metrics":[{"measure":"totalCost","aggregation":"sum"},{"measure":"count","aggregation":"count"}],
+    "dimensions":[{"field":"traceName"}],
+    "filters":[{"column":"traceName","operator":"=","value":"triage-support-ticket"}],
+    "fromTimestamp":"2026-07-01T00:00:00Z","toTimestamp":"2026-08-01T00:00:00Z",
+    "orderBy":[{"field":"sum_totalCost","direction":"desc"}]}' \
+  http://localhost:3001/api/public/v2/metrics
+```
+
+**Land.** "N× cost is the pattern's tax. Here it's a number on a dashboard and an
+alert threshold — not a surprise on the invoice. You decide the confidence you're
+willing to pay for, and you can *see* when someone changes that decision."
+
+**Ask.** "What's your ceiling — how much extra would you spend to move a decision
+from 'one guess' to 'five-sample consensus'? And would you set that per use case?"
+
+---
+
+## Act 6 · Which aggregator wins? (Experiment) (4 min)
+
+**Frame.** We picked `result-signature` voting. Is it actually better than the
+alternatives, or just our taste? That's a testable question — hold everything
+fixed, vary one component.
+
+**Show.**
+```bash
+python demos/support-triage-parallel/scripts/run_experiment.py --strategy all
+```
+Langfuse → **Datasets** → `support-triage/sql-voting` → **Runs**: three runs
+side-by-side (`aggregator-result-signature`, `aggregator-majority-exact`,
+`aggregator-judge-consensus`), each with per-item `item_accuracy` and a run-level
+**`voting_accuracy_rate`** + `mean_consensus_confidence`. Expect
+`result-signature` ≥ `judge-consensus` > `majority-exact`.
+
+**Land.** "The aggregation strategy is a variable, not a religion. Branch and
+voter prompts are pinned at `production`; only the aggregator changes; a run-level
+metric decides. `majority-exact` loses because string voting can't see that two
+queries compute the same answer — exactly the point from Act 4, now measured. Add
+`--ci` and it's a certification gate: below 0.8 accuracy, the build fails."
+
+**Ask.** "When you change one component of an LLM system, how do you prove it
+helped — vibes, or a run-level metric on a fixed dataset?"
+
+> **Bonus (one flag):** `--vary-n-samples 1,3,5` charts the diminishing-returns
+> asymptote — voting gains flatten fast.
+
+---
+
+## Act 7 · When a branch dies (fault injection) (3 min)
+
+**Frame.** Parallel systems fail *partially*. One slow branch must not stall the
+fan-out or corrupt the result — and you need to *see* that it happened.
+
+**Show.**
+```bash
+BRANCH_TIMEOUT_S=8 FAULT=slow-branch \
+  docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-005
+```
+Open the trace: `branch-sentiment-urgency` is `level=WARNING` (timed out),
+`analyze-sections` and `synthesize-triage-brief` metadata both show
+`failed_branches: 1` / `degraded: true`, the brief says **"sentiment: insufficient
+data"**, and the trace is tagged **`fault:slow-branch`**. The
+`triage-branch-failures` Monitor counts it.
+
+**Land.** "The aggregator degrades gracefully — it proceeds with N-1 and *says so*
+rather than inventing the missing dimension — and the trace proves it. Partial
+failure is observable, not silent."
+
+**Ask.** "When one step of a parallel pipeline fails for you today, does the
+system notice — and does the final answer admit what's missing?"
+
+---
+
+## Closing · Why this matters (1 min)
+
+**Land three takeaways:**
+1. **Parallel = the latency of the slowest branch**, visible as overlap in the
+   Timeline — and narrower prompts to boot.
+2. **Voting turns model variance into a confidence *score*** with ClickHouse as
+   the arbiter — semantic equivalence decided by executing SQL, not matching strings.
+3. **The whole thing is governed** — cost monitored, aggregator experimented,
+   consensus evaluated (deterministic *and* independent judge), prompts deployed
+   from Langfuse by label.
+
+Then hand them the asset: "This repo is public and self-contained — the fan-out,
+the voter, the validator, the seeds. Clone it, point it at your own tickets and
+datasets, and this is your prototype."
+
+---
+
+## Under the hood — how it's instrumented (for the "show me the code" moment)
+
+All in `demos/support-triage-parallel/`.
+
+**1 · Concurrent siblings via `asyncio.gather` inside a parent span — `triage_pipeline.py`**
+```python
+with lf.observe("analyze-sections", metadata={"branch_count": 4, "mode": "parallel"}) as parent:
+    results = await asyncio.gather(*(run_branch(*b, ticket) for b in BRANCHES))
+```
+*Why it matters:* opening the branches inside the parent's context makes OTel
+propagate the parent into each asyncio task — the branches auto-nest as siblings
+with overlapping Timeline spans. No manual span-passing.
+
+**2 · Low-cardinality names, index in metadata — `sql_voting.py`**
+```python
+with lf.observe("vote-candidate", as_type="generation", input=question,
+                metadata={"sample_index": index}, **gen_kwargs) as gen:  # same name on all N
+```
+
+**3 · The tally lives on the aggregator — `sql_voting.py` (`tally_votes`)**
+```python
+with lf.observe("tally-votes",
+        input={"candidates": [...]},            # every sample, one place
+        metadata={"strategy": strategy}) as agg:
+    agg.update(metadata={"votes": tally["votes"], "invalid": ..., "winner": ...,
+                         "margin": ..., "tie_break_used": ...})
+    lf.score_current_trace("consensus_confidence", confidence)
+```
+*Why it matters:* branch outputs on the aggregator's **input** are what let an
+observation-level evaluator (the `correlated-vote-risk` judge) score the whole
+vote — it cannot auto-pull the N child observations.
+
+**4 · ClickHouse is the vote counter — `sql_voting.py` / `ch_validator.py`**
+```python
+def _result_signature(sql):                       # execute + hash sorted rows
+    rows = ch_validator.execute_readonly(sql)
+    return "sig-" + hashlib.sha1(repr(sorted(...)).encode()).hexdigest()[:8]
+```
+
+**5 · Graceful degradation — `triage_pipeline.py` (`run_branch`)**
+```python
+except (asyncio.TimeoutError, Exception) as e:
+    obs.update(level="WARNING", status_message=f"branch dropped: {e}")
+    return {"branch": name, "ok": False, "output": None}
+```
+
+**6 · No-op without keys — `langfuse_config.py`**
+```python
+def observe(name, as_type="span", ...):
+    if get_langfuse_client() is None:
+        yield _NullObs(); return           # obs.update(...) is always safe
+```
+
+> One-liner for the room: *"Each branch is a typed `with`-block gathered
+> concurrently; the tally is one `update`; consensus is one score; and it all
+> no-ops without Langfuse keys."*
+
+---
+
+## Talking points & objections
+
+- **"Isn't N× cost a dealbreaker?"** Only if you can't see it. Cost is per-observation
+  in Langfuse, summed per trace, alertable via a Monitor — you buy exactly the
+  confidence you decide is worth it, per use case.
+- **"Voting can be confidently wrong."** Correct — correlated errors defeat majority
+  vote. That's why the independent `correlated-vote-risk` judge reads all samples
+  and flags a suspicious consensus, and why `consensus_margin_ok` is a separate
+  deterministic check. "Who checks the vote-counter" is a first-class score.
+- **"Why not string-match the SQL?"** `GROUP BY 1` ≡ `GROUP BY borough`. Executing +
+  hashing results catches semantic equivalence string voting misses — the
+  `result-signature` vs `majority-exact` experiment measures the gap.
+- **"Framework lock-in?"** None — raw Anthropic async API + the Langfuse SDK. The
+  same fan-out pattern applies to any framework or plain code.
+- **"Determinism / auditability?"** Voting relies on temperature > 0, so it's less
+  reproducible than a single call by design — but every sample, its validity, and
+  the tally are persisted, so the *decision* is fully auditable after the fact.
+
+---
+
+## Reset / re-run
+
+```bash
+# Re-run the batch, a single ticket, or interactively
+docker compose --profile demo run --rm support-triage-parallel python main.py
+docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-002
+docker compose --profile demo run --rm support-triage-parallel python main.py --interactive
+
+# Re-seed (idempotent)
+python demos/support-triage-parallel/scripts/seed_all.py
+./scripts/seed-support-triage-evaluators.sh
+
+# Try a different aggregation strategy live
+VOTE_STRATEGY=majority-exact docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-002
+
+# Pure-code tests (no services)
+cd demos/support-triage-parallel && python -m pytest
+```

--- a/demos/support-triage-parallel/Dockerfile
+++ b/demos/support-triage-parallel/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl gcc python3-dev && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+# The demo is a CLI batch (no long-running server). Run it with:
+#   docker compose --profile demo run --rm support-triage-parallel python main.py
+# Flags: --interactive | --sequential | --ticket TCK-002 ; FAULT=slow-branch env.
+CMD ["python", "main.py"]

--- a/demos/support-triage-parallel/README.md
+++ b/demos/support-triage-parallel/README.md
@@ -1,0 +1,157 @@
+# Support Triage Parallel — Pattern #3: Parallelization (sectioning + voting)
+
+A ClickHouse support ticket arrives. The app **fans out four independent
+analysis branches concurrently** (summary, sentiment/urgency, technical
+category, and a policy/PII guardrail — *sectioning*) and synthesizes a triage
+brief; then, for the data question embedded in the ticket, it **samples N=5 SQL
+candidates at high temperature, validates each with `EXPLAIN` against the live
+ClickHouse public playground, executes the valid ones, and majority-votes on the
+result-set signature** (*voting*) — with an LLM tie-break judge only when the
+vote splits.
+
+Every branch is a sibling observation under **one Langfuse trace**; the
+aggregators carry the merge inputs and the full vote tally in metadata; and
+consensus confidence is a first-class Langfuse score.
+
+> Both Anthropic sub-variants of parallelization
+> ([Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents))
+> in one trace: **sectioning** (`analyze-sections`) and **voting** (`vote-sql`).
+
+## What it demonstrates
+
+| Capability | How it shows up |
+|---|---|
+| **Sectioning fan-out** | 4 concurrent Haiku branches (`asyncio.gather`) → sibling observations that **overlap in the Timeline** (wall-clock ≈ slowest branch, not the sum). Run `--sequential` for the before/after. |
+| **Guardrail split** | The policy/PII screen is its own typed `guardrail` branch (not folded into analysis), with a `policy_flagged` span score. |
+| **Voting / self-consistency** | The same data question answered N=5× at `temperature=0.9`; identical-named `vote-candidate` generations with `sample_index` in metadata. |
+| **ClickHouse is the vote counter** | Candidates validated with `EXPLAIN` and executed against `sql.clickhouse.com`; the winner is decided by hashing **result sets**, not by string comparison. |
+| **Vote tally as metadata** | The `tally-votes` aggregator's metadata is a literal tally (`{votes, invalid, winner, margin, tie_break_used}`); its input holds every candidate. |
+| **Tie-break judge** | An Opus judge fires **only** when the vote splits (`tie_break_used: true`). |
+| **Consensus as a score** | `consensus_confidence = winner_votes / valid_candidates` — filterable, chartable, monitorable. |
+| **Partial-failure tolerance** | `FAULT=slow-branch` drops one branch (`level=WARNING`), the aggregator proceeds with N-1 and records `failed_branches`. |
+| **Cost fan-out, made visible** | Parallelization multiplies spend ~N×; a cost-per-trace Monitor bounds it. |
+| **Three aggregation strategies** | `result-signature` (default) / `majority-exact` / `judge-consensus`, compared head-to-head in an Experiment. |
+| **Deploy node** | 7 managed prompts fetched by `label=production` with local fallbacks; the SQL voter ships v1 + v2. |
+
+## Who it's for
+
+- **SAs** showing that *disagreement between model samples becomes a queryable
+  number in ClickHouse*, and that the N× cost of confidence is visible and
+  boundable — not a surprise on the invoice.
+- **Engineers** who want a clean, framework-light reference for concurrent LLM
+  fan-out (raw Anthropic async API + `asyncio.gather`) instrumented as sibling
+  Langfuse observations, plus a programmatic majority-vote arbitrated by a database.
+
+Natural pivot from **text-to-sql** (single-shot NL→SQL): *"what if one SQL sample
+isn't trustworthy — buy confidence with N samples and let ClickHouse arbitrate."*
+
+## Quick start
+
+```bash
+# From the repo root, with Langfuse up (docker compose --profile langfuse up -d)
+# and ANTHROPIC_API_KEY set in .env.
+
+# Seed the 7 managed prompts + 2 datasets, then the independent judge:
+python demos/support-triage-parallel/scripts/seed_all.py
+./scripts/seed-support-triage-evaluators.sh
+./scripts/seed-code-evaluators.sh          # (re)provisions consensus-margin-guard too
+
+# Run the batch of demo tickets:
+docker compose --profile demo run --rm support-triage-parallel python main.py
+
+# Single ticket / interactive / sequential baseline:
+docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-002
+docker compose --profile demo run --rm support-triage-parallel python main.py --interactive
+docker compose --profile demo run --rm support-triage-parallel python main.py --sequential --ticket TCK-001
+
+# Fault injection (dropped branch):
+FAULT=slow-branch docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-005
+
+# Aggregation-strategy experiment (branches fixed, aggregator varied):
+python demos/support-triage-parallel/scripts/run_experiment.py --strategy all
+```
+
+The demo runs green **with no Langfuse keys set** — instrumentation degrades to a
+no-op (repo convention). It needs `ANTHROPIC_API_KEY` and outbound access to
+`sql-clickhouse.clickhouse.com` (read-only `demo` user) to actually run.
+
+For the presenter walkthrough (acts, talk track, fallbacks) see
+[`DEMO_SCRIPT.md`](DEMO_SCRIPT.md).
+
+## Trace shape
+
+```
+TRACE triage-support-ticket            session_id: triage-<uuid8>   tags: [support-triage-parallel, demo]
+├─ SPAN analyze-sections               metadata: {branch_count: 4, mode: "parallel", failed_branches: 0}
+│  ├─ GENERATION branch-summary            (Haiku)  metadata: {branch: "summary"}
+│  ├─ GENERATION branch-sentiment-urgency  (Haiku)  metadata: {branch: "sentiment"}
+│  ├─ GENERATION branch-category           (Haiku)  metadata: {branch: "category"}
+│  ├─ GUARDRAIL  branch-policy-guard       (Haiku)  → span score: policy_flagged
+│  └─ SPAN synthesize-triage-brief
+│     └─ GENERATION synthesis-llm          (Sonnet; prompt: support-triage-synthesis@production)
+├─ SPAN vote-sql                       metadata: {n_samples: 5, vote_temperature: 0.9, strategy: "result-signature"}
+│  ├─ GENERATION vote-candidate ×5         (Sonnet, T=0.9)  metadata: {sample_index: 0..4}
+│  ├─ SPAN validate-candidates             → span score: sql_validity_rate
+│  │  └─ TOOL explain-candidate ×5         (EXPLAIN vs sql.clickhouse.com)
+│  └─ SPAN tally-votes                     metadata: {votes, invalid, winner, margin, tie_break_used}
+│     └─ GENERATION tie-break-judge        (Opus) — present ONLY when the vote ties
+└─ trace score: consensus_confidence
+   span scores:  policy_flagged, sql_validity_rate
+```
+
+## Configuration (env)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `ANTHROPIC_MODEL` | `claude-sonnet-4-6` | synthesis + vote-candidate model |
+| `BRANCH_MODEL` | `claude-haiku-4-5` | cheap sectioning branches |
+| `JUDGE_MODEL` | `claude-opus-4-7` | tie-break judge |
+| `VOTE_SAMPLES` | `5` | N SQL candidates per question |
+| `VOTE_TEMPERATURE` | `0.9` | sampling temperature for diversity |
+| `VOTE_STRATEGY` | `result-signature` | `result-signature` \| `majority-exact` \| `judge-consensus` |
+| `BRANCH_TIMEOUT_S` | `30` | per-branch timeout (lower it, e.g. `8`, for a snappier fault demo) |
+| `PUBLIC_CH_HOST` | `sql-clickhouse.clickhouse.com` | read-only playground for EXPLAIN + execution |
+| `FAULT` | (unset) | `slow-branch` drops the sentiment branch to demo degradation |
+
+## Files
+
+```
+demos/support-triage-parallel/
+├── README.md                # this file
+├── DEMO_SCRIPT.md           # presenter runbook (Frame/Show/Land/Ask acts)
+├── Dockerfile               # python:3.11-slim
+├── requirements.txt         # anthropic, langfuse>=3, httpx, sqlglot, clickhouse-connect
+├── main.py                  # batch + --interactive + --sequential + --ticket; one trace per ticket
+├── langfuse_config.py       # v3 wiring: is_langfuse_enabled(), observe() typed ctx mgr, scores, prompts, flush()
+├── llm.py                   # raw Anthropic async/sync call layer (updates the generation with usage/cost)
+├── triage_pipeline.py       # Stage 1: sectioning fan-out + synthesis aggregator + fault injection
+├── sql_voting.py            # Stage 2: voting fan-out + tally + tie-break; 3 pluggable strategies
+├── ch_validator.py          # EXPLAIN validation + read-only LIMIT-enforced execution vs the playground
+├── tickets.py               # deterministic synthetic ticket corpus
+├── scripts/                 # seed_prompts.py, seed_datasets.py, run_experiment.py, seed_all.py
+└── tests/                   # test_vote_tally.py, test_aggregator.py (pure code, no LLM/network)
+```
+
+Root-level companions: `scripts/seed-support-triage-evaluators.sh` (managed
+`correlated-vote-risk` judge) and `evaluators/consensus-margin-guard.ts` (the 6th
+deterministic code evaluator).
+
+## Tests
+
+```bash
+cd demos/support-triage-parallel && python -m pytest    # pure-code tally + aggregator; no services
+```
+
+## Troubleshooting
+
+- **No scores / no traces** — confirm `LANGFUSE_PUBLIC_KEY`/`SECRET_KEY` reach the
+  container (they degrade to a no-op if absent), and that a leaked shell
+  `LANGFUSE_*` isn't overriding `.env` (`unset` them before the demo).
+- **All candidates invalid (`sql_validity_rate = 0`)** — check outbound access to
+  `sql-clickhouse.clickhouse.com`; the validator fails candidates closed on any
+  connection error.
+- **No `correlated-vote-risk` score** — the judge is `NEW`-scoped; regenerate
+  traffic after running `scripts/seed-support-triage-evaluators.sh`, and ensure
+  `./setup.sh` provisioned the Anthropic LLM connection (default eval model).
+- **Fault demo feels slow** — the default branch timeout is 30s; set
+  `BRANCH_TIMEOUT_S=8` for a snappier dropped-branch moment.

--- a/demos/support-triage-parallel/ch_validator.py
+++ b/demos/support-triage-parallel/ch_validator.py
@@ -1,0 +1,130 @@
+"""
+ClickHouse candidate validator + read-only executor for the SQL voting stage.
+
+ClickHouse is the vote counter: candidate SQL is arbitrated by *executing* it
+against the public playground (``sql-clickhouse.clickhouse.com``) and hashing the
+result set — semantic equivalence decided by the database, not by string match.
+
+Safety posture mirrors ``demos/agentic-rag/sql_tool.py``:
+- SELECT/WITH only (statement whitelist + destructive-keyword reject).
+- LIMIT enforcement (auto-append ``LIMIT 100`` when absent).
+- HTTPS ``clickhouse-connect`` to ``PUBLIC_CH_HOST`` as the read-only ``demo`` user.
+- Short timeout so a slow candidate fails fast rather than stalling the vote.
+
+Each ``explain_ok`` call is wrapped in a Langfuse ``tool`` observation named
+``explain-candidate`` (low cardinality — the candidate index is not in the name).
+``clickhouse_connect`` is imported lazily so this module imports without the
+package (pure-logic helpers stay unit-testable offline).
+"""
+
+import os
+import re
+from typing import List, Optional, Tuple
+
+import langfuse_config as lf
+
+PUBLIC_CH_HOST = os.getenv("PUBLIC_CH_HOST", "sql-clickhouse.clickhouse.com")
+PUBLIC_CH_PORT = int(os.getenv("PUBLIC_CH_PORT", "443"))
+PUBLIC_CH_USER = os.getenv("PUBLIC_CH_USER", "demo")
+PUBLIC_CH_PASSWORD = os.getenv("PUBLIC_CH_PASSWORD", "")
+QUERY_TIMEOUT_S = int(os.getenv("CH_QUERY_TIMEOUT", "10"))
+MAX_ROWS = int(os.getenv("CH_MAX_ROWS", "100"))
+
+_DESTRUCTIVE = re.compile(
+    r"\b(DROP|DELETE|TRUNCATE|ALTER|INSERT|UPDATE|GRANT|REVOKE|CREATE|RENAME|DETACH|ATTACH|OPTIMIZE|SET)\b",
+    re.IGNORECASE,
+)
+
+_client = None
+
+
+def _get_client():
+    """Lazily construct a read-only clickhouse-connect client to the playground."""
+    global _client
+    if _client is None:
+        import clickhouse_connect
+        _client = clickhouse_connect.get_client(
+            host=PUBLIC_CH_HOST,
+            port=PUBLIC_CH_PORT,
+            username=PUBLIC_CH_USER,
+            password=PUBLIC_CH_PASSWORD,
+            secure=True,
+            connect_timeout=QUERY_TIMEOUT_S,
+            send_receive_timeout=QUERY_TIMEOUT_S,
+        )
+    return _client
+
+
+def normalize(sql: str) -> str:
+    """Strip trailing semicolons / whitespace from a candidate statement."""
+    return (sql or "").strip().rstrip(";").strip()
+
+
+def is_safe_select(sql: str) -> Tuple[bool, str]:
+    """Pure guard: SELECT/WITH only, no destructive keywords, single statement.
+
+    No I/O — unit-testable offline. Returns ``(ok, reason)``.
+    """
+    s = normalize(sql)
+    if not s:
+        return False, "empty statement"
+    if ";" in s:
+        return False, "multiple statements are not allowed"
+    if not s.lower().startswith(("select", "with")):
+        return False, "only SELECT/WITH queries are permitted"
+    if _DESTRUCTIVE.search(s):
+        return False, "destructive keyword detected"
+    return True, "ok"
+
+
+def enforce_limit(sql: str, limit: int = MAX_ROWS) -> str:
+    """Append a ``LIMIT`` when the statement has none (defence in depth)."""
+    s = normalize(sql)
+    if re.search(r"\blimit\s+\d+", s, re.IGNORECASE):
+        return s
+    return f"{s} LIMIT {limit}"
+
+
+def explain_ok(sql: str) -> bool:
+    """Validate a candidate by running ``EXPLAIN`` against the playground.
+
+    Wrapped in a Langfuse ``tool`` observation (``explain-candidate``). Invalid
+    candidates mark the observation ``level=WARNING`` so failed samples are
+    visible in the trace. Returns True iff the statement is safe AND ClickHouse
+    can plan it.
+    """
+    with lf.observe("explain-candidate", as_type="tool", input=sql) as obs:
+        safe, reason = is_safe_select(sql)
+        if not safe:
+            obs.update(level="WARNING", status_message=f"rejected: {reason}",
+                       output={"valid": False, "reason": reason})
+            return False
+        try:
+            _get_client().query(f"EXPLAIN {enforce_limit(sql)}",
+                                settings={"max_execution_time": QUERY_TIMEOUT_S})
+            obs.update(output={"valid": True})
+            return True
+        except Exception as e:  # invalid SQL / unknown table / timeout
+            obs.update(level="WARNING", status_message=f"EXPLAIN failed: {e}",
+                       output={"valid": False, "reason": str(e)[:200]})
+            return False
+
+
+def execute_readonly(sql: str) -> Optional[List[tuple]]:
+    """Execute a validated candidate read-only and return its rows.
+
+    Returns a list of row tuples (possibly empty) or None on error. SELECT-only +
+    LIMIT enforced. Used by the result-signature strategy to let ClickHouse
+    arbitrate semantic equivalence.
+    """
+    safe, _ = is_safe_select(sql)
+    if not safe:
+        return None
+    try:
+        result = _get_client().query(
+            enforce_limit(sql),
+            settings={"max_result_rows": MAX_ROWS, "max_execution_time": QUERY_TIMEOUT_S},
+        )
+        return [tuple(row) for row in result.result_rows]
+    except Exception:
+        return None

--- a/demos/support-triage-parallel/langfuse_config.py
+++ b/demos/support-triage-parallel/langfuse_config.py
@@ -1,0 +1,217 @@
+"""
+Langfuse instrumentation for the Support Triage Parallel demo (v3 SDK).
+
+This is the per-demo Langfuse wiring module (cloned from
+``demos/text-to-sql/langfuse_config.py`` and extended with the typed
+``observe()`` context manager from ``demos/agentic-rag/langfuse_config.py``).
+
+The whole module is a **no-op when Langfuse keys are absent** — every helper
+degrades gracefully so the demo still runs (and the pipeline still fans out /
+votes) without a Langfuse project. ``observe()`` yields a ``_NullObs`` in that
+case, so callers can always do ``obs.update(...)`` unconditionally.
+
+Design notes for the parallelization pattern:
+- ``observe(name, as_type=...)`` uses the low-level v3 SDK
+  ``start_as_current_observation``. Opening a parent observation and then
+  ``asyncio.gather``-ing child branches *inside* that context makes the branches
+  auto-nest as siblings (OTel context propagates into each asyncio task), which
+  is what renders the concurrent Timeline in Langfuse.
+- Branch names stay **low-cardinality** (``vote-candidate`` on all N samples);
+  the run index lives in ``metadata`` (``sample_index``) so branches stay
+  filterable — per the tracing best practices.
+"""
+
+import os
+import uuid
+from contextlib import contextmanager
+from typing import Optional
+
+# Langfuse is enabled only when both keys are present (repo convention).
+LANGFUSE_ENABLED = bool(
+    os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY")
+)
+
+
+def is_langfuse_enabled() -> bool:
+    """True when Langfuse keys are configured. Everything is a no-op otherwise."""
+    return LANGFUSE_ENABLED
+
+
+def get_langfuse_client():
+    """Return the v3 Langfuse client (process-global singleton), or None."""
+    if not LANGFUSE_ENABLED:
+        return None
+    try:
+        from langfuse import get_client
+        return get_client()
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse client unavailable: {e}")
+        return None
+
+
+class _NullObs:
+    """No-op observation handle used when Langfuse is disabled.
+
+    Supports ``.update(...)`` (returns self), the context-manager protocol, and
+    ``.score(...)`` so calling code never needs to branch on whether Langfuse is
+    configured.
+    """
+
+    def update(self, *args, **kwargs):
+        return self
+
+    def score(self, *args, **kwargs):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def new_session_id() -> str:
+    """One session per demo run — ``triage-<uuid8>`` (repo naming convention)."""
+    return f"triage-{uuid.uuid4().hex[:8]}"
+
+
+@contextmanager
+def trace_context(name: str = "triage-support-ticket", session_id: Optional[str] = None,
+                  tags=None, user_id=None):
+    """Set trace name / session / tags for every observation emitted within.
+
+    ``name`` is a stable, low-cardinality trace name — the ticket goes in the
+    trace *input*, never in the name (repo convention).
+    """
+    if not LANGFUSE_ENABLED:
+        yield
+        return
+    try:
+        from langfuse import propagate_attributes
+        with propagate_attributes(
+            trace_name=name,
+            session_id=session_id,
+            user_id=user_id,
+            tags=tags or ["support-triage-parallel", "demo"],
+        ):
+            yield
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse trace context failed: {e}")
+        yield
+
+
+@contextmanager
+def observe(name: str, as_type: str = "span", input=None, metadata=None, **kwargs):
+    """Typed observation context manager (span | generation | tool | guardrail | ...).
+
+    Yields the live observation handle (or a ``_NullObs`` when Langfuse is off),
+    so callers can always call ``obs.update(output=..., usage_details=...)``.
+
+    Extra kwargs (e.g. ``model=`` or ``prompt=`` for generations) are forwarded
+    to ``start_as_current_observation``. If the SDK rejects an ``as_type`` it
+    doesn't recognise, we retry once as a plain ``span`` so tracing never breaks
+    the run.
+    """
+    client = get_langfuse_client()
+    if client is None:
+        yield _NullObs()
+        return
+    try:
+        with client.start_as_current_observation(
+            as_type=as_type, name=name, input=input, metadata=metadata, **kwargs
+        ) as obs:
+            yield obs
+    except TypeError:
+        # Unknown as_type or unsupported kwarg for this SDK build — fall back to
+        # a plain span so the observation still lands.
+        try:
+            with client.start_as_current_observation(
+                as_type="span", name=name, input=input, metadata=metadata
+            ) as obs:
+                yield obs
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"Langfuse observation '{name}' failed: {e}")
+            yield _NullObs()
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse observation '{name}' failed: {e}")
+        yield _NullObs()
+
+
+def score_current_trace(name: str, value, comment: Optional[str] = None, data_type="NUMERIC"):
+    """Attach a score to the active trace (e.g. ``consensus_confidence`` — one per run)."""
+    client = get_langfuse_client()
+    if client is None:
+        return
+    try:
+        client.score_current_trace(name=name, value=value, comment=comment, data_type=data_type)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse trace score '{name}' failed: {e}")
+
+
+def score_current_span(name: str, value, comment: Optional[str] = None, data_type="NUMERIC"):
+    """Attach a score to the active observation/span.
+
+    Use for step-level verdicts that can repeat within a trace (e.g.
+    ``sql_validity_rate`` on validate-candidates, ``policy_flagged`` on the guard
+    branch), so the score sits on the exact step that produced it.
+    """
+    client = get_langfuse_client()
+    if client is None:
+        return
+    try:
+        client.score_current_span(name=name, value=value, comment=comment, data_type=data_type)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse span score '{name}' failed: {e}")
+
+
+def get_managed_prompt(name: str, label: str = "production"):
+    """Fetch a Langfuse-managed prompt (the Deploy node of the AI Engineering loop).
+
+    Returns the prompt object (``.compile(**vars)`` + links to traces) or None if
+    Langfuse is unavailable / the prompt isn't seeded — callers fall back to a
+    local template so the app always runs. Promoting a new version to
+    ``production`` in the UI changes behaviour on the next run with no redeploy.
+    """
+    client = get_langfuse_client()
+    if client is None:
+        return None
+    try:
+        return client.get_prompt(name, label=label)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse get_prompt('{name}') unavailable, using local fallback: {e}")
+        return None
+
+
+def render_prompt(_name: str, _fallback: str, **variables):
+    """Resolve a prompt to compiled text + an optional link handle.
+
+    Positional args are underscore-prefixed so any template variable name
+    (``question``, ``branch_outputs``, …) can be passed as a keyword without
+    colliding. Returns ``(text, prompt_obj_or_None)``:
+    - Managed prompt present -> ``prompt_obj.compile(**variables)`` + the object
+      (pass it as ``prompt=`` so the generation links the version).
+    - Otherwise -> the local ``_fallback`` template with ``{{var}}`` markers
+      substituted (kept in sync by hand with scripts/seed_prompts.py).
+    """
+    prompt_obj = get_managed_prompt(_name)
+    if prompt_obj is not None:
+        try:
+            return prompt_obj.compile(**variables), prompt_obj
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"Managed prompt '{_name}' unusable ({e}); using local fallback.")
+    text = _fallback
+    for key, value in variables.items():
+        text = text.replace("{{" + key + "}}", str(value))
+    return text, None
+
+
+def flush():
+    """Flush pending Langfuse events (non-destructive — never shutdown the singleton)."""
+    client = get_langfuse_client()
+    if client is None:
+        return
+    try:
+        if hasattr(client, "flush"):
+            client.flush()
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse flush failed: {e}")

--- a/demos/support-triage-parallel/llm.py
+++ b/demos/support-triage-parallel/llm.py
@@ -1,0 +1,117 @@
+"""
+Thin Anthropic call layer for the Support Triage Parallel demo.
+
+Uses the **raw Anthropic SDK** (not LangChain) because this demo fans out many
+concurrent LLM calls with ``asyncio.gather`` — the async client is the natural
+fit, and each call updates the Langfuse *generation* observation it runs inside
+(model + token usage + output) so per-branch cost lands in the trace. This is
+what makes the "N× cost fan-out" Monitor story real.
+
+``anthropic`` is imported **lazily** inside the call functions so the pure-logic
+modules (and their unit tests) import without the package installed.
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+_async_client = None
+_sync_client = None
+
+
+def _get_async_client():
+    global _async_client
+    if _async_client is None:
+        from anthropic import AsyncAnthropic
+        _async_client = AsyncAnthropic()  # reads ANTHROPIC_API_KEY from env
+    return _async_client
+
+
+def _get_sync_client():
+    global _sync_client
+    if _sync_client is None:
+        from anthropic import Anthropic
+        _sync_client = Anthropic()
+    return _sync_client
+
+
+def _extract(resp) -> Dict[str, Any]:
+    text = "".join(
+        b.text for b in resp.content if getattr(b, "type", None) == "text"
+    ).strip()
+    usage = {
+        "input_tokens": resp.usage.input_tokens,
+        "output_tokens": resp.usage.output_tokens,
+    }
+    return {"text": text, "usage": usage}
+
+
+def _apply_usage(obs, model: str, out: Dict[str, Any]):
+    """Record model + token usage + output on the generation observation so
+    Langfuse can price it. No-op-safe against ``_NullObs`` handles."""
+    if obs is None:
+        return
+    try:
+        obs.update(model=model, usage_details=out["usage"], output=out["text"])
+    except Exception:  # pragma: no cover - defensive (never let tracing break a call)
+        pass
+
+
+async def anthropic_call(
+    *,
+    model: str,
+    prompt: str,
+    system: Optional[str] = None,
+    temperature: float = 0.7,
+    max_tokens: int = 1024,
+    obs=None,
+) -> str:
+    """Async single-turn completion. Updates ``obs`` (a Langfuse generation) with
+    model/usage/output when provided. Returns the assistant text."""
+    client = _get_async_client()
+    resp = await client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        system=system or "You are a precise assistant. Follow the instructions exactly.",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    out = _extract(resp)
+    _apply_usage(obs, model, out)
+    return out["text"]
+
+
+def anthropic_call_sync(
+    *,
+    model: str,
+    prompt: str,
+    system: Optional[str] = None,
+    temperature: float = 0.0,
+    max_tokens: int = 1024,
+    obs=None,
+) -> str:
+    """Synchronous completion — used by the tie-break judge, which runs after the
+    fan-out has already been awaited (no need to stay async)."""
+    client = _get_sync_client()
+    resp = client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        system=system or "You are a precise assistant. Follow the instructions exactly.",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    out = _extract(resp)
+    _apply_usage(obs, model, out)
+    return out["text"]
+
+
+def strip_sql(text: str) -> str:
+    """Strip markdown fences and prose so we keep only the SQL statement."""
+    s = text.strip()
+    if "```" in s:
+        # take the content of the first fenced block if present
+        parts = s.split("```")
+        if len(parts) >= 2:
+            block = parts[1]
+            block = block[3:] if block.lower().startswith("sql") else block
+            s = block.strip()
+    return s.strip().rstrip(";").strip()

--- a/demos/support-triage-parallel/main.py
+++ b/demos/support-triage-parallel/main.py
@@ -1,0 +1,160 @@
+"""
+Support Triage Parallel — CLI runner (Pattern #3: Parallelization).
+
+One trace per ticket named ``triage-support-ticket`` (stable, low-cardinality;
+the ticket goes in the trace *input*). Each run stages two parallelization
+sub-variants under that trace:
+
+  Stage 1  sectioning fan-out (4 concurrent branches) -> synthesis brief
+  Stage 2  best-of-N SQL voting -> validate (EXPLAIN) -> tally -> tie-break
+
+Usage:
+    docker compose --profile demo run --rm support-triage-parallel python main.py
+    docker compose --profile demo run --rm support-triage-parallel python main.py --interactive
+    docker compose --profile demo run --rm support-triage-parallel python main.py --sequential --ticket TCK-001
+    FAULT=slow-branch docker compose --profile demo run --rm support-triage-parallel python main.py --ticket TCK-005
+
+Runs green with NO Langfuse keys set (instrumentation degrades to a no-op).
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+
+import langfuse_config as lf
+from tickets import TICKETS, get_ticket
+from triage_pipeline import analyze_sections
+from sql_voting import vote_sql, VOTE_STRATEGY, VOTE_SAMPLES
+
+LANGFUSE_URL = os.getenv("LANGFUSE_BASE_URL", "http://localhost:3001")
+
+
+def _fault() -> str:
+    return os.getenv("FAULT", "").strip().lower()
+
+
+async def triage_ticket(ticket: dict, session_id: str, sequential: bool = False) -> dict:
+    """Run the full triage over one ticket under a single Langfuse trace."""
+    fault = _fault()
+    tags = ["support-triage-parallel", "demo"]
+    if fault:
+        tags.append(f"fault:{fault}")
+
+    with lf.trace_context("triage-support-ticket", session_id=session_id, tags=tags):
+        with lf.observe(
+            "triage-support-ticket", as_type="span",
+            input={"ticket_id": ticket["id"], "subject": ticket["subject"],
+                   "body": ticket["body"], "data_question": ticket["data_question"]},
+        ) as root:
+            sections = await analyze_sections(ticket, sequential=sequential, fault=fault)
+            vote = await vote_sql(ticket["data_question"], strategy=VOTE_STRATEGY)
+
+            output = {
+                "triage_brief": sections["brief"],
+                "winning_sql": vote.get("winning_sql"),
+                "result_signature": vote.get("result_signature"),
+                "consensus_confidence": vote.get("consensus_confidence"),
+                "failed_branches": sections["failed_branches"],
+                "degraded": sections["degraded"],
+            }
+            root.update(output=output)
+
+    return {"ticket": ticket, "sections": sections, "vote": vote}
+
+
+def _print_result(res: dict, sequential: bool):
+    ticket = res["ticket"]
+    s, v = res["sections"], res["vote"]
+    mode = "sequential" if sequential else "parallel"
+    tally = " ".join(f"{k}:{n}" for k, n in sorted(v["tally"].items(), key=lambda x: -x[1])) or "none"
+    print(f"  fan-out {4 - s['failed_branches']}/4 branches ({mode}) | "
+          f"{s['wall_s']:.1f}s wall / {s['sum_s']:.1f}s sum "
+          f"| dropped={s['failed_branches']} degraded={s['degraded']}")
+    print(f"  vote {tally} | invalid={v['invalid']} | winner={v['winner']} "
+          f"| margin={v['margin']} | tie_break={v['tie_break_used']} "
+          f"| consensus={v['consensus_confidence']:.2f}")
+    print(f"  winning_sql: {(v.get('winning_sql') or '(none)')[:120]}")
+    print(f"\n  Triage brief:\n{_indent(s['brief'])}\n")
+
+
+def _indent(text: str, prefix: str = "    ") -> str:
+    return "\n".join(prefix + line for line in (text or "").splitlines())
+
+
+async def run_batch(tickets, sequential: bool):
+    session = lf.new_session_id()
+    print("\n" + "=" * 66)
+    print("Support Triage Parallel  (sectioning fan-out + best-of-N SQL voting)")
+    print(f"strategy={VOTE_STRATEGY}  n_samples={VOTE_SAMPLES}  "
+          f"mode={'sequential' if sequential else 'parallel'}"
+          + (f"  fault={_fault()}" if _fault() else ""))
+    if lf.is_langfuse_enabled():
+        print("+ Langfuse instrumentation enabled")
+    print("=" * 66)
+
+    for i, ticket in enumerate(tickets, 1):
+        print(f"\n[{i}/{len(tickets)}] {ticket['id']} — {ticket['subject']}")
+        print("-" * 58)
+        try:
+            res = await triage_ticket(ticket, session_id=session, sequential=sequential)
+            _print_result(res, sequential)
+        except Exception as e:
+            print(f"  Error: {e}")
+
+    lf.flush()
+    print("=" * 66)
+    if lf.is_langfuse_enabled():
+        print(f"View traces: {LANGFUSE_URL} (Langfuse → Traces → triage-support-ticket)")
+    print("=" * 66 + "\n")
+
+
+async def run_interactive(sequential: bool):
+    session = lf.new_session_id()
+    print("\nInteractive triage — enter a ticket body; blank data question is fine.")
+    print("Type 'quit' to exit.\n")
+    while True:
+        try:
+            body = input("Ticket body: ").strip()
+            if body.lower() in ("quit", "exit", "q"):
+                break
+            if not body:
+                continue
+            dq = input("Data question (optional): ").strip() or "No data question."
+            ticket = {"id": "TCK-INT", "subject": body[:48], "body": body, "data_question": dq}
+            res = await triage_ticket(ticket, session_id=session, sequential=sequential)
+            _print_result(res, sequential)
+        except KeyboardInterrupt:
+            break
+        except Exception as e:
+            print(f"Error: {e}\n")
+    lf.flush()
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Support Triage Parallel demo")
+    ap.add_argument("--interactive", action="store_true", help="Interactive mode")
+    ap.add_argument("--sequential", action="store_true",
+                    help="Run branches one-by-one (baseline for the wall-clock A/B)")
+    ap.add_argument("--ticket", type=str, default=None,
+                    help="Run a single ticket by id, e.g. TCK-002")
+    args = ap.parse_args()
+
+    if args.interactive:
+        asyncio.run(run_interactive(args.sequential))
+        return
+
+    if args.ticket:
+        ticket = get_ticket(args.ticket)
+        if ticket is None:
+            print(f"Unknown ticket id: {args.ticket}", file=sys.stderr)
+            sys.exit(1)
+        tickets = [ticket]
+    else:
+        tickets = TICKETS
+
+    asyncio.run(run_batch(tickets, args.sequential))
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/support-triage-parallel/pytest.ini
+++ b/demos/support-triage-parallel/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+addopts = -q

--- a/demos/support-triage-parallel/requirements.txt
+++ b/demos/support-triage-parallel/requirements.txt
@@ -1,0 +1,14 @@
+# Anthropic SDK — raw async/sync API (concurrent fan-out; no LangChain needed)
+anthropic>=0.40.0,<1.0.0
+
+# Langfuse - LLM observability (v3 typed observations, scores, managed prompts)
+langfuse>=3.0.0,<4.0.0
+
+# HTTP (Anthropic + Langfuse transitively depend on it; pinned for the seed scripts)
+httpx>=0.27.0,<1.0.0
+
+# SQL canonicalization for the majority-exact voting strategy
+sqlglot>=25.0.0,<27.0.0
+
+# ClickHouse client — EXPLAIN validation + read-only execution vs the playground
+clickhouse-connect>=0.8.0,<1.0.0

--- a/demos/support-triage-parallel/scripts/run_experiment.py
+++ b/demos/support-triage-parallel/scripts/run_experiment.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+Aggregation-strategy experiment for the Support Triage Parallel demo.
+
+Variable isolation (parallelization field guide): all branch/voter prompts are
+pinned at ``production``; ONLY the aggregation strategy varies. Each strategy runs
+the full best-of-N fan-out on the ``support-triage/sql-voting`` dataset, then a
+run-level ``voting_accuracy_rate`` decides which aggregator wins.
+
+Expected result: ``result-signature`` >= ``judge-consensus`` > ``majority-exact``
+(string voting loses semantically-equal SQL).
+
+Usage (from repo root, after sourcing .env):
+    python demos/support-triage-parallel/scripts/run_experiment.py --strategy all
+    python demos/support-triage-parallel/scripts/run_experiment.py --strategy result-signature --sample 4
+    python demos/support-triage-parallel/scripts/run_experiment.py --strategy result-signature --ci
+    python demos/support-triage-parallel/scripts/run_experiment.py --vary-n-samples 1,3,5
+    python demos/support-triage-parallel/scripts/run_experiment.py --local-aggregator   # pure code, no LLM/network (CI)
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scripts.seed_datasets import SQL_VOTING_DATASET, LOCAL_AGGREGATOR_CASES  # noqa: E402
+
+STRATEGIES = ["majority-exact", "result-signature", "judge-consensus"]
+CI_THRESHOLD = 0.8
+
+
+# --------------------------------------------------------------------------- #
+# Item + run-level evaluators (field-guide shapes).
+# --------------------------------------------------------------------------- #
+def item_accuracy(*, output, expected_output, **kw):
+    from langfuse import Evaluation
+    expected = (expected_output or {}).get("result_signature")
+    got = (output or {}).get("result_signature")
+    if not expected:
+        # No pinned signature (unreachable playground at seed time) -> skip.
+        return Evaluation(name="item_accuracy", value=None,
+                          comment="no pinned expected signature")
+    return Evaluation(name="item_accuracy", value=1.0 if got == expected else 0.0,
+                      comment=f"got {got} vs expected {expected}")
+
+
+def voting_agreement_rate(*, item_results, **kw):
+    from langfuse import Evaluation
+    vals = [e.value for r in item_results for e in r.evaluations
+            if e.name == "item_accuracy" and e.value is not None]
+    rate = sum(vals) / len(vals) if vals else None
+    comment = (f"majority answer matched pinned signature in {rate:.0%} of {len(vals)} scored items"
+               if rate is not None else "no scored items")
+    return Evaluation(name="voting_accuracy_rate", value=rate, comment=comment)
+
+
+def mean_consensus_confidence(*, item_results, **kw):
+    from langfuse import Evaluation
+    confs = [(r.output or {}).get("consensus_confidence") for r in item_results]
+    confs = [c for c in confs if c is not None]
+    val = sum(confs) / len(confs) if confs else None
+    return Evaluation(name="mean_consensus_confidence", value=val)
+
+
+def make_task(strategy: str, n_samples: int):
+    from sql_voting import vote_sql
+
+    def task(*, item, **kwargs):
+        inp = item.input if hasattr(item, "input") else item.get("input", {})
+        question = inp.get("question") if isinstance(inp, dict) else str(inp)
+        return asyncio.run(vote_sql(question, strategy=strategy, n_samples=n_samples))
+
+    return task
+
+
+def _run_one(lf, dataset, strategy, n_samples, label, sample):
+    items = dataset.items
+    if sample and sample < len(items):
+        items = items[:sample]
+    run_name = f"aggregator-{strategy}" + (f"-n{n_samples}" if n_samples != 5 else "")
+    if label:
+        run_name += f"-{label}"
+    print(f"\n=== strategy={strategy}  n_samples={n_samples}  items={len(items)}  run={run_name} ===")
+    result = dataset.run_experiment(
+        name="sql-voting aggregator comparison",
+        run_name=run_name,
+        description=f"Aggregator strategy '{strategy}' at n_samples={n_samples} "
+                    f"(branches/voter pinned at production).",
+        task=make_task(strategy, n_samples),
+        evaluators=[item_accuracy],
+        run_evaluators=[voting_agreement_rate, mean_consensus_confidence],
+        metadata={"varied_component": "aggregator", "strategy": strategy,
+                  "n_samples": n_samples},
+    )
+    try:
+        print(result.format())
+    except Exception:
+        pass
+    return result
+
+
+def _accuracy_of(result):
+    for ev in getattr(result, "run_evaluations", []) or []:
+        if ev.name == "voting_accuracy_rate" and ev.value is not None:
+            return ev.value
+    return None
+
+
+def run_local_aggregator():
+    """Pure-code CI target: exercise compute_tally + build_synthesis_input against
+    the local aggregator cases. No LLM, no network, no Langfuse required."""
+    from sql_voting import compute_tally
+    from triage_pipeline import build_synthesis_input
+    passed = failed = 0
+    for i, case in enumerate(LOCAL_AGGREGATOR_CASES):
+        inp, exp = case["input"], case["expected_output"]
+        if "candidates" in inp:
+            t = compute_tally(inp["candidates"])
+            checks = {k: t.get(k) == v for k, v in exp.items()}
+        else:
+            outputs, failed_n, degraded = build_synthesis_input(inp["branch_results"])
+            actual = {"degraded": degraded, "failed_branches": failed_n,
+                      "sentiment": outputs.get("sentiment")}
+            checks = {k: actual.get(k) == v for k, v in exp.items()}
+        ok = all(checks.values())
+        passed += ok
+        failed += (not ok)
+        print(f"  case {i}: {'PASS' if ok else 'FAIL'}  {checks}")
+    print(f"\nLocal aggregator: {passed} passed, {failed} failed")
+    return failed == 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Support Triage aggregation-strategy experiment")
+    ap.add_argument("--strategy", default="result-signature",
+                    help="all | result-signature | majority-exact | judge-consensus")
+    ap.add_argument("--sample", type=int, default=None, help="Run only the first N items")
+    ap.add_argument("--label", default=None, help="Suffix for the run name")
+    ap.add_argument("--vary-n-samples", default=None,
+                    help="Comma list of N to chart diminishing returns, e.g. 1,3,5")
+    ap.add_argument("--ci", action="store_true",
+                    help=f"Exit 1 if voting_accuracy_rate < {CI_THRESHOLD}")
+    ap.add_argument("--local-aggregator", action="store_true",
+                    help="Run the pure-code aggregator cases only (no LLM/network)")
+    args = ap.parse_args()
+
+    if args.local_aggregator:
+        ok = run_local_aggregator()
+        sys.exit(0 if ok or not args.ci else 1)
+
+    if not (os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY")):
+        raise SystemExit("LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set (source .env first).")
+
+    from langfuse import get_client
+    lf = get_client()
+    try:
+        dataset = lf.get_dataset(SQL_VOTING_DATASET)
+    except Exception as e:
+        raise SystemExit(f"Could not load dataset '{SQL_VOTING_DATASET}': {e}\n"
+                         f"Run scripts/seed_datasets.py first.")
+
+    results = []
+    if args.vary_n_samples:
+        ns = [int(x) for x in args.vary_n_samples.split(",") if x.strip()]
+        for n in ns:
+            results.append(_run_one(lf, dataset, args.strategy, n, args.label, args.sample))
+    else:
+        strategies = STRATEGIES if args.strategy == "all" else [args.strategy]
+        for strat in strategies:
+            results.append(_run_one(lf, dataset, strat, 5, args.label, args.sample))
+
+    lf.flush()
+
+    if args.ci:
+        worst = min((a for a in (_accuracy_of(r) for r in results) if a is not None), default=None)
+        if worst is None:
+            print("\nCI: no accuracy scored (no pinned signatures?) — not gating.", file=sys.stderr)
+        elif worst < CI_THRESHOLD:
+            print(f"\nCI GATE FAILED: voting_accuracy_rate {worst:.2f} < {CI_THRESHOLD}", file=sys.stderr)
+            sys.exit(1)
+        else:
+            print(f"\nCI GATE PASSED: min voting_accuracy_rate {worst:.2f} >= {CI_THRESHOLD}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/support-triage-parallel/scripts/run_experiment.py
+++ b/demos/support-triage-parallel/scripts/run_experiment.py
@@ -19,7 +19,6 @@ Usage (from repo root, after sourcing .env):
 """
 
 import argparse
-import asyncio
 import os
 import sys
 
@@ -67,10 +66,13 @@ def mean_consensus_confidence(*, item_results, **kw):
 def make_task(strategy: str, n_samples: int):
     from sql_voting import vote_sql
 
-    def task(*, item, **kwargs):
+    async def task(*, item, **kwargs):
         inp = item.input if hasattr(item, "input") else item.get("input", {})
         question = inp.get("question") if isinstance(inp, dict) else str(inp)
-        return asyncio.run(vote_sql(question, strategy=strategy, n_samples=n_samples))
+        # Langfuse's _run_task invokes this on its own running event loop and awaits
+        # the returned coroutine, so await vote_sql directly — never asyncio.run() here
+        # (that would raise "asyncio.run() cannot be called from a running event loop").
+        return await vote_sql(question, strategy=strategy, n_samples=n_samples)
 
     return task
 

--- a/demos/support-triage-parallel/scripts/seed_all.py
+++ b/demos/support-triage-parallel/scripts/seed_all.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Seed everything the Support Triage Parallel demo needs in Langfuse in one shot:
+the 7 managed prompts and the 3 datasets (2 hosted + local aggregator cases).
+
+The independent managed judge is a separate root-level shell script
+(``scripts/seed-support-triage-evaluators.sh``) because it upserts Postgres
+job_configurations like the other evaluator seeds.
+
+Usage (from repo root, after sourcing .env):
+    python demos/support-triage-parallel/scripts/seed_all.py
+"""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(_HERE))  # demo root (for sql_voting etc.)
+sys.path.insert(0, _HERE)                    # scripts dir (for sibling imports)
+
+import seed_prompts   # noqa: E402
+import seed_datasets  # noqa: E402
+
+
+def main():
+    print("== Seeding managed prompts ==")
+    seed_prompts.main()
+    print("\n== Seeding datasets ==")
+    seed_datasets.main()
+    print("\nAll done. Next: ./scripts/seed-support-triage-evaluators.sh (managed judge).")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/support-triage-parallel/scripts/seed_datasets.py
+++ b/demos/support-triage-parallel/scripts/seed_datasets.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Seed Langfuse datasets for the Support Triage Parallel demo.
+
+Per the parallelization field-guide's two dataset types:
+
+1. ``support-triage/category-branch`` (Langfuse-hosted, per-branch): 12 items,
+   ``input={ticket_body}``, ``expected_output={category}``. A sectioning branch is
+   a natural single-observation item; after a seeded run, link each item back with
+   ``source_observation_id`` of its ``branch-category`` span (from the UI).
+
+2. ``support-triage/sql-voting`` (Langfuse-hosted, E2E for the voter): 10 items,
+   ``input={question}``, ``expected_output={result_signature, canonical_sql}``.
+   Signatures are precomputed ONCE against the live playground and pinned, so the
+   experiment can score a majority answer against a stable expected signature.
+   (Requires network + clickhouse-connect at seed time; items with an
+   unreachable/failed reference query are seeded with ``result_signature=None``.)
+
+3. ``LOCAL_AGGREGATOR_CASES`` (NOT Langfuse-hosted — pure merge/vote code): run via
+   ``langfuse.run_experiment(...)`` so only traces are created. Doubles as the CI
+   target for the *aggregation-logic-bug* failure mode. Printed at the end.
+
+Idempotent: datasets are created if missing; items are upserted by a stable id.
+
+Usage (from repo root, after sourcing .env):
+    python demos/support-triage-parallel/scripts/seed_datasets.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+CATEGORY_DATASET = "support-triage/category-branch"
+SQL_VOTING_DATASET = "support-triage/sql-voting"
+
+# 12 (ticket_body, category) items for the category branch.
+CATEGORY_ITEMS = [
+    ("Our nyc_taxi dashboard's borough panel takes 20+ seconds to load since we added fare columns.", "query-performance"),
+    ("Ingestion job for the events table is backing up and rows are arriving hours late.", "ingestion"),
+    ("Our analytics replica is falling behind the primary and dashboards are stale.", "replication"),
+    ("We got a bill that's roughly double last month with no change in volume.", "billing"),
+    ("We need to add three columns to a 2B-row table without downtime — how?", "schema-migration"),
+    ("clickhouse-client times out connecting from our VPC, but works locally.", "connectivity"),
+    ("A GROUP BY query that used to take 1s now takes 40s after a version bump.", "query-performance"),
+    ("Kafka engine table stopped consuming after a broker restart.", "ingestion"),
+    ("ReplicatedMergeTree parts are diverging between two replicas.", "replication"),
+    ("Can you explain the line items on our ClickHouse Cloud invoice?", "billing"),
+    ("We want to change a column type from String to LowCardinality(String) safely.", "schema-migration"),
+    ("Just wanted to say the docs are great — no issue, thanks!", "other"),
+]
+
+# 10 (question, reference_sql) items for the SQL voter. The reference SQL is
+# executed once against the playground to pin the expected result signature.
+SQL_VOTING_ITEMS = [
+    ("Which pickup borough had the highest average fare_amount in nyc_taxi for 2015?",
+     "SELECT pickup_ntaname AS borough, avg(fare_amount) AS avg_fare FROM nyc_taxi.trips "
+     "WHERE toYear(pickup_datetime) = 2015 GROUP BY borough ORDER BY avg_fare DESC LIMIT 5"),
+    ("How many nyc_taxi trips were recorded in 2015 and 2016?",
+     "SELECT toYear(pickup_datetime) AS year, count() AS trips FROM nyc_taxi.trips "
+     "WHERE year IN (2015, 2016) GROUP BY year ORDER BY year LIMIT 10"),
+    ("How many Hacker News stories were posted in 2015?",
+     "SELECT count() AS stories FROM hackernews.hits WHERE type = 'story' AND toYear(time) = 2015 LIMIT 1"),
+    ("Top 10 Hacker News stories by score in 2015?",
+     "SELECT title, score FROM hackernews.hits WHERE type = 'story' AND toYear(time) = 2015 "
+     "ORDER BY score DESC LIMIT 10"),
+    ("What was the average uk_price_paid price in Greater London in 2022?",
+     "SELECT avg(price) AS avg_price FROM uk.uk_price_paid WHERE toYear(date) = 2022 "
+     "AND county = 'GREATER LONDON' LIMIT 1"),
+    ("Top 10 stackoverflow tags by number of questions?",
+     "SELECT arrayJoin(splitByChar('|', tags)) AS tag, count() AS questions FROM stackoverflow.posts "
+     "WHERE post_type_id = 1 GROUP BY tag ORDER BY questions DESC LIMIT 10"),
+    ("How many distinct github repos had at least one event in the last full year?",
+     "SELECT uniqExact(repo_name) AS repos FROM github.github_events "
+     "WHERE toYear(created_at) = toYear(now()) - 1 LIMIT 1"),
+    ("Top 10 github repos by number of stars (watch events) in the last full year?",
+     "SELECT repo_name, count() AS stars FROM github.github_events "
+     "WHERE event_type = 'WatchEvent' AND toYear(created_at) = toYear(now()) - 1 "
+     "GROUP BY repo_name ORDER BY stars DESC LIMIT 10"),
+    ("Average nyc_taxi trip_distance for airport pickups in 2015?",
+     "SELECT avg(trip_distance) AS avg_distance FROM nyc_taxi.trips "
+     "WHERE toYear(pickup_datetime) = 2015 AND pickup_ntaname LIKE '%Airport%' LIMIT 1"),
+    ("How many stackoverflow questions were asked per year for the last five years?",
+     "SELECT toYear(creation_date) AS year, count() AS questions FROM stackoverflow.posts "
+     "WHERE post_type_id = 1 AND year >= toYear(now()) - 5 GROUP BY year ORDER BY year LIMIT 10"),
+]
+
+# Pure merge/vote logic cases — run locally (traces only, no hosted dataset).
+LOCAL_AGGREGATOR_CASES = [
+    {"input": {"candidates": [{"valid": True, "signature": "sig-a"}] * 3
+               + [{"valid": True, "signature": "sig-b"}, {"valid": False, "signature": None}]},
+     "expected_output": {"winner": "sig-a", "tie": False, "margin": 2}},
+    {"input": {"candidates": [{"valid": True, "signature": "sig-a"}] * 2
+               + [{"valid": True, "signature": "sig-b"}] * 2
+               + [{"valid": True, "signature": "sig-c"}]},
+     "expected_output": {"winner": None, "tie": True, "margin": 0}},
+    {"input": {"candidates": [{"valid": False, "signature": None}] * 5},
+     "expected_output": {"winner": None, "tie": False, "empty": True}},
+    {"input": {"branch_results": [
+        {"branch": "branch-summary", "key": "summary", "ok": True, "output": "s"},
+        {"branch": "branch-sentiment-urgency", "key": "sentiment", "ok": False, "output": None},
+        {"branch": "branch-category", "key": "category", "ok": True, "output": "billing"},
+        {"branch": "branch-policy-guard", "key": "policy", "ok": True, "output": "{}"}]},
+     "expected_output": {"degraded": True, "failed_branches": 1,
+                         "sentiment": "insufficient data"}},
+]
+
+
+def _client():
+    from langfuse import get_client
+    return get_client()
+
+
+def _ensure_dataset(lf, name, description):
+    try:
+        lf.create_dataset(name=name, description=description)
+        print(f"  + dataset '{name}' created")
+    except Exception:
+        print(f"  ✓ dataset '{name}' exists")
+
+
+def _upsert_item(lf, dataset_name, item_id, input, expected_output):
+    lf.create_dataset_item(dataset_name=dataset_name, id=item_id,
+                           input=input, expected_output=expected_output)
+
+
+def seed_category(lf):
+    _ensure_dataset(lf, CATEGORY_DATASET, "Per-branch: ticket body -> expected category label")
+    for i, (body, category) in enumerate(CATEGORY_ITEMS):
+        _upsert_item(lf, CATEGORY_DATASET, f"cat-{i:02d}",
+                     {"ticket_body": body}, {"category": category})
+    print(f"  ✓ {len(CATEGORY_ITEMS)} category-branch items seeded")
+
+
+def seed_sql_voting(lf):
+    from sql_voting import _result_signature
+    _ensure_dataset(lf, SQL_VOTING_DATASET,
+                    "E2E voter: NL question -> pinned result signature + canonical SQL")
+    pinned = 0
+    for i, (question, ref_sql) in enumerate(SQL_VOTING_ITEMS):
+        sig = None
+        try:
+            sig = _result_signature(ref_sql)   # execute once against the playground + hash
+        except Exception as e:
+            print(f"    ! could not pin signature for item {i}: {e}")
+        if sig:
+            pinned += 1
+        _upsert_item(lf, SQL_VOTING_DATASET, f"vote-{i:02d}",
+                     {"question": question},
+                     {"result_signature": sig, "canonical_sql": ref_sql})
+    print(f"  ✓ {len(SQL_VOTING_ITEMS)} sql-voting items seeded ({pinned} with pinned signatures)")
+
+
+def main():
+    if not (os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY")):
+        raise SystemExit("LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set (source .env first).")
+    lf = _client()
+    print("Seeding support-triage datasets ...")
+    seed_category(lf)
+    seed_sql_voting(lf)
+    lf.flush()
+    print(f"\nLocal aggregator cases (run via scripts/run_experiment.py --local-aggregator): "
+          f"{len(LOCAL_AGGREGATOR_CASES)} cases")
+    for c in LOCAL_AGGREGATOR_CASES:
+        print(f"  - expects {c['expected_output']}")
+    print("\nDone. View: Langfuse → Datasets.")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/support-triage-parallel/scripts/seed_prompts.py
+++ b/demos/support-triage-parallel/scripts/seed_prompts.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Seed Langfuse-managed prompts for the Support Triage Parallel demo (Deploy node).
+
+Seven prompts, fetched by ``label=production`` at runtime with in-code fallbacks
+(see triage_pipeline.py / sql_voting.py). Editing one in the Langfuse UI — or
+promoting a new version to ``production`` — changes behaviour on the next run
+with no redeploy, and every generation links the prompt version that produced it.
+
+The prompt TEXTS mirror the local fallback templates (Langfuse {{var}} syntax).
+Keep them in sync by hand — when managed and fallback match, enabling prompt
+management changes nothing until you edit the prompt in Langfuse.
+
+``support-triage-sql-voter`` is seeded in TWO versions (v1 baseline, v2 promoted
+to ``production``) so the Prompts tab shows version history + linked generations.
+
+Idempotent: a prompt is (re)created only if missing or its production text
+differs from what's checked in here — re-running is a no-op.
+
+Usage (from repo root, after sourcing .env):
+    LANGFUSE_HOST=http://localhost:3001 \
+    LANGFUSE_PUBLIC_KEY=pk-lf-... LANGFUSE_SECRET_KEY=sk-lf-... \
+    python demos/support-triage-parallel/scripts/seed_prompts.py
+"""
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+HOST = os.getenv("LANGFUSE_HOST", "http://localhost:3001").rstrip("/")
+PK = os.getenv("LANGFUSE_PUBLIC_KEY", "")
+SK = os.getenv("LANGFUSE_SECRET_KEY", "")
+
+BRANCH_MODEL = os.getenv("BRANCH_MODEL", "claude-haiku-4-5")
+SONNET = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+JUDGE_MODEL = os.getenv("JUDGE_MODEL", "claude-opus-4-7")
+
+_auth = base64.b64encode(f"{PK}:{SK}".encode()).decode()
+_HEADERS = {"Authorization": f"Basic {_auth}", "Content-Type": "application/json"}
+LABEL = "production"
+
+# --------------------------------------------------------------------------- #
+# Prompt texts — MIRROR the in-code fallbacks in triage_pipeline.py / sql_voting.py
+# --------------------------------------------------------------------------- #
+SUMMARY = (
+    "Summarize the following ClickHouse support ticket in exactly two short, "
+    "factual sentences. Do not speculate.\n\nTicket:\n{{ticket_body}}\n\nSummary:"
+)
+SENTIMENT = (
+    "Analyze the customer's tone in this support ticket. Reply with ONLY a JSON "
+    'object: {"sentiment": "positive|neutral|negative", '
+    '"urgency": "low|medium|high"}.\n\nTicket:\n{{ticket_body}}\n\nJSON:'
+)
+CATEGORY = (
+    "Classify this ClickHouse support ticket into exactly ONE category from this "
+    "list: query-performance, ingestion, replication, billing, schema-migration, "
+    "connectivity, other. Reply with ONLY the category label.\n\n"
+    "Ticket:\n{{ticket_body}}\n\nCategory:"
+)
+POLICY_GUARD = (
+    "You are a policy/PII guardrail. Screen the ticket for personal data "
+    "(emails, phone numbers), leaked credentials/API keys, or abusive content. "
+    'Reply with ONLY JSON: {"flagged": true|false, "reasons": ["..."]}.\n\n'
+    "Ticket:\n{{ticket_body}}\n\nJSON:"
+)
+SYNTHESIS = (
+    "You are a support triage lead. Merge the labeled analysis branches below "
+    "into a concise triage brief (owner-ready): one-line summary, "
+    "sentiment/urgency, category, and any policy flags. If a branch reads "
+    "'insufficient data', you MUST say so explicitly for that dimension and do "
+    "not invent it.\n\nBranch outputs (JSON):\n{{branch_outputs}}\n\nTriage brief:"
+)
+SQL_VOTER_V1 = (
+    "You are a ClickHouse SQL expert. Write a single read-only ClickHouse SELECT "
+    "that answers the question using the public demo datasets (nyc_taxi, github, "
+    "hackernews, uk, stackoverflow). Reply with ONLY the SQL.\n\n"
+    "Question: {{question}}\n\nSQL:"
+)
+# v2 (production) mirrors the in-code fallback in sql_voting.py exactly.
+SQL_VOTER_V2 = (
+    "You are a ClickHouse SQL expert. Write a SINGLE read-only ClickHouse SELECT "
+    "that answers the question using the public demo datasets (nyc_taxi, github, "
+    "hackernews, uk, stackoverflow). Always qualify database.table, prefer an "
+    "explicit GROUP BY, and add a LIMIT. Reply with ONLY the SQL — no prose, no "
+    "code fences.\n\nQuestion: {{question}}\n\nSQL:"
+)
+TIE_BREAK = (
+    "The following SQL candidates tied in a majority vote. Pick the ONE that is "
+    "most correct and consistent for the question, using the result previews as "
+    "evidence. Reply with ONLY the integer index of the best candidate.\n\n"
+    "Question: {{question}}\n\nCandidates:\n{{candidates}}\n\n"
+    "Result previews:\n{{result_previews}}\n\nBest candidate index:"
+)
+
+# name -> (text, config, commit message)
+SINGLE_VERSION = [
+    ("support-triage-summary", SUMMARY, {"model": BRANCH_MODEL, "temperature": 0.3},
+     "2-sentence factual summary of the ticket"),
+    ("support-triage-sentiment", SENTIMENT, {"model": BRANCH_MODEL, "temperature": 0.3},
+     "JSON {sentiment, urgency}"),
+    ("support-triage-category", CATEGORY, {"model": BRANCH_MODEL, "temperature": 0.0},
+     "One label from the fixed category taxonomy"),
+    ("support-triage-policy-guard", POLICY_GUARD, {"model": BRANCH_MODEL, "temperature": 0.0},
+     "PII / credential / abuse screen -> JSON {flagged, reasons}"),
+    ("support-triage-synthesis", SYNTHESIS, {"model": SONNET, "temperature": 0.5},
+     "Merge labeled branch outputs into a triage brief (states insufficient data)"),
+    ("support-triage-tie-break-judge", TIE_BREAK, {"model": JUDGE_MODEL, "temperature": 0.0},
+     "USC-style tie-break: pick most consistent candidate"),
+]
+
+
+def _get(name: str, label: str):
+    url = f"{HOST}/api/public/v2/prompts/{urllib.parse.quote(name)}?label={label}"
+    req = urllib.request.Request(url, headers=_HEADERS, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.load(r)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None
+        raise
+
+
+def _create(name: str, text: str, labels, config: dict, message: str) -> dict:
+    body = {"name": name, "type": "text", "prompt": text, "labels": labels,
+            "config": config, "commitMessage": message}
+    req = urllib.request.Request(f"{HOST}/api/public/v2/prompts",
+                                 data=json.dumps(body).encode(), headers=_HEADERS, method="POST")
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.load(r)
+
+
+def _seed_single(name, text, config, message):
+    existing = _get(name, LABEL)
+    if existing is not None and (existing.get("prompt") or "").strip() == text.strip():
+        print(f"  ✓ {name} [{LABEL}] already up to date (v{existing.get('version')})")
+        return
+    created = _create(name, text, [LABEL], config, message)
+    verb = "updated" if existing is not None else "created"
+    print(f"  + {name} [{LABEL}] {verb} (v{created.get('version')})")
+
+
+def _seed_voter():
+    name = "support-triage-sql-voter"
+    config = {"model": SONNET, "temperature": 0.9}
+    existing = _get(name, LABEL)
+    if existing is not None and (existing.get("prompt") or "").strip() == SQL_VOTER_V2.strip():
+        print(f"  ✓ {name} [{LABEL}] already up to date (v{existing.get('version')})")
+        return
+    if existing is None:
+        v1 = _create(name, SQL_VOTER_V1, [], config, "Baseline SQL voter prompt")
+        print(f"  + {name} v{v1.get('version')} created (baseline)")
+    v2 = _create(name, SQL_VOTER_V2, [LABEL], config,
+                 "Qualify database.table + explicit GROUP BY + LIMIT; promote to production")
+    print(f"  + {name} v{v2.get('version')} created, labels={v2.get('labels')}")
+
+
+def main():
+    if not PK or not SK:
+        raise SystemExit("LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set (source .env first).")
+    print(f"Seeding support-triage prompts at {HOST} ...")
+    for name, text, config, message in SINGLE_VERSION:
+        _seed_single(name, text, config, message)
+    _seed_voter()
+    print(f"\nDone. View: {HOST} → Prompts. The demo fetches these by label=production at runtime.")
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/support-triage-parallel/sql_voting.py
+++ b/demos/support-triage-parallel/sql_voting.py
@@ -207,6 +207,27 @@ def tally_votes(question: str, candidates: List[dict], strategy: str = VOTE_STRA
         if strategy == "judge-consensus":
             winner_c = tie_break_judge(question, valid)  # judge decides, always
             tie_break_used = True
+        elif tally["empty"]:
+            # Every EXPLAIN-valid candidate still ended up with signature=None
+            # (e.g. execute_readonly timed out/errored for all of them during
+            # result-signature hashing). There is no vote to count: `winner_sig`
+            # would be None here, and `next(c for c in valid if c["signature"] ==
+            # None)` would match the FIRST such candidate purely because None ==
+            # None, and `tally["votes"].get(None, 1)` would then default to 1 —
+            # fabricating a "1/N agreed" consensus_confidence for a run where
+            # zero candidates actually produced a comparable result. Report zero
+            # consensus instead, mirroring the no-valid-candidates branch above.
+            meta = {"votes": {}, "invalid": tally["invalid"], "winner": None,
+                    "margin": 0, "tie_break_used": False, "strategy": strategy}
+            agg.update(metadata=meta,
+                       output={"error": "no candidate produced a usable result signature"})
+            lf.score_current_trace(
+                "consensus_confidence", 0.0,
+                comment="no candidate produced a usable result signature "
+                        f"({tally['valid_count']} EXPLAIN-valid, 0 executed successfully)")
+            return {"winning_sql": None, "result_signature": None, "tally": {},
+                    "consensus_confidence": 0.0, "tie_break_used": False,
+                    "winner": None, "margin": 0, "invalid": tally["invalid"]}
         elif tally["tie"]:
             winner_c = tie_break_judge(question, valid)  # break the split
             tie_break_used = True

--- a/demos/support-triage-parallel/sql_voting.py
+++ b/demos/support-triage-parallel/sql_voting.py
@@ -1,0 +1,259 @@
+"""
+Stage 2 — Voting (self-consistency) over N SQL candidates.
+
+The *same* data question is answered N times at high temperature (Wang et al.
+2022 self-consistency), each sample validated with ``EXPLAIN`` against the
+ClickHouse public playground; valid candidates are then executed and
+**majority-voted on their result-set signature** — the database, not string
+comparison, arbitrates semantic equivalence. A tie fires an Opus judge
+(Universal Self-Consistency-style) only when the vote splits.
+
+What lands in Langfuse:
+- ``vote-candidate`` — N sibling generations, **identical name**, ``sample_index``
+  in metadata (low cardinality so they stay filterable).
+- ``validate-candidates`` — span with an ``sql_validity_rate`` score; each
+  ``explain-candidate`` is a ``tool`` observation.
+- ``tally-votes`` — aggregator span whose **input holds all candidates** and whose
+  **metadata is the literal vote tally** (``votes``, ``invalid``, ``winner``,
+  ``margin``, ``tie_break_used``). ``consensus_confidence`` is a trace-level score.
+
+Three pluggable aggregation strategies (``VOTE_STRATEGY`` / experiment parameter)
+share one skeleton and differ only in how a candidate's signature is computed:
+- ``result-signature`` (default) — execute each candidate + hash sorted rows.
+- ``majority-exact``   — sqlglot canonical-form string equality (no execution).
+- ``judge-consensus``  — skip vote counting; an Opus judge picks among valids.
+"""
+
+import asyncio
+import hashlib
+import os
+from collections import Counter
+from typing import Dict, List, Optional
+
+import ch_validator
+import langfuse_config as lf
+from llm import anthropic_call, anthropic_call_sync, strip_sql
+
+VOTE_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+JUDGE_MODEL = os.getenv("JUDGE_MODEL", "claude-opus-4-7")
+VOTE_SAMPLES = int(os.getenv("VOTE_SAMPLES", "5"))
+VOTE_TEMPERATURE = float(os.getenv("VOTE_TEMPERATURE", "0.9"))
+VOTE_STRATEGY = os.getenv("VOTE_STRATEGY", "result-signature")
+
+# Local fallbacks — MIRROR the managed prompts in scripts/seed_prompts.py.
+SQL_VOTER_FALLBACK = (
+    "You are a ClickHouse SQL expert. Write a SINGLE read-only ClickHouse SELECT "
+    "that answers the question using the public demo datasets (nyc_taxi, github, "
+    "hackernews, uk, stackoverflow). Always qualify database.table, prefer an "
+    "explicit GROUP BY, and add a LIMIT. Reply with ONLY the SQL — no prose, no "
+    "code fences.\n\nQuestion: {{question}}\n\nSQL:"
+)
+TIE_BREAK_FALLBACK = (
+    "The following SQL candidates tied in a majority vote. Pick the ONE that is "
+    "most correct and consistent for the question, using the result previews as "
+    "evidence. Reply with ONLY the integer index of the best candidate.\n\n"
+    "Question: {{question}}\n\nCandidates:\n{{candidates}}\n\n"
+    "Result previews:\n{{result_previews}}\n\nBest candidate index:"
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pure vote math (no I/O) — the unit-test target for the aggregation logic.
+# --------------------------------------------------------------------------- #
+def compute_tally(candidates: List[dict]) -> dict:
+    """Tally votes over candidates annotated with ``valid`` (bool) and
+    ``signature`` (str). Pure function — no network, no LLM.
+
+    Returns ``{votes, invalid, winner, top, margin, tie, valid_count, empty}``.
+    ``winner`` is None when the vote ties or there are no valid candidates.
+    """
+    valid = [c for c in candidates if c.get("valid")]
+    votes = Counter(c["signature"] for c in valid if c.get("signature"))
+    invalid = len(candidates) - len(valid)
+    if not votes:
+        return {"votes": {}, "invalid": invalid, "winner": None, "top": 0,
+                "margin": 0, "tie": False, "valid_count": len(valid), "empty": True}
+    counts = sorted(votes.values(), reverse=True)
+    top = counts[0]
+    second = counts[1] if len(counts) > 1 else 0
+    tie = list(votes.values()).count(top) > 1
+    winner = None if tie else max(votes, key=lambda k: votes[k])
+    return {"votes": dict(votes), "invalid": invalid, "winner": winner, "top": top,
+            "margin": top - second, "tie": tie, "valid_count": len(valid), "empty": False}
+
+
+def _result_signature(sql: str) -> Optional[str]:
+    """Execute a candidate read-only and hash its sorted result set."""
+    rows = ch_validator.execute_readonly(sql)
+    if rows is None:
+        return None
+    payload = repr(sorted(tuple(str(cell) for cell in row) for row in rows))
+    return "sig-" + hashlib.sha1(payload.encode()).hexdigest()[:8]
+
+
+def _canonical_signature(sql: str) -> str:
+    """Signature from the sqlglot canonical SQL string (no execution).
+
+    Deliberately weaker than result-signature — it cannot see that
+    ``GROUP BY 1`` is equivalent to ``GROUP BY borough`` — which is the point the
+    experiment makes.
+    """
+    canonical = ch_validator.normalize(sql).lower()
+    try:
+        import sqlglot
+        canonical = sqlglot.parse_one(sql, dialect="clickhouse").sql(
+            dialect="clickhouse", normalize=True, pretty=False).lower()
+    except Exception:
+        canonical = " ".join(canonical.split())
+    return "csql-" + hashlib.sha1(canonical.encode()).hexdigest()[:8]
+
+
+def _assign_signatures(candidates: List[dict], strategy: str) -> None:
+    """Populate ``signature`` (used for voting) and ``result_signature`` (the
+    executed row-hash, strategy-agnostic for experiments) on each valid candidate."""
+    for c in candidates:
+        if not c.get("valid"):
+            c["signature"] = None
+            continue
+        if strategy == "majority-exact":
+            c["signature"] = _canonical_signature(c["sql"])
+            c["result_signature"] = None  # executed lazily for the winner only
+        else:  # result-signature and judge-consensus both execute + hash
+            sig = _result_signature(c["sql"])
+            c["signature"] = sig
+            c["result_signature"] = sig
+
+
+def _result_preview(sql: str, max_rows: int = 3) -> str:
+    rows = ch_validator.execute_readonly(sql)
+    if not rows:
+        return "(no rows / execution failed)"
+    return "\n".join(str(r) for r in rows[:max_rows])
+
+
+async def sample_candidate(question: str, index: int) -> dict:
+    """One voting attempt — a generation named ``vote-candidate`` (same on all N;
+    the run index lives in metadata)."""
+    text, prompt_obj = lf.render_prompt("support-triage-sql-voter",
+                                        SQL_VOTER_FALLBACK, question=question)
+    gen_kwargs = {"model": VOTE_MODEL}
+    if prompt_obj is not None:
+        gen_kwargs["prompt"] = prompt_obj
+    with lf.observe("vote-candidate", as_type="generation", input=question,
+                    metadata={"sample_index": index}, **gen_kwargs) as gen:
+        raw = await anthropic_call(model=VOTE_MODEL, prompt=text,
+                                   temperature=VOTE_TEMPERATURE, max_tokens=500, obs=gen)
+        sql = strip_sql(raw)
+        gen.update(output=sql)
+    return {"sql": sql, "sample_index": index, "valid": False, "signature": None}
+
+
+def tie_break_judge(question: str, valid: List[dict]) -> dict:
+    """Opus USC-style judge — pick the most consistent/correct candidate given the
+    candidates + their result previews. Deterministic fallback (first valid) when
+    the judge is unavailable."""
+    if not valid:
+        return {}
+    previews = "\n\n".join(f"[{i}] {c['sql']}\n-> {_result_preview(c['sql'])}"
+                           for i, c in enumerate(valid))
+    candidate_list = "\n".join(f"[{i}] {c['sql']}" for i, c in enumerate(valid))
+    text, prompt_obj = lf.render_prompt(
+        "support-triage-tie-break-judge", TIE_BREAK_FALLBACK,
+        question=question, candidates=candidate_list, result_previews=previews)
+    gen_kwargs = {"model": JUDGE_MODEL}
+    if prompt_obj is not None:
+        gen_kwargs["prompt"] = prompt_obj
+    with lf.observe("tie-break-judge", as_type="generation",
+                    input={"question": question, "candidates": candidate_list},
+                    **gen_kwargs) as gen:
+        try:
+            reply = anthropic_call_sync(model=JUDGE_MODEL, prompt=text,
+                                        temperature=0.0, max_tokens=50, obs=gen)
+            digits = "".join(ch for ch in reply if ch.isdigit())
+            idx = int(digits) if digits else 0
+            chosen = valid[idx] if 0 <= idx < len(valid) else valid[0]
+        except Exception as e:
+            gen.update(level="WARNING", status_message=f"judge unavailable: {e}")
+            chosen = valid[0]  # deterministic fallback
+        gen.update(output={"chosen_index": valid.index(chosen), "sql": chosen["sql"]})
+    return chosen
+
+
+def tally_votes(question: str, candidates: List[dict], strategy: str = VOTE_STRATEGY) -> dict:
+    """Aggregate candidates into a winner. Writes the full tally to the
+    ``tally-votes`` observation metadata and ``consensus_confidence`` to the trace."""
+    _assign_signatures(candidates, strategy)
+    valid = [c for c in candidates if c.get("valid")]
+
+    with lf.observe(
+        "tally-votes",
+        input={"candidates": [{k: c.get(k) for k in ("sql", "valid", "signature",
+                                                      "sample_index")} for c in candidates]},
+        metadata={"strategy": strategy},
+    ) as agg:
+        if not valid:
+            meta = {"votes": {}, "invalid": len(candidates), "winner": None,
+                    "margin": 0, "tie_break_used": False, "strategy": strategy}
+            agg.update(metadata=meta, output={"error": "no valid SQL candidates"})
+            lf.score_current_trace("consensus_confidence", 0.0,
+                                   comment="no valid SQL candidates")
+            return {"winning_sql": None, "result_signature": None, "tally": {},
+                    "consensus_confidence": 0.0, "tie_break_used": False,
+                    "winner": None, "margin": 0, "invalid": len(candidates)}
+
+        tally = compute_tally(candidates)
+        tie_break_used = False
+
+        if strategy == "judge-consensus":
+            winner_c = tie_break_judge(question, valid)  # judge decides, always
+            tie_break_used = True
+        elif tally["tie"]:
+            winner_c = tie_break_judge(question, valid)  # break the split
+            tie_break_used = True
+        else:
+            winner_sig = tally["winner"]
+            winner_c = next(c for c in valid if c.get("signature") == winner_sig)
+
+        winner_sig = winner_c.get("signature")
+        winner_votes = tally["votes"].get(winner_sig, 1)
+        confidence = winner_votes / max(len(valid), 1)
+
+        # Winner's executed result signature (strategy-agnostic — experiments
+        # compare THIS to the pinned expected signature).
+        result_sig = winner_c.get("result_signature") or _result_signature(winner_c["sql"])
+
+        meta = {"votes": tally["votes"], "invalid": tally["invalid"],
+                "winner": winner_sig, "margin": tally["margin"],
+                "tie_break_used": tie_break_used, "strategy": strategy}
+        agg.update(metadata=meta,
+                   output={"winning_sql": winner_c["sql"], "result_signature": result_sig})
+        lf.score_current_trace(
+            "consensus_confidence", confidence,
+            comment=f"{winner_votes}/{len(valid)} valid samples agreed; strategy={strategy}")
+
+        return {"winning_sql": winner_c["sql"], "result_signature": result_sig,
+                "tally": tally["votes"], "consensus_confidence": confidence,
+                "tie_break_used": tie_break_used, "winner": winner_sig,
+                "margin": tally["margin"], "invalid": tally["invalid"]}
+
+
+async def vote_sql(question: str, strategy: str = VOTE_STRATEGY,
+                   n_samples: int = VOTE_SAMPLES) -> dict:
+    """Voting fan-out parent: sample N candidates concurrently, validate via
+    EXPLAIN, then tally."""
+    with lf.observe("vote-sql",
+                    metadata={"n_samples": n_samples, "vote_temperature": VOTE_TEMPERATURE,
+                              "strategy": strategy}):
+        candidates = await asyncio.gather(
+            *(sample_candidate(question, i) for i in range(n_samples)))
+        candidates = list(candidates)
+
+        with lf.observe("validate-candidates"):
+            for c in candidates:
+                c["valid"] = ch_validator.explain_ok(c["sql"])
+            rate = sum(1 for c in candidates if c["valid"]) / max(len(candidates), 1)
+            lf.score_current_span("sql_validity_rate", rate,
+                                  comment=f"{sum(1 for c in candidates if c['valid'])}/"
+                                          f"{len(candidates)} candidates planned successfully")
+
+        return tally_votes(question, candidates, strategy)

--- a/demos/support-triage-parallel/tests/conftest.py
+++ b/demos/support-triage-parallel/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Test configuration: make demo modules importable and force Langfuse off.
+
+These tests exercise only the pure aggregation/merge logic — NO LLM, NO
+ClickHouse, NO Langfuse — so they are safe for CI. Langfuse keys are popped
+before any demo module is imported so ``is_langfuse_enabled()`` is False and
+every observation no-ops. Third-party clients (anthropic, clickhouse-connect,
+sqlglot) are imported lazily inside the modules, so they need not be installed
+for these tests to run.
+"""
+
+import os
+import sys
+
+for _k in ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"):
+    os.environ.pop(_k, None)
+
+# Make the demo package root importable (parent of this tests/ dir).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/demos/support-triage-parallel/tests/test_aggregator.py
+++ b/demos/support-triage-parallel/tests/test_aggregator.py
@@ -1,0 +1,77 @@
+"""Pure-code tests for the sectioning aggregator input builder
+(triage_pipeline.build_synthesis_input).
+
+Verifies graceful degradation: a missing / failed branch becomes
+``"insufficient data"`` in the labeled outputs, the failed count is right, and
+the ``degraded`` flag is set — the *aggregation must tolerate N-1 branches*
+guarantee. No LLM involved.
+"""
+
+from triage_pipeline import build_synthesis_input
+
+
+def _ok(branch, key, output):
+    return {"branch": branch, "key": key, "ok": True, "output": output}
+
+
+def _failed(branch, key):
+    return {"branch": branch, "key": key, "ok": False, "output": None}
+
+
+def _all_ok():
+    return [
+        _ok("branch-summary", "summary", "A two-sentence summary."),
+        _ok("branch-sentiment-urgency", "sentiment", '{"sentiment":"negative","urgency":"high"}'),
+        _ok("branch-category", "category", "query-performance"),
+        _ok("branch-policy-guard", "policy", '{"flagged":false,"reasons":[]}'),
+    ]
+
+
+def test_all_branches_present_not_degraded():
+    outputs, failed, degraded = build_synthesis_input(_all_ok())
+    assert failed == 0
+    assert degraded is False
+    assert set(outputs) == {"summary", "sentiment", "category", "policy"}
+    assert "insufficient data" not in outputs.values()
+
+
+def test_one_branch_failed_is_degraded():
+    results = _all_ok()
+    results[1] = _failed("branch-sentiment-urgency", "sentiment")  # slow-branch fault
+    outputs, failed, degraded = build_synthesis_input(results)
+    assert failed == 1
+    assert degraded is True
+    assert outputs["sentiment"] == "insufficient data"
+    assert outputs["summary"] != "insufficient data"
+
+
+def test_none_output_treated_as_failed():
+    results = _all_ok()
+    results[2] = _ok("branch-category", "category", None)  # ok flag but empty output
+    outputs, failed, degraded = build_synthesis_input(results)
+    assert outputs["category"] == "insufficient data"
+    assert failed == 1
+    assert degraded is True
+
+
+def test_multiple_failures_counted():
+    results = [
+        _failed("branch-summary", "summary"),
+        _failed("branch-sentiment-urgency", "sentiment"),
+        _ok("branch-category", "category", "billing"),
+        _ok("branch-policy-guard", "policy", '{"flagged":true,"reasons":["email"]}'),
+    ]
+    outputs, failed, degraded = build_synthesis_input(results)
+    assert failed == 2
+    assert degraded is True
+    assert outputs["summary"] == "insufficient data"
+    assert outputs["sentiment"] == "insufficient data"
+    assert outputs["category"] == "billing"
+
+
+def test_key_derived_from_branch_name_when_missing():
+    # A result missing an explicit 'key' should derive it from the branch name.
+    results = [{"branch": "branch-summary", "ok": True, "output": "hi"}]
+    outputs, failed, degraded = build_synthesis_input(results)
+    assert "summary" in outputs
+    assert outputs["summary"] == "hi"

--- a/demos/support-triage-parallel/tests/test_tally_votes.py
+++ b/demos/support-triage-parallel/tests/test_tally_votes.py
@@ -1,0 +1,78 @@
+"""Pure-code regression test for sql_voting.tally_votes's handling of the
+"EXPLAIN-valid but zero usable signatures" degenerate case.
+
+Live testing (real Anthropic + real sql-clickhouse.clickhouse.com execution)
+found that a full-table aggregation candidate can pass EXPLAIN (fast, planning
+only) but then time out during the actual execution used to compute its
+result-signature. When this happens to EVERY candidate, ``compute_tally``
+correctly reports ``empty=True`` (no votes were cast) — but ``tally_votes`` was
+not checking that flag, so it fell into the "pick the winner by signature"
+branch. Since every candidate's ``signature`` is ``None`` in that case, and
+``winner_sig = tally["winner"]`` is also ``None``, ``next(c for c in valid if
+c["signature"] == winner_sig)`` matched the FIRST candidate purely because
+``None == None`` — fabricating a "winner" — and ``tally["votes"].get(None, 1)``
+defaulted to ``1``, fabricating a nonzero ``consensus_confidence`` for a run
+where zero candidates actually agreed on anything.
+
+No network/LLM calls: ``ch_validator.execute_readonly`` is monkeypatched to
+always fail (simulating the live timeout), matching how EXPLAIN can pass while
+execution fails.
+"""
+
+import ch_validator
+import sql_voting
+
+
+def _explain_valid_candidate(sql: str, index: int) -> dict:
+    # Mirrors sample_candidate()'s return shape after explain_ok() has set
+    # valid=True; signature/result_signature are filled in by
+    # _assign_signatures() inside tally_votes().
+    return {"sql": sql, "sample_index": index, "valid": True, "signature": None}
+
+
+def test_all_signatures_failing_reports_zero_confidence_not_fabricated(monkeypatch):
+    monkeypatch.setattr(ch_validator, "execute_readonly", lambda sql: None)
+
+    candidates = [_explain_valid_candidate("SELECT 1", i) for i in range(5)]
+    result = sql_voting.tally_votes("irrelevant question", candidates,
+                                     strategy="result-signature")
+
+    assert result["consensus_confidence"] == 0.0
+    assert result["winner"] is None
+    assert result["winning_sql"] is None
+    assert result["result_signature"] is None
+    assert result["tally"] == {}
+    assert result["tie_break_used"] is False
+    # All 5 were EXPLAIN-valid; none produced a signature. They must NOT be
+    # counted as "invalid" SQL (that would misreport sql_validity_rate's
+    # partner metric) — they are correctly-planned candidates whose execution
+    # failed, a distinct failure mode from a bad EXPLAIN.
+    assert result["invalid"] == 0
+
+
+def test_one_real_signature_among_failures_still_wins():
+    # Sanity check the fix doesn't over-trigger: if even one candidate DID
+    # produce a signature, that's a real (if lonely) vote and must still win —
+    # this is not the degenerate "empty" case.
+    candidates = [
+        {"sql": "SELECT 1", "sample_index": 0, "valid": True, "signature": None},
+        {"sql": "SELECT 2", "sample_index": 1, "valid": True, "signature": None},
+    ]
+
+    def fake_execute(sql):
+        return [(1,)] if sql.strip().rstrip(";") == "SELECT 1" else None
+
+    import ch_validator as chv
+    orig = chv.execute_readonly
+    chv.execute_readonly = fake_execute
+    try:
+        result = sql_voting.tally_votes("irrelevant question", candidates,
+                                         strategy="result-signature")
+    finally:
+        chv.execute_readonly = orig
+
+    assert result["winner"] is not None
+    assert result["winning_sql"] == "SELECT 1"
+    # 1 vote out of 2 EXPLAIN-valid candidates (the other's signature is None,
+    # i.e. its execution failed but it still counts against the denominator).
+    assert result["consensus_confidence"] == 0.5

--- a/demos/support-triage-parallel/tests/test_vote_tally.py
+++ b/demos/support-triage-parallel/tests/test_vote_tally.py
@@ -1,0 +1,85 @@
+"""Pure-code tests for the vote tally math (sql_voting.compute_tally).
+
+No LLM, no ClickHouse — candidates are hand-annotated with ``valid`` +
+``signature`` so we test only the aggregation logic: clear majority, a 2-2-1
+tie, all-invalid, N-1 degradation, and margin arithmetic. This doubles as the CI
+target for the *aggregation-logic-bug* failure mode.
+"""
+
+from sql_voting import compute_tally
+
+
+def _cand(sig, valid=True, i=0):
+    return {"sql": f"SELECT {i}", "sample_index": i, "valid": valid, "signature": sig}
+
+
+def test_clear_majority_5_0():
+    cands = [_cand("sig-a", i=i) for i in range(5)]
+    t = compute_tally(cands)
+    assert t["winner"] == "sig-a"
+    assert t["tie"] is False
+    assert t["votes"] == {"sig-a": 5}
+    assert t["margin"] == 5
+    assert t["invalid"] == 0
+    assert t["valid_count"] == 5
+
+
+def test_majority_with_one_invalid():
+    # 3x sig-a, 1x sig-b, 1 invalid -> winner sig-a, margin 2
+    cands = [_cand("sig-a", i=0), _cand("sig-a", i=1), _cand("sig-a", i=2),
+             _cand("sig-b", i=3), _cand(None, valid=False, i=4)]
+    t = compute_tally(cands)
+    assert t["winner"] == "sig-a"
+    assert t["margin"] == 2
+    assert t["invalid"] == 1
+    assert t["valid_count"] == 4
+    assert t["tie"] is False
+
+
+def test_two_two_one_tie_fires_tiebreak():
+    # 2x sig-a, 2x sig-b, 1x sig-c -> tie at the top, no winner
+    cands = [_cand("sig-a", i=0), _cand("sig-a", i=1),
+             _cand("sig-b", i=2), _cand("sig-b", i=3),
+             _cand("sig-c", i=4)]
+    t = compute_tally(cands)
+    assert t["tie"] is True
+    assert t["winner"] is None
+    assert t["margin"] == 0
+    assert t["valid_count"] == 5
+
+
+def test_all_invalid_is_empty_and_graceful():
+    cands = [_cand(None, valid=False, i=i) for i in range(5)]
+    t = compute_tally(cands)
+    assert t["empty"] is True
+    assert t["winner"] is None
+    assert t["votes"] == {}
+    assert t["invalid"] == 5
+    assert t["valid_count"] == 0
+
+
+def test_n_minus_1_degradation_still_tallies():
+    # One candidate dropped (invalid); the remaining 4 still produce a winner.
+    cands = [_cand("sig-a", i=0), _cand("sig-a", i=1), _cand("sig-a", i=2),
+             _cand("sig-b", i=3), _cand(None, valid=False, i=4)]
+    t = compute_tally(cands)
+    assert t["valid_count"] == 4
+    assert t["winner"] == "sig-a"
+    assert t["top"] == 3
+
+
+def test_margin_is_top_minus_second():
+    # 4x sig-a, 1x sig-b -> margin 3
+    cands = [_cand("sig-a", i=i) for i in range(4)] + [_cand("sig-b", i=4)]
+    t = compute_tally(cands)
+    assert t["top"] == 4
+    assert t["margin"] == 3
+
+
+def test_single_valid_candidate():
+    cands = [_cand("sig-a", i=0), _cand(None, valid=False, i=1),
+             _cand(None, valid=False, i=2)]
+    t = compute_tally(cands)
+    assert t["winner"] == "sig-a"
+    assert t["valid_count"] == 1
+    assert t["margin"] == 1

--- a/demos/support-triage-parallel/tickets.py
+++ b/demos/support-triage-parallel/tickets.py
@@ -1,0 +1,176 @@
+"""
+Deterministic synthetic support-ticket corpus for the Support Triage Parallel
+demo (seed data — no external files, no network).
+
+Each ticket carries:
+- ``subject`` / ``body``  -> drive the 4 sectioning branches (summary, sentiment,
+  category, policy-guard). Some bodies embed an email / API key to trip the guard.
+- ``data_question``       -> drives best-of-N SQL voting against the public
+  ClickHouse playground datasets (nyc_taxi, github, hackernews, uk, stackoverflow).
+- ``designed_moment``     -> the demo beat each ticket is engineered to produce
+  (documented in DEMO_SCRIPT.md so the presenter never hunts for a moment live).
+
+Themed on the same ``sql.clickhouse.com`` public datasets used by the text-to-sql
+and agentic-rag demos, so the SA has a natural pivot line from those demos.
+"""
+
+TICKETS = [
+    {
+        "id": "TCK-001",
+        "subject": "NYC taxi dashboard is slow",
+        "body": (
+            "Our nyc_taxi analytics dashboard has gotten really sluggish over the "
+            "last week — the borough breakdown panel takes 20+ seconds to load. "
+            "It was fine before we added the fare columns. While you look into "
+            "that, our finance team also needs a number: which pickup borough had "
+            "the highest average fare in 2015?"
+        ),
+        "data_question": (
+            "Using the nyc_taxi.trips table, which pickup_ntaname / borough had the "
+            "highest average fare_amount for trips in 2015? Return the borough and "
+            "the average fare, ordered descending."
+        ),
+        "designed_moment": "clean 5-0 consensus (consensus_confidence=1.0)",
+    },
+    {
+        "id": "TCK-002",
+        "subject": "Which repos are most active? (metric unclear)",
+        "body": (
+            "We're building an internal leaderboard from the github dataset and "
+            "leadership keeps asking for 'the most active repositories last year'. "
+            "Nobody can agree whether that means stars, pull requests, pushes, or "
+            "total events. Can you give us the top repositories — pick whatever "
+            "'most active' should reasonably mean?"
+        ),
+        "data_question": (
+            "From the github.github_events dataset, what were the most active "
+            "repositories in the last full year? ('most active' is intentionally "
+            "ambiguous — stars vs PRs vs pushes vs total events.)"
+        ),
+        "designed_moment": "vote splits 2-2-1 -> tie-break judge fires",
+    },
+    {
+        "id": "TCK-003",
+        "subject": "Hacker News export keeps failing - here are my creds",
+        "body": (
+            "The scheduled export from the hackernews dataset failed again. I'm "
+            "pasting my details so you can reproduce: reach me at "
+            "ops.oncall@example.com and here's the service API key we use for the "
+            "job: sk-live-9f8e7d6c5b4a3210. Also, roughly how many stories were "
+            "posted to Hacker News in 2015 so I can sanity-check the export size?"
+        ),
+        "data_question": (
+            "From the hackernews.hits table, how many stories (type = 'story') "
+            "were posted in the year 2015?"
+        ),
+        "designed_moment": "policy guard flags (policy_flagged=1)",
+    },
+    {
+        "id": "TCK-004",
+        "subject": "UK property price question (date formats are a mess)",
+        "body": (
+            "We're pulling from the uk price_paid dataset and our numbers look off "
+            "— I think there's a date-format trap because some of our queries use "
+            "the transfer date as a string. Can you tell us the average paid price "
+            "in Greater London for the year 2022?"
+        ),
+        "data_question": (
+            "From the uk.uk_price_paid table, what was the average price for "
+            "properties in Greater London (county or town) during 2022? Beware the "
+            "date column type when filtering the year."
+        ),
+        "designed_moment": "1-2 invalid candidates -> sql_validity_rate < 1",
+    },
+    {
+        "id": "TCK-005",
+        "subject": "Stack Overflow tag trends - urgent for a deck",
+        "body": (
+            "Slightly panicked — I have a leadership deck in an hour. From the "
+            "stackoverflow dataset, which programming-language tags have the most "
+            "questions overall? Just the top handful is fine."
+        ),
+        "data_question": (
+            "From the stackoverflow posts/tags data, which tags are attached to "
+            "the most questions? Return the top 10 tags by question count."
+        ),
+        "designed_moment": "run with FAULT=slow-branch -> dropped branch, degraded synthesis",
+    },
+    {
+        "id": "TCK-006",
+        "subject": "Billing overage on our taxi ingestion pipeline",
+        "body": (
+            "We just got a bill that's roughly double last month and we're not sure "
+            "why — ingestion volume shouldn't have changed. Frustrated, honestly. "
+            "As a side check: how many nyc_taxi trips were recorded in total in "
+            "2015 versus 2016?"
+        ),
+        "data_question": (
+            "From nyc_taxi.trips, how many trips were recorded in 2015 and how many "
+            "in 2016? Return one row per year with the trip count."
+        ),
+        "designed_moment": "filler — billing tone, volume for Monitor/dashboard",
+    },
+    {
+        "id": "TCK-007",
+        "subject": "Replication lag panic on our analytics replica",
+        "body": (
+            "Replica is falling behind and dashboards are stale — this is becoming "
+            "an incident. Once you help with that, can you also confirm: in the "
+            "github dataset, how many distinct repositories saw activity last year?"
+        ),
+        "data_question": (
+            "From github.github_events, how many distinct repositories had at least "
+            "one event in the last full year?"
+        ),
+        "designed_moment": "filler — high-urgency tone, volume",
+    },
+    {
+        "id": "TCK-008",
+        "subject": "Quick question about Hacker News top stories",
+        "body": (
+            "No rush and everything's working great, just curious — what were the "
+            "highest-scoring Hacker News stories of 2015? Love the product, thanks!"
+        ),
+        "data_question": (
+            "From hackernews.hits, what were the top 10 stories by score in 2015? "
+            "Return the title and score."
+        ),
+        "designed_moment": "filler — positive tone, volume",
+    },
+    {
+        "id": "TCK-009",
+        "subject": "Airport taxi trips - need a breakdown",
+        "body": (
+            "For a capacity plan we need to understand airport traffic. From the "
+            "nyc_taxi data, what's the average trip distance for trips that started "
+            "at an airport in 2015?"
+        ),
+        "data_question": (
+            "From nyc_taxi.trips, what is the average trip_distance for airport "
+            "pickups in 2015? Use the pickup location / airport flag available in "
+            "the dataset."
+        ),
+        "designed_moment": "filler — neutral tone, volume",
+    },
+    {
+        "id": "TCK-010",
+        "subject": "Stack Overflow answer rate by year",
+        "body": (
+            "We're studying community health. From the stackoverflow dataset, how "
+            "has the number of questions asked changed year over year for the last "
+            "five years?"
+        ),
+        "data_question": (
+            "From the stackoverflow posts data, how many questions were asked per "
+            "year for the last five years? Return year and question count."
+        ),
+        "designed_moment": "filler — neutral tone, volume",
+    },
+]
+
+TICKETS_BY_ID = {t["id"]: t for t in TICKETS}
+
+
+def get_ticket(ticket_id: str):
+    """Return a ticket by id (case-insensitive), or None."""
+    return TICKETS_BY_ID.get(ticket_id.upper())

--- a/demos/support-triage-parallel/triage_pipeline.py
+++ b/demos/support-triage-parallel/triage_pipeline.py
@@ -112,14 +112,17 @@ async def run_branch(name: str, short_key: str, as_type: str, temperature: float
         if prompt_obj is not None:
             obs.update(prompt=prompt_obj)  # link managed prompt version to the generation
         try:
-            # Fault injection: force the sentiment branch to blow past the timeout.
-            if fault == "slow-branch" and short_key == "sentiment":
-                await asyncio.sleep(BRANCH_TIMEOUT_S + 1)
-            out = await asyncio.wait_for(
-                anthropic_call(model=BRANCH_MODEL, prompt=text,
-                               temperature=temperature, max_tokens=400, obs=obs),
-                timeout=BRANCH_TIMEOUT_S,
-            )
+            async def _do_call():
+                # Fault injection: force the sentiment branch to blow past the
+                # timeout. The sleep must live INSIDE the coroutine that wait_for
+                # bounds, otherwise it completes uncancelled and the real call
+                # gets a fresh budget — so the branch would never actually drop.
+                if fault == "slow-branch" and short_key == "sentiment":
+                    await asyncio.sleep(BRANCH_TIMEOUT_S + 1)
+                return await anthropic_call(model=BRANCH_MODEL, prompt=text,
+                                            temperature=temperature, max_tokens=400, obs=obs)
+
+            out = await asyncio.wait_for(_do_call(), timeout=BRANCH_TIMEOUT_S)
         except (asyncio.TimeoutError, Exception) as e:  # noqa: B014 - deliberate broad catch
             kind = "timeout" if isinstance(e, asyncio.TimeoutError) else type(e).__name__
             obs.update(level="WARNING", status_message=f"branch dropped: {kind}: {e}")

--- a/demos/support-triage-parallel/triage_pipeline.py
+++ b/demos/support-triage-parallel/triage_pipeline.py
@@ -1,0 +1,208 @@
+"""
+Stage 1 — Sectioning fan-out + synthesis aggregator.
+
+Four *different* questions about the *same* ticket run concurrently
+(``asyncio.gather``), each a narrow prompt on a cheap model (Haiku): summary,
+sentiment/urgency, technical category, and a policy/PII guardrail. A meta-agent
+(Sonnet) then synthesizes the labeled branch outputs into one triage brief.
+
+Why this is the Sectioning sub-variant:
+- Truly independent branches, isolated inputs, no cross-branch state.
+- The **guardrail split** is its own branch (typed ``guardrail``) rather than
+  folded into the main analysis call — LLMs handle a narrow consideration better
+  than an omnibus prompt, and a policy screen shouldn't slow the answer.
+- Partial-failure tolerant: a timed-out branch is dropped (``level=WARNING``) and
+  the aggregator proceeds with N-1, recording ``failed_branches``.
+
+Instrumentation: the fan-out parent is a ``span`` (``analyze-sections``); opening
+the branches *inside* it and gathering them makes them auto-nest as siblings
+with overlapping Timeline spans (parallel) or a staircase (``--sequential``).
+"""
+
+import asyncio
+import json
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import langfuse_config as lf
+from llm import anthropic_call
+
+BRANCH_MODEL = os.getenv("BRANCH_MODEL", "claude-haiku-4-5")
+SYNTH_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+SYNTH_TEMPERATURE = float(os.getenv("SYNTH_TEMPERATURE", "0.5"))
+BRANCH_TIMEOUT_S = float(os.getenv("BRANCH_TIMEOUT_S", "30"))
+
+CATEGORY_TAXONOMY = [
+    "query-performance", "ingestion", "replication", "billing",
+    "schema-migration", "connectivity", "other",
+]
+
+# --- Local fallback prompt templates -----------------------------------------
+# These MIRROR the managed prompts in scripts/seed_prompts.py (Langfuse {{var}}
+# syntax). Keep them in sync by hand — when managed and fallback match, enabling
+# prompt management changes nothing until you edit the prompt in Langfuse.
+SUMMARY_FALLBACK = (
+    "Summarize the following ClickHouse support ticket in exactly two short, "
+    "factual sentences. Do not speculate.\n\nTicket:\n{{ticket_body}}\n\nSummary:"
+)
+SENTIMENT_FALLBACK = (
+    "Analyze the customer's tone in this support ticket. Reply with ONLY a JSON "
+    'object: {"sentiment": "positive|neutral|negative", '
+    '"urgency": "low|medium|high"}.\n\nTicket:\n{{ticket_body}}\n\nJSON:'
+)
+CATEGORY_FALLBACK = (
+    "Classify this ClickHouse support ticket into exactly ONE category from this "
+    "list: query-performance, ingestion, replication, billing, schema-migration, "
+    "connectivity, other. Reply with ONLY the category label.\n\n"
+    "Ticket:\n{{ticket_body}}\n\nCategory:"
+)
+POLICY_GUARD_FALLBACK = (
+    "You are a policy/PII guardrail. Screen the ticket for personal data "
+    "(emails, phone numbers), leaked credentials/API keys, or abusive content. "
+    'Reply with ONLY JSON: {"flagged": true|false, "reasons": ["..."]}.\n\n'
+    "Ticket:\n{{ticket_body}}\n\nJSON:"
+)
+SYNTHESIS_FALLBACK = (
+    "You are a support triage lead. Merge the labeled analysis branches below "
+    "into a concise triage brief (owner-ready): one-line summary, "
+    "sentiment/urgency, category, and any policy flags. If a branch reads "
+    "'insufficient data', you MUST say so explicitly for that dimension and do "
+    "not invent it.\n\nBranch outputs (JSON):\n{{branch_outputs}}\n\nTriage brief:"
+)
+
+# (name, short_key, as_type, temperature, prompt_name, fallback)
+BRANCHES = [
+    ("branch-summary", "summary", "generation", 0.3, "support-triage-summary", SUMMARY_FALLBACK),
+    ("branch-sentiment-urgency", "sentiment", "generation", 0.3, "support-triage-sentiment", SENTIMENT_FALLBACK),
+    ("branch-category", "category", "generation", 0.0, "support-triage-category", CATEGORY_FALLBACK),
+    ("branch-policy-guard", "policy", "guardrail", 0.0, "support-triage-policy-guard", POLICY_GUARD_FALLBACK),
+]
+
+
+def _fault() -> str:
+    """Deterministic fault injection (repo convention). FAULT=slow-branch makes
+    branch-sentiment-urgency exceed the timeout so it is dropped."""
+    return os.getenv("FAULT", "").strip().lower()
+
+
+def _parse_json(text: str) -> Optional[dict]:
+    """Best-effort JSON extraction from a model reply (tolerates prose/fences)."""
+    if not text:
+        return None
+    s = text.strip()
+    start, end = s.find("{"), s.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        return json.loads(s[start:end + 1])
+    except Exception:
+        return None
+
+
+async def run_branch(name: str, short_key: str, as_type: str, temperature: float,
+                     prompt_name: str, fallback: str, ticket: dict,
+                     fault: str = "") -> dict:
+    """Run one sectioning branch as a typed observation. On timeout/error the
+    branch is dropped (``level=WARNING``) and the aggregator proceeds with N-1."""
+    started = time.perf_counter()
+    with lf.observe(name, as_type=as_type, input=ticket["body"],
+                    metadata={"branch": short_key}) as obs:
+        text, prompt_obj = lf.render_prompt(prompt_name, fallback, ticket_body=ticket["body"])
+        if prompt_obj is not None:
+            obs.update(prompt=prompt_obj)  # link managed prompt version to the generation
+        try:
+            # Fault injection: force the sentiment branch to blow past the timeout.
+            if fault == "slow-branch" and short_key == "sentiment":
+                await asyncio.sleep(BRANCH_TIMEOUT_S + 1)
+            out = await asyncio.wait_for(
+                anthropic_call(model=BRANCH_MODEL, prompt=text,
+                               temperature=temperature, max_tokens=400, obs=obs),
+                timeout=BRANCH_TIMEOUT_S,
+            )
+        except (asyncio.TimeoutError, Exception) as e:  # noqa: B014 - deliberate broad catch
+            kind = "timeout" if isinstance(e, asyncio.TimeoutError) else type(e).__name__
+            obs.update(level="WARNING", status_message=f"branch dropped: {kind}: {e}")
+            return {"branch": name, "key": short_key, "ok": False, "output": None,
+                    "elapsed": time.perf_counter() - started}
+
+        # The guardrail branch scores its OWN span (span-level, because a guard
+        # can fire on any ticket and repeat across a trace).
+        if short_key == "policy":
+            parsed = _parse_json(out) or {}
+            flagged = bool(parsed.get("flagged"))
+            lf.score_current_span(
+                "policy_flagged", 1.0 if flagged else 0.0, data_type="BOOLEAN",
+                comment="; ".join(parsed.get("reasons", []))[:300] or "no policy issues",
+            )
+        obs.update(output=out)
+        return {"branch": name, "key": short_key, "ok": True, "output": out,
+                "elapsed": time.perf_counter() - started}
+
+
+def build_synthesis_input(results: List[dict]) -> Tuple[Dict[str, Any], int, bool]:
+    """Pure aggregator input builder — no I/O, unit-testable offline.
+
+    Maps branch results to ``{short_key: output}``, substituting
+    ``"insufficient data"`` for any missing/failed branch. Returns
+    ``(branch_outputs, failed_count, degraded)``.
+    """
+    outputs: Dict[str, Any] = {}
+    failed = 0
+    for r in results:
+        key = r.get("key") or r.get("branch", "").removeprefix("branch-")
+        if r.get("ok") and r.get("output") is not None:
+            outputs[key] = r["output"]
+        else:
+            outputs[key] = "insufficient data"
+            failed += 1
+    return outputs, failed, failed > 0
+
+
+async def synthesize(branch_outputs: Dict[str, Any], degraded: bool) -> str:
+    """Meta-agent synthesis (Sonnet) over labeled branch outputs -> triage brief."""
+    text, prompt_obj = lf.render_prompt(
+        "support-triage-synthesis", SYNTHESIS_FALLBACK,
+        branch_outputs=json.dumps(branch_outputs, indent=2),
+    )
+    gen_kwargs = {"model": SYNTH_MODEL}
+    if prompt_obj is not None:
+        gen_kwargs["prompt"] = prompt_obj
+    with lf.observe("synthesis-llm", as_type="generation", **gen_kwargs) as gen:
+        gen.update(input={"branch_outputs": branch_outputs, "degraded": degraded})
+        brief = await anthropic_call(model=SYNTH_MODEL, prompt=text,
+                                     temperature=SYNTH_TEMPERATURE, max_tokens=600, obs=gen)
+    return brief
+
+
+async def analyze_sections(ticket: dict, sequential: bool = False,
+                           fault: str = "") -> dict:
+    """Sectioning fan-out + synthesis. Returns
+    ``{brief, branch_outputs, failed_branches, degraded}``."""
+    fault = fault or _fault()
+    with lf.observe("analyze-sections",
+                    metadata={"branch_count": len(BRANCHES),
+                              "mode": "sequential" if sequential else "parallel"}) as parent:
+        coros = [run_branch(*b, ticket, fault=fault) for b in BRANCHES]
+        wall_start = time.perf_counter()
+        if sequential:
+            results = [await c for c in coros]        # baseline for the latency A/B
+        else:
+            results = await asyncio.gather(*coros)     # concurrent siblings
+        wall = time.perf_counter() - wall_start
+        branch_sum = sum(r.get("elapsed", 0.0) for r in results)
+
+        branch_outputs, failed, degraded = build_synthesis_input(results)
+        parent.update(metadata={"branch_count": len(BRANCHES),
+                                "mode": "sequential" if sequential else "parallel",
+                                "failed_branches": failed})
+
+        with lf.observe("synthesize-triage-brief",
+                        input={"branch_outputs": branch_outputs},
+                        metadata={"failed_branches": failed, "degraded": degraded}) as agg:
+            brief = await synthesize(branch_outputs, degraded)
+            agg.update(output=brief)
+
+    return {"brief": brief, "branch_outputs": branch_outputs,
+            "failed_branches": failed, "degraded": degraded,
+            "wall_s": wall, "sum_s": branch_sum}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -382,7 +382,7 @@ services:
       context: ./demos/support-triage-parallel
     container_name: support-triage-parallel
     ports:
-      - "${SUPPORT_TRIAGE_PORT:-8008}:8000"
+      - "${SUPPORT_TRIAGE_PORT:-8009}:8000"
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-sonnet-4-6}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -370,6 +370,42 @@ services:
       - vector-rag-models:/root/.cache
 
   # =============================================================================
+  # Support Triage Parallel Demo — sectioning fan-out + best-of-N SQL voting
+  # =============================================================================
+  # Pattern #3 (Parallelization): 4 concurrent analysis branches + a 5-sample
+  # SQL voter arbitrated by executing candidates against the ClickHouse public
+  # playground. Sibling spans + vote-tally metadata land in Langfuse.
+  # Run: docker compose --profile demo run --rm support-triage-parallel python main.py
+  # =============================================================================
+  support-triage-parallel:
+    build:
+      context: ./demos/support-triage-parallel
+    container_name: support-triage-parallel
+    ports:
+      - "${SUPPORT_TRIAGE_PORT:-8008}:8000"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-sonnet-4-6}
+      - BRANCH_MODEL=${BRANCH_MODEL:-claude-haiku-4-5}          # cheap sectioning branches
+      - JUDGE_MODEL=${JUDGE_MODEL:-claude-opus-4-7}             # tie-break judge (repo tiering convention)
+      - TEMPERATURE=${TEMPERATURE:-0.7}
+      - VOTE_SAMPLES=${VOTE_SAMPLES:-5}
+      - VOTE_TEMPERATURE=${VOTE_TEMPERATURE:-0.9}
+      - VOTE_STRATEGY=${VOTE_STRATEGY:-result-signature}
+      # ClickHouse public playground (read-only; same target as text-to-sql / agentic-rag sql_tool)
+      - PUBLIC_CH_HOST=${PUBLIC_CH_HOST:-sql-clickhouse.clickhouse.com}
+      - PUBLIC_CH_USER=${PUBLIC_CH_USER:-demo}
+      - PUBLIC_CH_PASSWORD=${PUBLIC_CH_PASSWORD:-}
+      # Langfuse instrumentation
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
+      - LANGFUSE_HOST=${LANGFUSE_INTERNAL_URL:-http://langfuse-web:3000}
+    profiles:
+      - demo
+    volumes:
+      - ./demos/support-triage-parallel:/app
+
+  # =============================================================================
   # Test Scenarios - Export synthetic conversations for evaluation demos
   # =============================================================================
   # Exports pre-crafted prompt/response pairs that demonstrate evaluation failures:

--- a/evaluators/consensus-margin-guard.ts
+++ b/evaluators/consensus-margin-guard.ts
@@ -1,0 +1,98 @@
+/**
+ * Consensus Margin Guard — code evaluator (live observations)
+ *
+ * Target: the `tally-votes` observation on `support-triage-parallel` traces.
+ * Why code, not LLM-as-a-judge: the vote margin is already a number the app
+ * wrote onto the aggregator's metadata. A deterministic check costs nothing,
+ * never hallucinates, and is demoably different from the `correlated-vote-risk`
+ * LLM judge that reads the *content* of the samples.
+ *
+ * The app writes the full tally onto `tally-votes` metadata
+ * (`{votes: {"sig-a": 3, "sig-b": 1}, invalid, winner, margin, tie_break_used}`),
+ * so this evaluator reads it directly — no need to pull in the N child
+ * observations (an observation-level evaluator cannot do that).
+ *
+ * Scores:
+ *   consensus_margin_ok (BOOLEAN)     — winning margin >= 2 (a comfortable win)
+ *   consensus_margin    (NUMERIC)     — the margin itself, for charting
+ *   consensus_shape     (CATEGORICAL) — unanimous | clear | narrow | tie | none
+ */
+
+type EvaluationContext = {
+  observation: { input: any; output: any; metadata: any };
+  experiment: { itemExpectedOutput: any; itemMetadata: any } | undefined;
+};
+
+type Score = {
+  name: string;
+  value: number | string | boolean;
+  dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN" | "TEXT";
+  comment?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type EvaluationResult = { scores: Score[] };
+
+const MARGIN_THRESHOLD = 2;
+
+function asObject(value: any): Record<string, any> {
+  if (value == null) return {};
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" ? value : {};
+}
+
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const meta = asObject(ctx.observation.metadata);
+  const votes = asObject(meta.votes);
+  const counts = Object.values(votes)
+    .map((v) => Number(v))
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => b - a);
+
+  const top = counts[0] ?? 0;
+  const second = counts[1] ?? 0;
+  // Prefer the app-recorded margin; fall back to computing it from the tally.
+  const margin =
+    typeof meta.margin === "number" ? meta.margin : top - second;
+  const validCount = counts.reduce((a, b) => a + b, 0);
+  const tieBreakUsed = Boolean(meta.tie_break_used);
+
+  let shape: string;
+  if (validCount === 0) shape = "none";
+  else if (tieBreakUsed || (counts.length > 1 && top === second)) shape = "tie";
+  else if (counts.length <= 1 && top === validCount) shape = "unanimous";
+  else if (margin >= MARGIN_THRESHOLD) shape = "clear";
+  else shape = "narrow";
+
+  const ok = margin >= MARGIN_THRESHOLD;
+
+  return {
+    scores: [
+      {
+        name: "consensus_margin_ok",
+        value: ok,
+        dataType: "BOOLEAN",
+        comment: `Winning margin ${margin} (threshold ${MARGIN_THRESHOLD}); shape=${shape}.`,
+      },
+      {
+        name: "consensus_margin",
+        value: margin,
+        dataType: "NUMERIC",
+        comment: `top ${top} vs second ${second} across ${validCount} valid votes.`,
+        metadata: { votes, tie_break_used: tieBreakUsed },
+      },
+      {
+        name: "consensus_shape",
+        value: shape,
+        dataType: "CATEGORICAL",
+        comment: `Vote shape derived from the tally metadata.`,
+      },
+    ],
+  };
+}

--- a/scripts/seed-code-evaluators.sh
+++ b/scripts/seed-code-evaluators.sh
@@ -105,6 +105,12 @@ seed_evaluator "credential-leak-guard" "credential-leak" "event" \
 seed_evaluator "response-structure-check" "structure-clean" "event" \
     '[{"type":"stringOptions","value":["GENERATION"],"column":"type","operator":"any of"},{"type":"stringOptions","value":["text-to-sql","vector-rag"],"column":"traceName","operator":"any of"}]' 0
 
+# Support Triage Parallel (Pattern #3): deterministic margin check on the
+# `tally-votes` aggregator span — reads the vote tally the app writes onto
+# metadata (no need to pull in the N candidate child observations).
+seed_evaluator "consensus-margin-guard" "consensus_margin_ok" "event" \
+    '[{"type":"stringOptions","value":["tally-votes"],"column":"name","operator":"any of"},{"type":"stringOptions","value":["triage-support-ticket"],"column":"traceName","operator":"any of"}]' 0
+
 # ─── Experiment evaluators (target: dataset experiment runs) ────────────────
 
 QUALITY_DS=$(dataset_id "coding-assistant-quality")

--- a/scripts/seed-support-triage-evaluators.sh
+++ b/scripts/seed-support-triage-evaluators.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Provision the INDEPENDENT managed LLM-as-a-Judge for the support-triage-parallel
+# demo — the "who checks the vote-counter" evaluator that complements the
+# deterministic consensus-margin-guard code evaluator (evaluators/consensus-margin-guard.ts).
+#
+# Seeds one judge over the aggregator observation:
+#   correlated-vote-risk  → scores 0–1 the RISK that the winning majority is a
+#   *correlated* failure (all samples share the same wrong table / filter / bad
+#   assumption — "confidently wrong consensus", the pattern's key failure mode).
+#
+# Because the app writes ALL candidates onto the `tally-votes` observation INPUT
+# and the tally onto its METADATA (see demos/support-triage-parallel/sql_voting.py),
+# the judge sees every sample + the vote in one place — an observation-level
+# evaluator otherwise cannot pull in the N candidate child-observations.
+#
+# Mechanism mirrors scripts/seed-agentic-rag-evaluators.sh: Postgres upsert
+# (schema-coupled to the langfuse:3 image). Unlike that script this judge has no
+# stock template, so we CREATE a project-scoped LLM eval_template (prompt +
+# output_schema) reusing the Anthropic connection setup.sh provisions.
+# time_scope=NEW so only NEW traces are scored — regenerate traffic to see it.
+# Idempotent. Self-hosted only (prints UI guidance in cloud mode).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; cd "$SCRIPT_DIR/.."
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+ok(){ echo -e "  ${GREEN}✓${NC} $1"; }; warn(){ echo -e "  ${YELLOW}⚠${NC} $1"; }; fail(){ echo -e "  ${RED}✗${NC} $1"; exit 1; }
+[ -f .env ] && set -a && source .env && set +a
+
+PG="${LANGFUSE_POSTGRES_CONTAINER:-langfuse-postgres}"
+REDIS="${LANGFUSE_REDIS_CONTAINER:-langfuse-redis}"
+EVAL_MODEL="${LANGFUSE_EVAL_MODEL:-claude-haiku-4-5-20251001}"
+
+echo ""
+echo "Provisioning the independent 'correlated-vote-risk' judge for support-triage-parallel..."
+
+if [ "${DEPLOY_MODE:-self-hosted}" = "cloud" ]; then
+  warn "DEPLOY_MODE=cloud — create this observation-level judge in the Langfuse UI:"
+  echo "     Evaluators > New evaluator > Custom > target Observations, filter"
+  echo "       type=SPAN, name any-of [tally-votes], traceName any-of [triage-support-ticket]:"
+  echo "       correlated-vote-risk — prompt scores 0–1 the risk the majority is a correlated"
+  echo "       failure; map {{candidates}}<-input.candidates, {{tally}}<-metadata.votes; score 'correlated-vote-risk'"
+  exit 0
+fi
+
+docker ps --format '{{.Names}}' | grep -q "^${PG}$" || fail "Postgres ${PG} not running (run ./setup.sh first)"
+pg(){ docker exec -i "$PG" sh -c 'psql -v ON_ERROR_STOP=1 -q -t -A -U "$POSTGRES_USER" -d "$POSTGRES_DB"'; }
+
+PID=$(echo "SELECT project_id FROM api_keys WHERE public_key='${LANGFUSE_PUBLIC_KEY:-pk-lf-1234567890}' LIMIT 1;" | pg)
+PID="${PID:-demo-project}"; ok "Project: ${PID}"
+
+# ── Default eval model (reuse the Anthropic connection setup.sh provisions) ──
+LLM_KEY_ID=$(echo "SELECT id FROM llm_api_keys WHERE project_id='${PID}' AND adapter='anthropic' LIMIT 1;" | pg)
+if [ -z "$LLM_KEY_ID" ]; then
+  warn "No Anthropic LLM connection — run ./setup.sh first; the judge stays blocked until a default eval model exists"
+fi
+if [ "$(echo "SELECT count(*) FROM default_llm_models WHERE project_id='${PID}';" | pg)" = "0" ] && [ -n "$LLM_KEY_ID" ]; then
+  echo "INSERT INTO default_llm_models (id, project_id, llm_api_key_id, provider, adapter, model, model_params, created_at, updated_at)
+        SELECT 'default-eval-model-${PID}','${PID}','${LLM_KEY_ID}',provider,adapter,'${EVAL_MODEL}','{}'::jsonb,now(),now()
+        FROM llm_api_keys WHERE id='${LLM_KEY_ID}' ON CONFLICT (project_id) DO NOTHING;" | pg >/dev/null
+  ok "Default eval model set (${EVAL_MODEL})"
+else
+  ok "Default eval model already configured (or no Anthropic connection yet)"
+fi
+
+# ── Custom LLM judge template (project-scoped) ───────────────────────────────
+TID="eval-tmpl-correlated-vote-risk"
+JUDGE_PROMPT='You are auditing a best-of-N self-consistency vote. N SQL candidates were sampled for the SAME question and a majority winner was chosen. Voting defends against random per-sample error but NOT against correlated error: if every sample shares the same wrong table, wrong filter, or bad assumption, they will confidently agree on a wrong answer.
+
+Question and candidates (with the vote tally) are below.
+
+Candidates:
+{{candidates}}
+
+Vote tally:
+{{tally}}
+
+Score the RISK that the winning majority is a CORRELATED failure (a confidently-wrong consensus), from 0.0 (independent, well-diversified, trustworthy majority) to 1.0 (all samples share the same suspicious table/filter/assumption — do not trust the vote). Explain which shared pattern drove the score.'
+OUTPUT_SCHEMA='{"score":"A float from 0.0 (trustworthy majority) to 1.0 (likely correlated failure)","reasoning":"One or two sentences naming the shared pattern (or its absence)."}'
+
+# type is left to its default (NULL = LLM judge); CODE templates set type='CODE'.
+echo "INSERT INTO eval_templates (id, project_id, name, version, prompt, provider, model, model_params, vars, output_schema, created_at, updated_at)
+      SELECT '${TID}','${PID}','correlated-vote-risk',1,\$LFJUDGE\$${JUDGE_PROMPT}\$LFJUDGE\$,
+             adapter,'${EVAL_MODEL}','{}'::jsonb,ARRAY['candidates','tally'],
+             '${OUTPUT_SCHEMA}'::jsonb,now(),now()
+      FROM llm_api_keys WHERE project_id='${PID}' AND adapter='anthropic' LIMIT 1
+      ON CONFLICT (project_id, name, version) DO UPDATE SET prompt=EXCLUDED.prompt, output_schema=EXCLUDED.output_schema, vars=EXCLUDED.vars, model=EXCLUDED.model, updated_at=now();" | pg >/dev/null
+ok "eval_template 'correlated-vote-risk' created"
+
+# ── Job configuration: score the tally-votes aggregator span ─────────────────
+FILTER='[{"type":"stringOptions","value":["SPAN"],"column":"type","operator":"any of"},{"type":"stringOptions","value":["tally-votes"],"column":"name","operator":"any of"},{"type":"stringOptions","value":["triage-support-ticket"],"column":"traceName","operator":"any of"}]'
+MAPPING='[{"templateVariable":"candidates","langfuseObject":"event","selectedColumnId":"input","jsonSelector":"candidates"},{"templateVariable":"tally","langfuseObject":"event","selectedColumnId":"metadata","jsonSelector":"votes"}]'
+
+echo "INSERT INTO job_configurations (id, project_id, job_type, eval_template_id, score_name, filter, target_object, variable_mapping, sampling, delay, status, time_scope, created_at, updated_at)
+      VALUES ('job-correlated-vote-risk','${PID}','EVAL','${TID}','correlated-vote-risk','${FILTER}'::jsonb,'event','${MAPPING}'::jsonb,1.0,0,'ACTIVE',ARRAY['NEW'],now(),now())
+      ON CONFLICT (id) DO UPDATE SET eval_template_id=EXCLUDED.eval_template_id, filter=EXCLUDED.filter, variable_mapping=EXCLUDED.variable_mapping, score_name=EXCLUDED.score_name, status='ACTIVE', blocked_at=NULL, block_reason=NULL, block_message=NULL, updated_at=now();" | pg >/dev/null
+ok "correlated-vote-risk → observation-level judge on tally-votes"
+
+# Clear the worker's "no evaluators" cache so the new config picks up traffic now.
+if docker ps --format '{{.Names}}' | grep -q "^${REDIS}$"; then
+  docker exec "$REDIS" redis-cli del \
+    "langfuse:eval:no-event-and-experiment-job-configs:${PID}" \
+    "langfuse:eval:no-trace-and-dataset-job-configs:${PID}" >/dev/null 2>&1 || true
+  ok "Cleared evaluator config cache"
+fi
+
+echo ""
+ok "Independent judge seeded (time_scope=NEW). Regenerate triage traffic, then compare:"
+echo "     deterministic (code)   consensus_margin_ok   (evaluators/consensus-margin-guard.ts)"
+echo "     independent  (LLM)     correlated-vote-risk  (this script)"
+echo "  View: ${LANGFUSE_BASE_URL:-http://localhost:3001}/project/${PID}/evals"
+echo ""


### PR DESCRIPTION
## What this adds

A new container demo `demos/support-triage-parallel/` that demonstrates **Pattern #3 (parallelization)** — both Anthropic sub-variants in one Langfuse trace:

- **Sectioning** (`analyze-sections`): a ClickHouse support ticket fans out into **4 concurrent Haiku branches** — summary, sentiment/urgency, technical category, and a typed `guardrail` policy/PII screen — via `asyncio.gather`, then a Sonnet meta-agent synthesizes a triage brief. Tolerates N-1 branches.
- **Voting** (`vote-sql`): the ticket's embedded data question is answered by **N=5 SQL samples at T=0.9**, each `EXPLAIN`-validated against `sql.clickhouse.com`, then **majority-voted on result-set signatures** (ClickHouse executes the candidates and the rows are hashed — semantic equivalence decided by the database, not string match). An **Opus tie-break judge** fires only when the vote splits.

## How the pattern is made visible in Langfuse

- **Sibling branch observations under one parent** created concurrently → the Timeline shows temporal overlap (parallel) vs a staircase (`--sequential`). Low-cardinality names (`vote-candidate` ×5, `sample_index` in metadata).
- The **`tally-votes` aggregator's metadata is the literal vote tally** (`votes`, `invalid`, `winner`, `margin`, `tie_break_used`); its **input holds every candidate** (so an observation-level judge can score the whole vote).
- **Scores**: `consensus_confidence` (trace), `sql_validity_rate` (validate span), `policy_flagged` (guard span, BOOLEAN).
- **Partial-failure**: `FAULT=slow-branch` drops one branch (`level=WARNING`), aggregator records `failed_branches`/`degraded`, brief says "insufficient data", trace tagged `fault:slow-branch`.
- **3 aggregation strategies** (`result-signature` / `majority-exact` / `judge-consensus`) compared head-to-head in an Experiment with a run-level `voting_accuracy_rate` and a `--ci` gate.
- **Deploy node**: 7 managed prompts by `label=production` with local fallbacks (SQL voter ships v1 + v2). Independent evals: `consensus-margin-guard.ts` (6th deterministic code evaluator) + `correlated-vote-risk` managed LLM judge.

## File tree added

```
demos/support-triage-parallel/
├── README.md · DEMO_SCRIPT.md · Dockerfile · requirements.txt · pytest.ini
├── main.py                 # batch + --interactive + --sequential + --ticket; one trace per ticket; FAULT env
├── langfuse_config.py      # v3 wiring: is_langfuse_enabled(), typed observe() ctx mgr, scores, managed prompts, flush()
├── llm.py                  # raw Anthropic async/sync call layer (updates the generation with usage/cost)
├── triage_pipeline.py      # Stage 1: sectioning fan-out + synthesis aggregator + fault injection
├── sql_voting.py           # Stage 2: voting fan-out + tally + tie-break; 3 pluggable strategies
├── ch_validator.py         # EXPLAIN validation + read-only LIMIT-enforced execution vs the playground
├── tickets.py              # 10 deterministic synthetic tickets (designed demo moments)
├── scripts/                # seed_prompts.py · seed_datasets.py · run_experiment.py · seed_all.py
└── tests/                  # test_vote_tally.py · test_aggregator.py (pure code, no LLM/network)
```

Root-level additions/edits (minimal, additive):
- `evaluators/consensus-margin-guard.ts` (6th code evaluator) + a `seed_evaluator` line in `scripts/seed-code-evaluators.sh`
- `scripts/seed-support-triage-evaluators.sh` (managed `correlated-vote-risk` judge, mirrors `seed-agentic-rag-evaluators.sh`)
- `docker-compose.yaml` service (`demo` profile, port 8008), `.env.example`, `demos/README.md` row, `AI_ENGINEERING_LOOP.md` mapping

## Notes / small deviations from the spec

- Added `llm.py` (a thin raw-Anthropic async/sync call layer, mirroring `demos/real-estate/agent/llm.py`) and `pytest.ini` + `scripts/__init__.py` — small wiring helpers not itemized in the spec's tree. All third-party imports (anthropic, clickhouse-connect, sqlglot) are **lazy** so the pure-logic modules and tests import offline.
- Datasets: SQL-voting result signatures are pinned by executing reference queries against the live playground **at seed time**; items whose reference query is unreachable are seeded with `result_signature=None` and skipped by the experiment (graceful).
- `seed-support-triage-evaluators.sh` creates a project-scoped custom LLM eval template (no stock template exists for this judge); it is schema-coupled to the `langfuse:3` image like the agentic-rag evaluator seed.

## Test plan

Validated **without** starting the shared stack (no `docker compose up` / `setup.sh`):

- `python -m py_compile` on every new `.py` (all 14 modules + scripts + tests) — clean.
- `python -m pytest` in the demo dir — **12 passed** (pure `compute_tally` math: majority / 2-2-1 tie / all-invalid / N-1 degradation / margin; and `build_synthesis_input` degradation).
- `python scripts/run_experiment.py --local-aggregator` — **4/4** aggregator cases pass offline (CI target).
- Offline end-to-end orchestration check (Langfuse disabled, LLM + ClickHouse mocked): `triage_ticket` runs parallel **and** `--sequential`, 4 branches synthesize, 5 samples validate and vote 5-0 → `consensus_confidence=1.0`, no tie-break.
- No-op-without-Langfuse-keys path, `ch_validator` SELECT-only/LIMIT guards, `strip_sql`, and the 10-ticket corpus smoke-checked.
- `docker compose config` YAML parse for the new service; `bash -n` on both shell scripts.
- Confirmed the installed Langfuse SDK accepts `as_type="guardrail"` and the generation kwargs (`model`, `usage_details`, `prompt`) used here.

Not run (per task constraints / no live services): `docker build`, live Langfuse ingestion, live playground execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
