### PR TITLE
demos: add query-router front door + text-to-sql/vector-rag HTTP wrappers (Pattern 2 — routing)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,12 @@ LANGFUSE_PORT=3001
 DASHBOARD_PORT=8005
 AGENTIC_RAG_PORT=8006
 MCP_RAG_RETRIEVER_PORT=8007
+QUERY_ROUTER_PORT=8008
+# Query Router demo (front-door classification-dispatch — Pattern 2: Routing)
+ROUTER_MODEL=claude-haiku-4-5
+ROUTER_CONFIDENCE_THRESHOLD=0.70
+# Leave empty; set ROUTER_FAULT=sql-blindness to demo the seeded misroute (Act 3).
+ROUTER_FAULT=
 # LiteLLM gateway demo
 LITELLM_PORT=4000
 LITELLM_MASTER_KEY=sk-litellm-demo

--- a/AI_ENGINEERING_LOOP.md
+++ b/AI_ENGINEERING_LOOP.md
@@ -31,6 +31,7 @@ it across the whole stack.
 | `demos/text-to-sql/` | NL → SQL over ClickHouse via MCP | LangChain + Langfuse `CallbackHandler` |
 | `demos/vector-rag/` | RAG over ChromaDB | LangChain + Langfuse `CallbackHandler` |
 | `demos/agentic-rag/` | Self-correcting RAG on ClickHouse-native vectors | LangGraph + Langfuse SDK |
+| `demos/query-router/` | Front-door classification-dispatch over the other demos (Pattern 2: Routing) — the cleanest full-loop story after real-estate, at a fraction of the size | raw Anthropic SDK + `httpx` + Langfuse SDK |
 | `librechat/` | Shared chat frontend | LibreChat native Langfuse tracing |
 | `demos/real-estate/` | Self-contained agentic concierge — the loop shown end-to-end in one place | Langfuse SDK |
 | `demos/brand-promo-multi-agent/` | Multi-agent promo-planning assistant (standalone): synthetic history, online + offline evals, persona dashboards | LangGraph + CrewAI + Langfuse `CallbackHandler` |
@@ -45,6 +46,29 @@ it across the whole stack.
 | 4 | **Experiment** | `scripts/run-experiments.py` — compare **models / datasets** on the eval sets | **prompt-variant** experiments: `demos/real-estate/` + `agentic-rag` |
 | 5 | **Evaluate** | Deterministic **code evaluators** (`evaluators/*.ts`, seeded by `scripts/seed-code-evaluators.sh`) + **LLM-as-a-Judge** (`scripts/seed-llm-judge-evaluators.sh`) | human **annotation** queue in `demos/real-estate/` |
 | ⟳ | **Deploy** | **Prompt management by label** — apps fetch prompts from Langfuse at runtime with a local fallback: `agentic-rag` (`scripts/seed-langfuse-prompt.py`), `text-to-sql` + `vector-rag` (`scripts/seed-app-prompts.py`). Promote a label to ship a prompt with no redeploy. | **GitHub CI/CD** reference for gated prompt deploys in `demos/real-estate/cicd/` |
+
+### `demos/query-router/` closes the whole loop on the cheapest surface (Pattern 2: Routing)
+
+The front-door router is a one-LLM-call classifier, so it demonstrates every
+loop step at a fraction of a full agent's size:
+
+1. **Trace** — the router decision is its own `route-query` **generation**
+   (`{route, confidence, rationale}`, `metadata.route`, prompt-linked) under a
+   stable `route-and-dispatch` trace, with exactly one handler's full subtree
+   nested beneath it (SDK v3 distributed tracing across services).
+2. **Monitor** — a **Router Ops** dashboard: route-distribution-over-time
+   (drift), fallback rate, avg `router_confidence`, misroute rate — seeded with
+   14 days of history by `scripts/seed-router-history.py`.
+3. **Datasets** — `query-router-accuracy` (`scripts/seed-router-dataset.py`);
+   production misroutes pinned via `source_observation_id` on the `route-query`
+   generation.
+4. **Experiment** — `scripts/run-router-experiment.py` varies ONLY the router
+   prompt label/model, scoring `route-match` + run-level `avg_route_accuracy`
+   (`--ci` gate).
+5. **Evaluate** — deterministic `evaluators/route-match.ts` (code) +
+   categorical `route-plausibility` LLM judge (`scripts/seed-router-judge.sh`);
+   misroutes recorded as post-hoc **scores** (`routing_correct`), never
+   retroactive tags. **Deploy** = promote the router prompt's `production` label.
 
 ## The Deploy node across the stack
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,6 +1,6 @@
 # Demos
 
-Seven independently runnable demos, each building on the same ClickHouse-backed
+Eight independently runnable demos, each building on the same ClickHouse-backed
 Langfuse stack. The container demos share the platform at the repo root
 (`docker-compose.yaml`, `setup.sh`, `scripts/`, `evaluators/`, `mcp-*/`); the
 standalone demos bring their own toolchain. For how they map to the AI
@@ -11,14 +11,17 @@ Engineering loop, see [`../AI_ENGINEERING_LOOP.md`](../AI_ENGINEERING_LOOP.md).
 | **[text-to-sql](text-to-sql/)** | NL → SQL over ClickHouse via MCP (LangChain) | Trace · Deploy (managed prompts) | `docker compose --profile demo run --rm text-to-sql python main.py` · client script: [`DEMO_SCRIPT.md`](text-to-sql/DEMO_SCRIPT.md) |
 | **[vector-rag](vector-rag/)** | RAG over ChromaDB (LangChain) | Trace · Evaluate · Deploy | `docker compose --profile demo run --rm vector-rag python main.py` · client script: [`DEMO_SCRIPT.md`](vector-rag/DEMO_SCRIPT.md) |
 | **[agentic-rag](agentic-rag/)** | Self-correcting RAG on ClickHouse-native vectors (LangGraph) | Trace · Experiment · Deploy | see [`DEMO_SCRIPT.md`](agentic-rag/DEMO_SCRIPT.md) (client script) or [`../docs/AGENTIC_RAG_DEMO_RUNBOOK.md`](../docs/AGENTIC_RAG_DEMO_RUNBOOK.md) (deep reference) |
+| **[query-router](query-router/)** | Front-door classification-dispatch over the other demos (confidence gate, fallback, HITL escalation, router-accuracy evals) — Pattern 2: Routing | Trace · Monitor · Datasets · Experiment · Evaluate | `docker compose --profile demo run --rm query-router python main.py` · client script: [`DEMO_SCRIPT.md`](query-router/DEMO_SCRIPT.md) |
 | **[litellm-gateway](litellm-gateway/)** | LiteLLM AI gateway with centralized Langfuse OTLP tracing | Trace · Gateway | `./demos/litellm-gateway/run_demo.sh` · client script: [`DEMO_SCRIPT.md`](litellm-gateway/DEMO_SCRIPT.md) |
 | **[real-estate](real-estate/)** | Self-contained agentic concierge — the whole loop end-to-end in one place | ALL 5 + Deploy | `cd demos/real-estate && ./run_demo.sh` then `./run_portal.sh` · client script: [`DEMO_SCRIPT.md`](real-estate/DEMO_SCRIPT.md) |
 | **[brand-promo-multi-agent](brand-promo-multi-agent/)** | Multi-agent promo-planning assistant (LangGraph + CrewAI): synthetic history, online + offline evals, persona dashboards | Trace · Datasets · Experiment · Evaluate · Deploy | see [`DEMO_SCRIPT.md`](brand-promo-multi-agent/DEMO_SCRIPT.md) (client script) or [README](brand-promo-multi-agent/) |
 | **[langfuse-rls](langfuse-rls/)** | Attribute-based row-level-security prototype over Langfuse traces (Next.js): trace governance / access control | Governance (adjacent to the loop) | `cd demos/langfuse-rls && npm install && npm run dev` · client script: [`DEMO_SCRIPT.md`](langfuse-rls/DEMO_SCRIPT.md) |
 
 Each demo has its own README. **text-to-sql**, **vector-rag**, **agentic-rag**,
-and **litellm-gateway** run as containers in the root `docker-compose.yaml`
-(the `demo` profile). LiteLLM can use a dedicated Langfuse project through
+**query-router**, and **litellm-gateway** run as containers in the root
+`docker-compose.yaml` (the `demo` profile). **query-router** is a thin front
+door that dispatches over HTTP to the first three as specialized handlers (which
+is why text-to-sql :8002 and vector-rag :8003 now serve `/query` too). LiteLLM can use a dedicated Langfuse project through
 local `LITELLM_LANGFUSE_*` credentials; see the
 [gateway operations guide](../docs/LITELLM_GATEWAY_DEMO.md). **real-estate**
 (Python, own `.venv` + `.env`),

--- a/demos/agentic-rag/graph.py
+++ b/demos/agentic-rag/graph.py
@@ -283,12 +283,36 @@ class AgenticRAG:
         return g.compile()
 
     # ----------------------------------------------------------------- run
-    def run(self, question: str, session_id: Optional[str] = None) -> dict:
+    def run(self, question: str, session_id: Optional[str] = None,
+            trace_context: Optional[dict] = None) -> dict:
         session_id = session_id or lf.new_session_id()
         handler = lf.get_handler()
         config = {"callbacks": [handler]} if handler else {}
-        with lf.trace_context("agentic-rag", session_id=session_id):
-            final = self.graph.invoke({"question": question}, config=config)
+        if trace_context:
+            # Nested under the query-router front door (:8008): join the router's
+            # trace as an `agentic-rag-handler` agent observation instead of
+            # opening a new `agentic-rag` trace. The router OWNS the trace
+            # name/session, so we must NOT call lf.trace_context() here — that
+            # would overwrite trace-level attributes. Standalone callers (no
+            # trace_context) keep today's behavior exactly, so existing
+            # agentic-rag scripts/judges are unaffected. Note: reflect_node's
+            # lf.score_current_trace("groundedness", ...) then lands on the
+            # router's trace — the E2E groundedness of the routed answer.
+            client = lf.get_client()
+            if client is not None:
+                with client.start_as_current_observation(
+                    as_type="agent", name="agentic-rag-handler",
+                    trace_context=trace_context, input={"question": question},
+                ) as obs:
+                    final = self.graph.invoke({"question": question}, config=config)
+                    if obs:
+                        obs.update(output={"answer": final.get("answer", ""),
+                                           "route": final.get("route")})
+            else:
+                final = self.graph.invoke({"question": question}, config=config)
+        else:
+            with lf.trace_context("agentic-rag", session_id=session_id):
+                final = self.graph.invoke({"question": question}, config=config)
         lf.flush()
         return {
             "question": question,

--- a/demos/agentic-rag/server.py
+++ b/demos/agentic-rag/server.py
@@ -3,9 +3,13 @@ Agentic RAG Demo — FastAPI server.
 
 Endpoints:
     GET  /health         -> liveness + ClickHouse chunk count
-    POST /query          -> {question, session_id?} -> agent result (answer, route, steps)
+    POST /query          -> {question, session_id?, trace_context?} -> agent result (answer, route, steps)
 
-Mirrors the other demo APIs (text-to-sql :8002, vector-rag :8003); runs on :8006.
+Mirrors the other demo APIs — text-to-sql :8002 and vector-rag :8003 now serve
+`/query` too — and is dispatched to by the :8008 query-router front door. Runs
+on :8006. When `trace_context` is provided (by the router), the agent nests its
+whole subtree under the router's trace instead of opening its own (see
+graph.py::run); omit it for today's standalone behavior.
 """
 
 from typing import Optional
@@ -32,6 +36,7 @@ def _get_agent():
 class QueryRequest(BaseModel):
     question: str
     session_id: Optional[str] = None
+    trace_context: Optional[dict] = None  # {"trace_id","parent_span_id"} from the router front door
 
 
 @app.get("/health")
@@ -45,7 +50,7 @@ def health():
 
 @app.post("/query")
 def query(req: QueryRequest):
-    return _get_agent().run(req.question, session_id=req.session_id)
+    return _get_agent().run(req.question, session_id=req.session_id, trace_context=req.trace_context)
 
 
 if __name__ == "__main__":

--- a/demos/query-router/DEMO_SCRIPT.md
+++ b/demos/query-router/DEMO_SCRIPT.md
@@ -1,0 +1,235 @@
+# Query Router — client demo script
+
+**Pattern:** Routing / classification-dispatch (Anthropic's "Building Effective
+Agents" #2). **Runtime:** ~15 min full; short path is Acts 1–2 (~6 min).
+
+> The marquee decision this demo lands: **the router's choice is a first-class,
+> scorable object** — its route, its confidence, whether it misrouted, and
+> whether a better prompt/model would route more accurately. Not a log line.
+
+This is written as a **conversation, not a walkthrough**. Every act has four
+beats: **Frame** (the problem in the customer's world), **Show** (the thing on
+screen), **Land** (the one sentence that sticks), **Ask** (a question that makes
+them talk about their stack). Skip acts freely; the honesty notes at the bottom
+are load-bearing — read them before you present.
+
+---
+
+## 0 · Pre-flight (do this before the customer joins)
+
+```bash
+# Footgun: a shell with stale Langfuse keys exported makes trace export 401.
+unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY
+
+# Router dispatches over HTTP, so the three handlers must be up too:
+docker compose --profile langfuse --profile demo up -d   # query-router + text-to-sql + vector-rag + agentic-rag
+# One-time: build the agentic-rag vector index if you haven't:
+#   docker compose --profile demo run --rm agentic-rag python ingest.py
+
+# Seed the loop artifacts (idempotent):
+python scripts/seed-router-prompt.py      # query-router-classifier v1 (baseline) + v2 (production)
+python scripts/seed-router-dataset.py     # query-router-accuracy (~30 items)
+python scripts/seed-router-history.py     # 14 days of backdated router traces (for the dashboard)
+./scripts/seed-router-judge.sh            # categorical route-plausibility judge (sampling 0.25)
+./scripts/seed-code-evaluators.sh         # registers evaluators/route-match.ts on the router dataset
+
+# Sanity check the front door + handler reachability:
+curl -s localhost:8008/health | python3 -m json.tool
+```
+
+Build the **Router Ops** dashboard once (see Act 4 for the four widgets — ~5 min
+of clicks). Open three tabs: Langfuse **Traces** filtered `name = route-and-dispatch`,
+the **Router Ops** dashboard, and **Prompts** (`query-router-classifier`).
+
+**What each act proves**
+
+| Act | Proves |
+|---|---|
+| 1 | The router decision is a scorable observation; the chosen specialist's full trace nests beneath it |
+| 2 | The fallback + HITL path is what separates a routing *pattern* from an `if` statement |
+| 3 | Silent misclassification is the signature failure mode — and it's captured as a **score, not a tag** |
+| 4 | Route drift and misroute rate are only visible in aggregate — ClickHouse makes that query instant |
+| 5 | You can fix the router, prove it, and ship it by moving a label — the whole loop on one LLM call |
+
+---
+
+## Act 1 — One question, one specialist (the clean route)
+
+**Frame.** "One prompt tuned for everything is tuned for nothing. Teams end up
+with a mega-prompt that's mediocre at SQL, mediocre at docs, mediocre at
+everything. Routing lets each handler stay narrow — and the *only* new risk is
+the router being wrong, which is exactly what we're going to make observable."
+
+**Show.**
+```bash
+docker compose --profile demo run --rm query-router python main.py
+```
+Open a `docs_complex` trace (`name = route-and-dispatch`). Point at:
+- the **`route-query` generation** — output `{route, confidence, rationale}`,
+  `metadata.route` set, **prompt-linked** to `query-router-classifier`, with a
+  `router_confidence` score right on it;
+- and *beneath it*, the **entire agentic-rag subtree** — `route → retrieve →
+  grade → generate → reflect`, with its own `retrieval_relevance` /
+  `groundedness` scores — nested into this one trace across two services.
+
+Then open an `analytics_sql` trace: same front door, a totally different
+specialist (text-to-sql's 2-stage chain + MCP catalog).
+
+**Land.** "The router decision is a first-class, scorable object — and the trace
+proves *which* specialist ran and *why*."
+
+**Ask.** "Where in your stack does a classifier decide something today with no
+trace of why it chose what it chose?"
+
+---
+
+## Act 2 — The ambiguous question (threshold → fallback → HITL)
+
+**Frame.** "The interesting question isn't the clean one. It's: what does the
+system do when the classifier *isn't sure*?"
+
+**Show.** Interactive mode:
+```bash
+docker compose --profile demo run --rm query-router python main.py --interactive
+```
+- Ask **"Is ClickHouse fast?"** → confidence ~0.55 < 0.70 → a `fallback-handler`
+  answer *with a caveat* + an `escalate-to-human` event carrying
+  `reason = low_confidence`.
+- Now stop the vector-rag container and route a `docs_simple` question:
+  ```bash
+  docker compose stop vector-rag
+  ```
+  → the same graceful path, this time `reason = handler_unreachable` (a HTTP 5xx
+  from a specialist becomes a fallback, **not** a 500 to the user). Restart it
+  after: `docker compose start vector-rag`.
+
+**Land.** "The fallback route + the machine-readable escalation reason are what
+separate a routing *pattern* from an if-statement."
+
+**Ask.** "When your classifier is unsure today — does it guess, or does it have
+somewhere safe to send the request?"
+
+---
+
+## Act 3 — The seeded misroute (post-hoc SCORE, not a tag)
+
+**Frame.** "The dangerous failure isn't the error — it's the confident wrong
+answer. A misroute sends a live-numbers question to the docs handler, which
+answers *plausibly* from the wrong corpus. No exception. *Silent
+misclassification.*"
+
+**Show.** Restart the router with the seeded fault and ask the taxi-count
+question:
+```bash
+ROUTER_FAULT=sql-blindness docker compose --profile demo run --rm -e ROUTER_FAULT query-router \
+  python main.py --interactive
+# Ask: "How many taxi rides were there in NYC in July 2015?"
+```
+→ confidently routed `docs_simple`, a plausible-but-wrong docs answer. Fix it on
+camera as a **post-hoc score**:
+```bash
+docker compose --profile demo run --rm query-router \
+  python scripts/score_misroute.py <trace_id> <route_query_observation_id> --expected analytics_sql
+```
+Say the line: **"Tags are immutable at creation — an after-the-fact judgment is a
+*score*."** `routing_correct = 0` (BOOLEAN) now sits on the `route-query`
+observation. Then pin the case into the dataset (UI: Observations → filter
+`name = route-query`, sort by `router_confidence` ascending → **Actions → Add to
+dataset**, or `score_misroute.py … --add-to-dataset --question "…"`).
+
+**Land.** "Production misroutes become tomorrow's regression tests — pinned to
+the exact router decision that was wrong."
+
+**Ask.** "How would someone on your team even *notice* a confident misroute
+today, let alone turn it into a test?"
+
+---
+
+## Act 4 — Router Ops dashboard (drift + misroute rate)
+
+**Frame.** "Per-trace, everything looks fine. The failures of routing —
+*drift* and *silent misroutes* — only show up in aggregate."
+
+**Show.** The **Router Ops** dashboard over the seeded 14 days:
+
+| Widget | View / measure | Dimension / filter | Watches |
+|---|---|---|---|
+| Route distribution over time | observations · count | `metadata.route`, filter `name=route-query`, daily | **route drift** |
+| Fallback rate | observations · count | filter `metadata.fallback_triggered=true` vs total | threshold too tight / taxonomy gaps |
+| Avg `router_confidence` | scores (numeric) · avg | score `router_confidence`, daily | classifier degradation before misroutes surface |
+| Misroute rate | scores · avg of `routing_correct` | daily | **silent misclassification** |
+
+Point at the `analytics_sql` **share doubling in week 2** (drift you'd never see
+per-trace) and the misroute cluster. Note the WARNING thresholds:
+`avg(routing_correct) < 0.90` or fallback rate `> 15%`. The headless polling hook
+behind each widget is the Metrics API:
+
+```bash
+curl -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" -G \
+  --data-urlencode 'query={
+    "view": "observations",
+    "metrics": [{"measure": "count", "aggregation": "count"}],
+    "dimensions": [{"field": "metadata.route"}],
+    "filters": [{"column": "name", "operator": "=", "value": "route-query", "type": "string"}],
+    "timeDimension": {"granularity": "day"},
+    "fromTimestamp": "2026-07-10T00:00:00Z", "toTimestamp": "2026-07-24T00:00:00Z",
+    "config": {"row_limit": 1000}}' \
+  http://localhost:3001/api/public/v2/metrics
+```
+
+**Land.** "This distribution is a query over *every* router decision — it comes
+back instantly because Langfuse aggregates it in ClickHouse."
+
+**Ask.** "Who would own this dashboard in your org — and what's their alert
+threshold for 'the router drifted'?"
+
+---
+
+## Act 5 — Fix the router, prove it, ship it (Experiment → Deploy)
+
+**Frame.** "We found a misroute. Now the loop: change *only* the router, prove
+the change on a dataset, and ship it without touching the handlers."
+
+**Show.**
+```bash
+python scripts/run-router-experiment.py --sample 30
+```
+Three runs, each differing in exactly one axis — prompt `baseline` vs
+`production`, and router model Haiku vs Sonnet — with `avg_route_accuracy`
+side-by-side in the Langfuse experiment view, and per-item `route-match` scores.
+The Act 3 misroute is green under `production`. Promote by moving the
+`production` **label** on `query-router-classifier` — no redeploy. The CI gate is
+the same command:
+```bash
+python scripts/run-router-experiment.py --sample 30 --ci   # exits 1 if avg_route_accuracy < 0.90
+```
+
+**Land.** "That's the entire AI-engineering loop — trace, monitor, dataset,
+experiment, evaluate, deploy — on the cheapest possible surface: a one-call
+classifier."
+
+**Ask.** "If shipping a routing change were one label move behind a passing eval,
+how much faster would your team iterate on it?"
+
+---
+
+## Honesty notes (read before presenting)
+
+- **Handlers answer from different corpora** (live catalog vs docs), so a wrong
+  route sometimes still yields a *passable* answer — that is exactly why
+  misroutes are *silent* and need scores, not exceptions.
+- **`confidence` is model-self-reported**, calibrated only by the prompt (v2's
+  calibration rules). It is a useful gate, not ground truth — the
+  dataset/experiment loop is the real safety net.
+- **Nested groundedness lands on the router's trace.** When agentic-rag runs as a
+  handler, its `reflect_node` calls `score_current_trace("groundedness", …)`,
+  which attaches to the *router's* `route-and-dispatch` trace (the E2E
+  groundedness of the routed answer) — desirable, but don't be surprised to see
+  it there.
+- **Classification-only experiments** (`run-router-experiment.py` default) do not
+  measure end-to-end answer quality — that isolates the router as the only
+  variable and keeps a 30-item run at cents on Haiku. Use `--e2e` to dispatch to
+  the live handlers when you want end-to-end comparison.
+- **The route taxonomy is deliberately distinct** from agentic-rag's internal
+  `kb|sql|direct` — this is the *front-door* router over whole demos, not the
+  in-graph node.

--- a/demos/query-router/Dockerfile
+++ b/demos/query-router/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+# Default: run the FastAPI front door on :8000 (mapped to host :8008).
+# Run the CLI batch demo with:
+#   docker compose --profile demo run --rm query-router python main.py
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/demos/query-router/README.md
+++ b/demos/query-router/README.md
@@ -1,0 +1,90 @@
+# Query Router — front-door classification-dispatch (Pattern 2: Routing)
+
+A thin front door that **classifies** an incoming question and **dispatches** it
+over HTTP to exactly one of three existing demos, each a genuinely specialized
+handler — plus an in-process fallback with confidence-threshold gating and
+human-in-the-loop escalation. Routing is the *star*: the router decision is a
+first-class, scorable Langfuse observation, not a log line.
+
+> **Why a new demo?** Routing already existed *embedded* inside `agentic-rag`
+> (`route_node`) and `brand-promo-multi-agent` (`_classify_intent_node`), but
+> those walkthroughs are about something else. This demo puts the router
+> decision — confidence, misroute scores, a router experiment — on the marquee.
+
+## What it demonstrates
+
+| Capability | How |
+|---|---|
+| Router decision as a scorable object | `route-query` **generation** with `{route, confidence, rationale}` in output + `metadata.route`, prompt-linked to the managed `query-router-classifier`, with a runtime `router_confidence` score |
+| Genuinely specialized handlers | `analytics_sql` → text-to-sql (:8002), `docs_simple` → vector-rag (:8003, the cheap tier), `docs_complex` → agentic-rag (:8006, the expensive self-correcting tier) — different prompts, stacks, tools, cost/quality tiers |
+| Distributed trace nesting | one `route-and-dispatch` trace shows the router decision AND the chosen handler's full existing subtree, joined cross-process via SDK v3 `trace_context` |
+| Confidence gating + fallback | sub-threshold / out-of-scope / malformed / unknown-route / handler-down all divert to a best-effort `fallback-handler` |
+| HITL escalation | an `escalate-to-human` **event** carries a machine-readable `reason` for a triage queue |
+| Misroute curation | misroutes recorded as post-hoc **scores** (`routing_correct`, BOOLEAN) — *not* tags (tags are immutable at creation) |
+| Router-accuracy loop | dedicated `query-router-accuracy` dataset + an experiment that varies **only** the router (prompt label / model), scored by a deterministic code eval + a categorical judge |
+
+## Route taxonomy
+
+| Route | Handler | Specialization the router protects |
+|---|---|---|
+| `analytics_sql` | text-to-sql :8002 | live numbers over ClickHouse public datasets |
+| `docs_simple` | vector-rag :8003 | cheap, fast single-shot doc lookup (low-cost tier) |
+| `docs_complex` | agentic-rag :8006 | multi-part / comparative / verification-worthy questions (expensive tier) |
+| `fallback` | in-process | out-of-scope, low confidence, malformed output, or handler down → best-effort + escalation |
+
+## Who it's for
+
+SAs showing **routing / classification-dispatch** and the *full AI-engineering
+loop* on the cheapest possible surface (a one-call classifier): a customer asking
+"where does a classifier decide something in my stack today, with no trace of
+why?" or "what does your system do when the classifier isn't sure?".
+
+## Quick start
+
+```bash
+# The router dispatches over HTTP, so bring up the handlers too:
+docker compose --profile langfuse --profile demo up -d   # router + 3 handlers
+
+# Seed the loop artifacts (idempotent):
+python scripts/seed-router-prompt.py      # managed router prompt (v1 baseline + v2 production)
+python scripts/seed-router-dataset.py     # query-router-accuracy dataset (~30 items)
+python scripts/seed-router-history.py     # 14 days of backdated history for the dashboard
+./scripts/seed-router-judge.sh            # categorical route-plausibility judge
+./scripts/seed-code-evaluators.sh         # registers evaluators/route-match.ts
+
+# Run the batch demo (10 questions covering every route + edge cases):
+docker compose --profile demo run --rm query-router python main.py
+# or interactive:
+docker compose --profile demo run --rm query-router python main.py --interactive
+
+# Compare router variants (vary ONLY the router):
+python scripts/run-router-experiment.py --sample 30
+```
+
+See [`DEMO_SCRIPT.md`](DEMO_SCRIPT.md) for the presenter runbook.
+
+## Layout
+
+```
+demos/query-router/
+├── router.py            # classify -> {route, confidence, rationale}; gate on confidence
+├── handlers.py          # route registry + HTTP dispatch + in-process fallback + escalation
+├── server.py            # FastAPI /health + /query; run() = classify -> dispatch under one trace
+├── main.py              # CLI batch (DEMO_QUESTIONS) + --interactive
+├── langfuse_config.py   # v3 wiring: observe(), scores, managed prompt, trace_context — no-ops without keys
+├── scripts/score_misroute.py   # record routing_correct as a POST-HOC score (+ pin to dataset)
+├── tests/               # classifier / gating / dispatch / fallback / server unit tests (HTTP stubbed)
+├── Dockerfile · requirements.txt
+└── README.md · DEMO_SCRIPT.md
+```
+
+Related root scripts: `scripts/seed-router-prompt.py`, `scripts/seed-router-dataset.py`,
+`scripts/seed-router-history.py`, `scripts/run-router-experiment.py`,
+`scripts/seed-router-judge.sh`, `evaluators/route-match.ts`.
+
+## Graceful degradation
+
+Everything runs without Langfuse keys (`langfuse_config` no-ops) and without a
+managed prompt (a local fallback prompt ships in `router.py`). If a handler
+container is down, its route degrades to the fallback + escalation instead of
+erroring — by design (see Act 2 of the DEMO_SCRIPT).

--- a/demos/query-router/handlers.py
+++ b/demos/query-router/handlers.py
@@ -1,0 +1,88 @@
+"""Route registry + HTTP dispatch to the existing demo services.
+
+Registry keys MUST match router.ROUTES — drift lands in fallback, visibly.
+Each dispatch passes `trace_context` so the handler's own spans nest under THIS
+trace (Langfuse SDK v3 distributed tracing): the same trace shows the router
+decision AND the specialist's full existing instrumentation.
+"""
+
+import os
+
+import httpx
+
+import langfuse_config as lf
+
+HANDLERS = {
+    "analytics_sql": os.getenv("TEXT_TO_SQL_URL", "http://text-to-sql:8000"),
+    "docs_simple": os.getenv("VECTOR_RAG_URL", "http://vector-rag:8000"),
+    "docs_complex": os.getenv("AGENTIC_RAG_URL", "http://agentic-rag:8000"),
+}
+FALLBACK_MODEL = os.getenv("ROUTER_FALLBACK_MODEL", "claude-haiku-4-5")
+HANDLER_TIMEOUT = float(os.getenv("HANDLER_TIMEOUT", "180"))
+
+
+def _anthropic():
+    """Lazy Anthropic client (unit tests patch this)."""
+    from anthropic import Anthropic
+    return Anthropic()
+
+
+def dispatch(decision: dict, question: str, session_id: str) -> dict:
+    """Route to exactly one specialist handler over HTTP, or the fallback."""
+    route = decision["route"]
+    if route == "fallback":
+        return run_fallback(decision, question)
+
+    base_url = HANDLERS[route]
+    with lf.observe(
+        f"dispatch-{route}", as_type="agent",
+        input={"question": question, "handler": base_url},
+    ) as obs:
+        payload = {"question": question, "session_id": session_id}
+        if obs:  # v3 distributed nesting: handler joins THIS trace under THIS span
+            payload["trace_context"] = {"trace_id": obs.trace_id, "parent_span_id": obs.id}
+        try:
+            r = httpx.post(f"{base_url}/query", json=payload, timeout=HANDLER_TIMEOUT)
+            r.raise_for_status()
+            body = r.json()
+            answer = body.get("answer", body)
+            if obs:
+                obs.update(output={"answer": answer})
+            return {"answer": answer, "handled_by": route}
+        except httpx.HTTPError as e:
+            # Handler down / timeout -> graceful degrade to fallback + escalation,
+            # NOT a 500 (deliberate: the router degrades if a specialist is down).
+            decision = {**decision, "fallback_reason": "handler_unreachable",
+                        "fallback_triggered": True}
+            if obs:
+                obs.update(output={"error": str(e)}, level="ERROR")
+            return run_fallback(decision, question)
+
+
+def run_fallback(decision: dict, question: str) -> dict:
+    """Best-effort answer with an explicit caveat + machine-readable escalation event."""
+    with lf.observe("fallback-handler", as_type="generation",
+                    input={"question": question}) as obs:
+        resp = _anthropic().messages.create(
+            model=FALLBACK_MODEL, max_tokens=600,
+            messages=[{
+                "role": "user",
+                "content": "Answer briefly and note that this question could not be routed "
+                           f"to a specialist.\n\nQuestion: {question}",
+            }],
+        )
+        answer = resp.content[0].text
+        if obs:
+            obs.update(output=answer, metadata={"route": "fallback"})
+
+    # HITL escalation: a point-in-time event carrying a machine-readable reason
+    # (low_confidence | out_of_scope | unknown_route | malformed_output |
+    # handler_unreachable) -> feeds a 'router-triage' annotation queue.
+    with lf.observe("escalate-to-human", as_type="event",
+                    input={"reason": decision.get("fallback_reason"),
+                           "confidence": decision.get("confidence"),
+                           "rationale": decision.get("rationale")}):
+        pass
+
+    return {"answer": answer, "handled_by": "fallback",
+            "escalation_reason": decision.get("fallback_reason")}

--- a/demos/query-router/langfuse_config.py
+++ b/demos/query-router/langfuse_config.py
@@ -1,0 +1,162 @@
+"""
+Langfuse instrumentation for the Query Router demo (v3 SDK).
+
+Adapted from demos/agentic-rag/langfuse_config.py — the front-door router is a
+thin, LangChain-free service (raw `anthropic` SDK + `httpx`), so this module
+drops the LangChain CallbackHandler and keeps only the typed-observation
+helpers the router needs:
+
+  * observe()            — typed observations (generation | agent | event | ...)
+  * score_current_span() — runtime scores on the active observation (router_confidence)
+  * score_current_trace()— trace-level scores (handlers may set these when nested)
+  * get_prompt()         — managed router prompt (Deploy node), local fallback if absent
+  * trace_context()      — sets the stable trace name / session / tags for a run
+  * flush()
+
+Everything is a no-op when Langfuse keys are absent, so the router still runs
+(and still dispatches to the handler services) with tracing disabled.
+"""
+
+import os
+import uuid
+from contextlib import contextmanager
+from typing import Optional
+
+LANGFUSE_ENABLED = bool(
+    os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY")
+)
+
+
+def is_langfuse_enabled() -> bool:
+    return LANGFUSE_ENABLED
+
+
+def get_client():
+    if not LANGFUSE_ENABLED:
+        return None
+    try:
+        from langfuse import get_client as _gc
+        return _gc()
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse client unavailable: {e}")
+        return None
+
+
+def new_session_id() -> str:
+    return f"query-router-{uuid.uuid4().hex[:8]}"
+
+
+@contextmanager
+def trace_context(name: str, session_id: Optional[str] = None, tags=None, user_id=None):
+    """Set trace name / session / tags for everything emitted within the block.
+
+    The router owns the trace: a stable, low-cardinality, verb-first name
+    (`route-and-dispatch`) with the question in the trace input, so filtering
+    and dashboards work. Nested handlers join this trace and must NOT overwrite
+    these attributes (see demos/agentic-rag/graph.py::run trace_context branch).
+    """
+    if not LANGFUSE_ENABLED:
+        yield
+        return
+    try:
+        from langfuse import propagate_attributes
+        with propagate_attributes(
+            trace_name=name,
+            session_id=session_id,
+            user_id=user_id,
+            tags=tags or ["query-router", "demo"],
+        ):
+            yield
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse trace context failed: {e}")
+        yield
+
+
+@contextmanager
+def observe(name: str, as_type: str = "span", input=None):
+    """Create a typed observation (generation | agent | event | retriever | ...).
+
+    Yields the observation handle (or None). Call `.update(output=...)` on it.
+    Using a non-`span`/`generation` type is what triggers Langfuse's agentic
+    graph semantics (e.g. `agent` for the dispatch subtree).
+
+    `as_type="event"` is special-cased: v3's start_as_current_observation does
+    not accept "event", so we emit a point-in-time `create_event` nested under
+    the current span (used for the escalate-to-human HITL signal).
+    """
+    client = get_client()
+    if client is None:
+        yield None
+        return
+    if as_type == "event":
+        try:
+            ev = client.create_event(name=name, input=input)
+            yield ev
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"Langfuse event '{name}' failed: {e}")
+            yield None
+        return
+    try:
+        with client.start_as_current_observation(as_type=as_type, name=name, input=input) as obs:
+            yield obs
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse observation '{name}' failed: {e}")
+        yield None
+
+
+def score_current_trace(name: str, value, comment: Optional[str] = None, data_type="NUMERIC"):
+    """Attach an evaluation score to the active trace."""
+    client = get_client()
+    if client is None:
+        return
+    try:
+        client.score_current_trace(name=name, value=value, comment=comment, data_type=data_type)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse score '{name}' failed: {e}")
+
+
+def score_current_span(name: str, value, comment: Optional[str] = None, data_type="NUMERIC"):
+    """Attach an evaluation score to the active observation/span.
+
+    Used for `router_confidence` — a RUNTIME score (known at execution time),
+    scored on the router's own `route-query` generation so it is chartable and
+    filterable for dataset curation (sort by confidence ascending).
+    """
+    client = get_client()
+    if client is None:
+        return
+    try:
+        client.score_current_span(name=name, value=value, comment=comment, data_type=data_type)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse span score '{name}' failed: {e}")
+
+
+def get_prompt(name: str, label: str = "production"):
+    """Fetch a managed prompt from Langfuse (prompt management / Deploy node).
+
+    Returns the Langfuse prompt object (has .compile(**vars) and links to
+    traces) or None if Langfuse is unavailable / the prompt doesn't exist —
+    callers fall back to a local template so the router always runs.
+    """
+    client = get_client()
+    if client is None:
+        return None
+    try:
+        return client.get_prompt(name, label=label)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse get_prompt('{name}') unavailable, using local fallback: {e}")
+        return None
+
+
+def flush():
+    client = get_client()
+    if client is None:
+        return
+    try:
+        # flush() (non-destructive), NOT shutdown(): get_client() returns a
+        # process-global singleton reused by the FastAPI server across requests,
+        # so shutdown() would drop traces for every subsequent request.
+        if hasattr(client, "flush"):
+            client.flush()
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse flush failed: {e}")

--- a/demos/query-router/main.py
+++ b/demos/query-router/main.py
@@ -1,0 +1,90 @@
+"""
+Query Router Demo — CLI runner.
+
+Usage:
+    docker compose --profile demo run --rm query-router python main.py
+    docker compose --profile demo run --rm query-router python main.py --interactive
+
+Dispatches over HTTP to the text-to-sql / vector-rag / agentic-rag services, so
+those containers must be up (docker compose --profile demo up -d). If one is
+down, its route degrades to the in-process fallback + a HITL escalation event.
+"""
+
+import sys
+
+import langfuse_config as lf
+from server import run
+
+# 10 seeded questions: 2 per real route, 1 out-of-scope, 2 ambiguous, 1 drift stress.
+DEMO_QUESTIONS = [
+    "How many taxi rides were there in NYC in July 2015?",            # analytics_sql
+    "What are the top 5 most-starred GitHub repositories this year?",  # analytics_sql
+    "What is a vector index?",                                         # docs_simple
+    "What does Langfuse's session view show?",                         # docs_simple
+    "Compare ClickHouse-native vector search with Chroma for RAG and when each wins.",  # docs_complex
+    "Walk through how CRAG self-correction reduces hallucinations, with the failure cases.",  # docs_complex
+    "Write me a poem about databases.",                                # out_of_scope -> fallback
+    "Is ClickHouse fast?",                                             # ambiguous (docs vs numbers)
+    "Show me how RAG performs on real data.",                          # ambiguous (mixed intent)
+    "Can you both chart our taxi volume AND explain what a HNSW index is?",  # registry/taxonomy stress
+]
+
+
+def _print_result(res: dict):
+    print(f"\nRoute:       {res.get('route')}")
+    print(f"Confidence:  {res.get('confidence')}")
+    print(f"Handled by:  {res.get('handled_by')}")
+    if res.get("escalation_reason"):
+        print(f"Escalated:   reason={res['escalation_reason']}")
+    answer = res.get("answer", "")
+    if not isinstance(answer, str):
+        answer = str(answer)
+    print(f"\nAnswer:\n{answer[:600]}\n")
+
+
+def run_demo():
+    print("\n" + "=" * 64)
+    print("Query Router Demo  (front-door classify -> dispatch over HTTP)")
+    if lf.is_langfuse_enabled():
+        print("+ Langfuse tracing enabled (route-query generation + nested handler subtree)")
+    print("=" * 64)
+    session = lf.new_session_id()
+    for i, q in enumerate(DEMO_QUESTIONS, 1):
+        print(f"\n[{i}/{len(DEMO_QUESTIONS)}] {q}")
+        print("-" * 56)
+        try:
+            _print_result(run(q, session_id=session))
+        except Exception as e:
+            print(f"Error: {e}")
+    print("=" * 64)
+    if lf.is_langfuse_enabled():
+        print("View traces (name=route-and-dispatch): http://localhost:3001 (Langfuse → Traces)")
+    print("=" * 64 + "\n")
+
+
+def run_interactive():
+    print("\nInteractive Query Router — type 'quit' to exit\n")
+    session = lf.new_session_id()
+    while True:
+        try:
+            q = input("Question: ").strip()
+            if q.lower() in ("quit", "exit", "q"):
+                break
+            if not q:
+                continue
+            _print_result(run(q, session_id=session))
+        except KeyboardInterrupt:
+            break
+        except Exception as e:
+            print(f"Error: {e}\n")
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--interactive":
+        run_interactive()
+    else:
+        run_demo()
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/query-router/pytest.ini
+++ b/demos/query-router/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -q

--- a/demos/query-router/requirements-dev.txt
+++ b/demos/query-router/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Test-only dependencies (not installed in the production image).
+# Run:  docker compose --profile demo run --rm query-router \
+#         sh -c "pip install -q -r requirements-dev.txt && pytest -q"
+-r requirements.txt
+pytest>=8.0.0,<9.0.0

--- a/demos/query-router/requirements.txt
+++ b/demos/query-router/requirements.txt
@@ -1,0 +1,12 @@
+# Thin by design: raw Anthropic SDK (no LangChain) + httpx for HTTP dispatch.
+anthropic>=0.40.0,<1.0.0
+httpx>=0.27.0,<1.0.0
+
+# API server (front door)
+fastapi>=0.115.0,<1.0.0
+uvicorn>=0.30.0,<1.0.0
+
+# Langfuse - LLM observability (typed observations, managed prompts, scores)
+langfuse>=3.0.0,<4.0.0
+
+python-dotenv>=1.0.0,<2.0.0

--- a/demos/query-router/router.py
+++ b/demos/query-router/router.py
@@ -1,0 +1,135 @@
+"""Front-door router: classify a question, gate on confidence, dispatch.
+
+The router decision is its OWN Langfuse generation (name='route-query') with
+{route, confidence, rationale} as output — so it is filterable, chartable,
+dataset-source-able (source_observation_id) and scorable independently of
+whichever handler runs next.
+
+Design notes:
+- {route, confidence} lives in BOTH `output` (human-readable, judge-mappable)
+  and `metadata` (`metadata.route` is the dashboard dimension).
+- `router_confidence` is a RUNTIME score (known at execution time — allowed);
+  `routing_correct` is POST-HOC only (see scripts/score_misroute.py).
+- Registry drift (router emits a label with no registered handler) is handled
+  explicitly -> `fallback` with reason=unknown_route, made visible not crashed.
+- Determinism: routing wants temperature 0.0 (managed prompt config), a
+  deliberate contrast with the demos' default TEMPERATURE=0.7.
+"""
+
+import json
+import os
+
+import langfuse_config as lf
+
+# taxonomy == handler registry keys (see handlers.HANDLERS)
+ROUTES = ("analytics_sql", "docs_simple", "docs_complex")
+CONFIDENCE_THRESHOLD = float(os.getenv("ROUTER_CONFIDENCE_THRESHOLD", "0.70"))
+ROUTER_MODEL = os.getenv("ROUTER_MODEL", "claude-haiku-4-5")  # model tiering: cheap router
+ROUTER_PROMPT_NAME = os.getenv("ROUTER_PROMPT_NAME", "query-router-classifier")
+ROUTER_FAULT = os.getenv("ROUTER_FAULT", "")  # e.g. 'sql-blindness' — seeded misroute for the demo
+ROUTER_TEMPERATURE = float(os.getenv("ROUTER_TEMPERATURE", "0.0"))
+
+# Local fallback prompt so the demo runs without Langfuse (repo convention).
+_FALLBACK_PROMPT = (
+    "You are the front-door router for a data-and-docs assistant. "
+    "Classify the user question into exactly ONE route:\n"
+    "- analytics_sql : needs LIVE numbers from ClickHouse public datasets "
+    "(taxi rides, github stars, stackoverflow, prices, ...)\n"
+    "- docs_simple   : a single factual/definitional question answerable from docs\n"
+    "- docs_complex  : multi-part, comparative, or accuracy-critical doc questions "
+    "that merit retrieval verification\n"
+    "- out_of_scope  : none of the above (small talk, unrelated domains, unsafe asks)\n\n"
+    "Respond ONLY with JSON: "
+    '{"route": "<analytics_sql|docs_simple|docs_complex|out_of_scope>", '
+    '"confidence": <0.0-1.0>, "rationale": "<one sentence>"}\n'
+    "Calibration: confidence reflects P(correct route). Mixed-intent or vague "
+    "questions must score below 0.7.\n\n"
+    "Question: {{question}}"
+)
+
+
+def _anthropic():
+    """Lazy Anthropic client so the module imports without the SDK/keys present
+    (unit tests patch this)."""
+    from anthropic import Anthropic
+    return Anthropic()
+
+
+def classify(question: str, prompt_label: str = "production", model: str = None) -> dict:
+    """One LLM call -> {route, confidence, rationale, fallback_triggered, fallback_reason}.
+
+    `prompt_label` / `model` let the experiment runner vary ONLY the router
+    (scripts/run-router-experiment.py) while keeping taxonomy/threshold/handlers
+    byte-identical; both default to production behaviour.
+    """
+    model = model or ROUTER_MODEL
+    prompt_obj = lf.get_prompt(ROUTER_PROMPT_NAME, label=prompt_label)
+    text = (
+        prompt_obj.compile(question=question)
+        if prompt_obj
+        else _FALLBACK_PROMPT.replace("{{question}}", question)
+    )
+    if ROUTER_FAULT == "sql-blindness":
+        # Deterministic degradation (repo fault convention): blind the router to
+        # the SQL route so analytics questions get confidently misrouted.
+        text = text.replace("analytics_sql", "docs_simple")
+
+    with lf.observe("route-query", as_type="generation", input={"question": question}) as obs:
+        resp = _anthropic().messages.create(
+            model=model,
+            max_tokens=200,
+            temperature=ROUTER_TEMPERATURE,
+            messages=[{"role": "user", "content": text}],
+        )
+        raw = resp.content[0].text.strip()
+        try:
+            decision = json.loads(_strip_fences(raw))
+            route = decision.get("route", "")
+            confidence = float(decision.get("confidence", 0.0))
+            rationale = decision.get("rationale", "")
+            reason = None
+        except (json.JSONDecodeError, TypeError, ValueError):
+            route, confidence, rationale, reason = "fallback", 0.0, raw[:200], "malformed_output"
+
+        if reason is None:
+            if route not in ROUTES:  # includes out_of_scope + registry drift
+                reason = "out_of_scope" if route == "out_of_scope" else "unknown_route"
+                route = "fallback"
+            elif confidence < CONFIDENCE_THRESHOLD:
+                reason, route = "low_confidence", "fallback"
+
+        result = {
+            "route": route,
+            "confidence": confidence,
+            "rationale": rationale,
+            "fallback_triggered": route == "fallback",
+            "fallback_reason": reason,
+        }
+        if obs:
+            obs.update(
+                output={"route": route, "confidence": confidence, "rationale": rationale},
+                metadata={
+                    "route": route,
+                    "threshold": CONFIDENCE_THRESHOLD,
+                    "fallback_triggered": route == "fallback",
+                    "router_model": model,
+                },
+                model=model,
+                prompt=prompt_obj if prompt_obj else None,  # links prompt version -> trace
+            )
+            result["router_observation_id"] = obs.id  # for post-hoc scoring / dataset pinning
+            result["router_trace_id"] = obs.trace_id
+        # Runtime score on the router's own observation -> chartable, filterable.
+        lf.score_current_span(
+            "router_confidence", confidence, comment=f"threshold={CONFIDENCE_THRESHOLD}"
+        )
+    return result
+
+
+def _strip_fences(raw: str) -> str:
+    """Tolerate ```json fenced output from the model before json.loads."""
+    s = raw.strip()
+    if s.startswith("```"):
+        s = s.split("\n", 1)[-1] if "\n" in s else s
+        s = s.replace("```json", "").replace("```", "").strip()
+    return s

--- a/demos/query-router/scripts/score_misroute.py
+++ b/demos/query-router/scripts/score_misroute.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Record a human misroute verdict as a POST-HOC SCORE.
+
+Tags are immutable at creation — after-the-fact judgments belong on scores
+(Langfuse best practice). This attaches `routing_correct` (BOOLEAN) to the
+`route-query` observation, NOT the trace, so the verdict pins to the exact
+router decision that was wrong.
+
+Usage:
+    python scripts/score_misroute.py <trace_id> <router_observation_id> \\
+        --expected analytics_sql [--correct] [--comment "..."]
+
+Optionally also pin the misroute into the router-accuracy dataset (the
+production-misroute -> regression-test loop) with --add-to-dataset:
+    python scripts/score_misroute.py <trace_id> <obs_id> --expected analytics_sql \\
+        --add-to-dataset --question "How many taxi rides in July 2015?" \\
+        --original-route docs_simple
+
+Env: LANGFUSE_HOST/BASE_URL, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY.
+"""
+
+import argparse
+import os
+import sys
+
+try:
+    from langfuse import Langfuse
+except ImportError:
+    print("Error: langfuse not installed. Run: pip install 'langfuse>=3.0,<4.0'", file=sys.stderr)
+    sys.exit(1)
+
+DATASET_NAME = os.getenv("ROUTER_DATASET_NAME", "query-router-accuracy")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Record a post-hoc routing_correct score")
+    ap.add_argument("trace_id")
+    ap.add_argument("observation_id", help="the route-query generation id")
+    ap.add_argument("--expected", required=True, help="the route it SHOULD have taken")
+    ap.add_argument("--correct", action="store_true",
+                    help="record routing_correct=1 (default is 0 = misroute)")
+    ap.add_argument("--comment", default=None)
+    ap.add_argument("--add-to-dataset", action="store_true",
+                    help="also pin this case into the router-accuracy dataset")
+    ap.add_argument("--question", default=None, help="required with --add-to-dataset")
+    ap.add_argument("--original-route", default=None, help="the route actually taken (metadata)")
+    args = ap.parse_args()
+
+    host = os.getenv("LANGFUSE_HOST", os.getenv("LANGFUSE_BASE_URL", "http://localhost:3001"))
+    pk = os.getenv("LANGFUSE_PUBLIC_KEY", "pk-lf-1234567890")
+    sk = os.getenv("LANGFUSE_SECRET_KEY", "sk-lf-1234567890")
+    lf = Langfuse(public_key=pk, secret_key=sk, host=host)
+
+    value = 1 if args.correct else 0
+    lf.create_score(
+        trace_id=args.trace_id,
+        observation_id=args.observation_id,  # pin to the route-query generation, not just the trace
+        name="routing_correct",
+        value=value,
+        data_type="BOOLEAN",
+        comment=args.comment or f"should have routed to {args.expected}",
+    )
+    print(f"routing_correct={value} on observation {args.observation_id} (trace {args.trace_id})")
+
+    if args.add_to_dataset:
+        if not args.question:
+            print("--add-to-dataset requires --question", file=sys.stderr)
+            sys.exit(2)
+        lf.create_dataset_item(
+            dataset_name=DATASET_NAME,
+            input={"question": args.question},
+            expected_output={"route": args.expected},  # human-corrected
+            source_trace_id=args.trace_id,
+            source_observation_id=args.observation_id,  # pins the route-query generation
+            metadata={"source": "production-misroute", "original_route": args.original_route},
+        )
+        print(f"pinned into dataset '{DATASET_NAME}' (source_observation_id={args.observation_id})")
+
+    lf.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/query-router/server.py
+++ b/demos/query-router/server.py
@@ -1,0 +1,65 @@
+"""
+Query Router Demo — FastAPI front door.
+
+Endpoints:
+    GET  /health   -> router liveness + reachability of the 3 handler services + Langfuse status
+    POST /query     -> {question, session_id?} -> {route, confidence, rationale, answer, handled_by, ...}
+
+The router classifies the question (its own `route-query` generation), gates on
+confidence, and dispatches over HTTP to exactly one specialist handler
+(text-to-sql :8002 / vector-rag :8003 / agentic-rag :8006) or an in-process
+fallback. One Langfuse trace `route-and-dispatch` shows the router decision AND
+the chosen handler's full nested subtree. Runs on :8000 (mapped to host :8008).
+"""
+
+import httpx
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Optional
+
+from handlers import HANDLERS, dispatch
+import langfuse_config as lf
+from router import classify
+
+app = FastAPI(title="Query Router Demo", version="1.0.0")
+
+
+class QueryRequest(BaseModel):
+    question: str
+    session_id: Optional[str] = None
+
+
+def run(question: str, session_id: Optional[str] = None) -> dict:
+    """Classify -> gate -> dispatch, all under ONE trace named route-and-dispatch."""
+    session_id = session_id or lf.new_session_id()
+    with lf.trace_context("route-and-dispatch", session_id=session_id):  # verb-first, stable name
+        decision = classify(question)
+        result = dispatch(decision, question, session_id)
+    lf.flush()
+    return {"question": question, **decision, **result, "session_id": session_id}
+
+
+@app.get("/health")
+def health():
+    """Report our own liveness, whether Langfuse tracing is on, and whether each
+    downstream handler answers /health (the router still runs — and degrades to
+    fallback — if a handler is down, so this is informational, not fatal)."""
+    handlers = {}
+    for route, base_url in HANDLERS.items():
+        try:
+            r = httpx.get(f"{base_url}/health", timeout=3.0)
+            handlers[route] = "ok" if r.status_code == 200 else f"http {r.status_code}"
+        except Exception as e:
+            handlers[route] = f"unreachable: {e.__class__.__name__}"
+    return {"status": "ok", "langfuse": lf.is_langfuse_enabled(), "handlers": handlers}
+
+
+@app.post("/query")
+def query(req: QueryRequest):
+    return run(req.question, session_id=req.session_id)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/demos/query-router/server.py
+++ b/demos/query-router/server.py
@@ -30,11 +30,37 @@ class QueryRequest(BaseModel):
 
 
 def run(question: str, session_id: Optional[str] = None) -> dict:
-    """Classify -> gate -> dispatch, all under ONE trace named route-and-dispatch."""
+    """Classify -> gate -> dispatch, all under ONE trace named route-and-dispatch.
+
+    BUG FIX (live-testing finding): `lf.trace_context(...)` (= SDK v3
+    `propagate_attributes`) only sets trace-level attributes on the *currently
+    active span* and cascades them to its children — per the SDK's own
+    docstring, it does not, by itself, make independent top-level
+    `start_as_current_observation()` calls share a trace_id. `classify()` and
+    `dispatch()` each open their OWN top-level observation (`route-query`,
+    `dispatch-{route}`); with no active parent span at the time
+    `propagate_attributes` was entered, each one minted its OWN random
+    trace_id, so the router's decision and the dispatched specialist's subtree
+    landed in TWO DISCONNECTED traces — even before the HTTP call to the
+    handler. The handler-side `trace_context` join then correctly attached the
+    specialist's subtree to `dispatch()`'s (wrong, second) trace, not to
+    `route-query`'s trace — confirmed in ClickHouse: two distinct trace ids for
+    the same request, e.g. `route-query` alone in one trace and
+    `dispatch-analytics_sql` + the full text-to-sql subtree in another.
+
+    Fix: open one real root observation FIRST (`route-and-dispatch`), so
+    `classify()`'s and `dispatch()`'s observations become actual OTEL children
+    of it and inherit its trace_id, instead of independent roots. This matches
+    the SDK's own documented pattern (`start_as_current_span` BEFORE
+    `propagate_attributes`).
+    """
     session_id = session_id or lf.new_session_id()
-    with lf.trace_context("route-and-dispatch", session_id=session_id):  # verb-first, stable name
-        decision = classify(question)
-        result = dispatch(decision, question, session_id)
+    with lf.observe("route-and-dispatch", as_type="span", input={"question": question}) as root:
+        with lf.trace_context("route-and-dispatch", session_id=session_id):  # verb-first, stable name
+            decision = classify(question)
+            result = dispatch(decision, question, session_id)
+        if root:
+            root.update(output={"route": decision.get("route"), "handled_by": result.get("handled_by")})
     lf.flush()
     return {"question": question, **decision, **result, "session_id": session_id}
 

--- a/demos/query-router/tests/conftest.py
+++ b/demos/query-router/tests/conftest.py
@@ -1,0 +1,52 @@
+"""Make the demo modules importable and provide fakes.
+
+These tests run WITHOUT Langfuse keys (langfuse_config no-ops) and WITHOUT any
+live handler services — the Anthropic client and the httpx dispatch are stubbed,
+so nothing hits the network.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the demo package modules (router.py, handlers.py, ...) without a package.
+DEMO_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(DEMO_DIR))
+
+# Ensure Langfuse is disabled for the whole test session (no accidental exports).
+os.environ.pop("LANGFUSE_PUBLIC_KEY", None)
+os.environ.pop("LANGFUSE_SECRET_KEY", None)
+
+
+class _Block:
+    def __init__(self, text):
+        self.text = text
+
+
+class _Msg:
+    def __init__(self, text):
+        self.content = [_Block(text)]
+
+
+class FakeMessages:
+    def __init__(self, text):
+        self._text = text
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return _Msg(self._text)
+
+
+class FakeAnthropic:
+    """Stand-in Anthropic client whose messages.create returns a fixed text."""
+
+    def __init__(self, text):
+        self.messages = FakeMessages(text)
+
+
+@pytest.fixture
+def fake_anthropic():
+    return lambda text: (lambda: FakeAnthropic(text))

--- a/demos/query-router/tests/test_handlers.py
+++ b/demos/query-router/tests/test_handlers.py
@@ -1,0 +1,82 @@
+"""Dispatch + fallback + escalation tests (HTTP + Anthropic stubbed)."""
+
+import httpx
+
+import handlers
+
+
+def _fallback_client():
+    class C:
+        class messages:
+            @staticmethod
+            def create(**kw):
+                return type("M", (), {"content": [type("B", (), {"text": "best-effort answer"})()]})()
+    return C()
+
+
+def test_dispatch_success_routes_to_handler(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        return type("R", (), {"raise_for_status": lambda self: None,
+                              "json": lambda self: {"answer": "42 rides", "session_id": json["session_id"]}})()
+
+    monkeypatch.setattr(handlers.httpx, "post", fake_post)
+    decision = {"route": "analytics_sql", "confidence": 0.95, "rationale": "numbers",
+                "fallback_triggered": False, "fallback_reason": None}
+    res = handlers.dispatch(decision, "how many taxi rides?", "sess-1")
+    assert res["handled_by"] == "analytics_sql"
+    assert res["answer"] == "42 rides"
+    assert captured["url"].endswith("/query")
+    assert captured["payload"]["question"] == "how many taxi rides?"
+    # No trace_context added when Langfuse disabled (obs is None).
+    assert "trace_context" not in captured["payload"]
+
+
+def test_dispatch_handler_unreachable_degrades_to_fallback(monkeypatch):
+    def fake_post(url, json=None, timeout=None):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(handlers.httpx, "post", fake_post)
+    monkeypatch.setattr(handlers, "_anthropic", _fallback_client)
+    decision = {"route": "docs_simple", "confidence": 0.9, "rationale": "docs",
+                "fallback_triggered": False, "fallback_reason": None}
+    res = handlers.dispatch(decision, "what is a vector index?", "sess-2")
+    assert res["handled_by"] == "fallback"
+    assert res["escalation_reason"] == "handler_unreachable"
+    assert res["answer"] == "best-effort answer"
+
+
+def test_dispatch_http_status_error_degrades_to_fallback(monkeypatch):
+    def fake_post(url, json=None, timeout=None):
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("500", request=None, response=None)
+        return type("R", (), {"raise_for_status": raise_for_status, "json": lambda self: {}})()
+
+    monkeypatch.setattr(handlers.httpx, "post", fake_post)
+    monkeypatch.setattr(handlers, "_anthropic", _fallback_client)
+    decision = {"route": "docs_complex", "confidence": 0.9, "rationale": "hard",
+                "fallback_triggered": False, "fallback_reason": None}
+    res = handlers.dispatch(decision, "compare X and Y", "sess-3")
+    assert res["handled_by"] == "fallback"
+    assert res["escalation_reason"] == "handler_unreachable"
+
+
+def test_fallback_route_never_hits_http(monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("dispatch must not call httpx for a fallback decision")
+
+    monkeypatch.setattr(handlers.httpx, "post", boom)
+    monkeypatch.setattr(handlers, "_anthropic", _fallback_client)
+    decision = {"route": "fallback", "confidence": 0.4, "rationale": "vague",
+                "fallback_triggered": True, "fallback_reason": "low_confidence"}
+    res = handlers.dispatch(decision, "is clickhouse fast?", "sess-4")
+    assert res["handled_by"] == "fallback"
+    assert res["escalation_reason"] == "low_confidence"
+
+
+def test_registry_keys_match_router_routes():
+    import router
+    assert tuple(sorted(handlers.HANDLERS.keys())) == tuple(sorted(router.ROUTES))

--- a/demos/query-router/tests/test_router.py
+++ b/demos/query-router/tests/test_router.py
@@ -1,0 +1,117 @@
+"""Classifier + confidence-threshold gating tests (Anthropic call stubbed)."""
+
+import json
+
+import router
+
+
+def _client(text):
+    class C:
+        class messages:
+            @staticmethod
+            def create(**kw):
+                return type("M", (), {"content": [type("B", (), {"text": text})()]})()
+    return C()
+
+
+def test_clear_route_high_confidence(monkeypatch):
+    monkeypatch.setattr(router, "CONFIDENCE_THRESHOLD", 0.70)
+    monkeypatch.setattr(router, "ROUTER_FAULT", "")
+    monkeypatch.setattr(router, "_anthropic",
+                        lambda: _client(json.dumps({"route": "analytics_sql",
+                                                    "confidence": 0.95, "rationale": "live numbers"})))
+    res = router.classify("how many taxi rides in 2015?")
+    assert res["route"] == "analytics_sql"
+    assert res["confidence"] == 0.95
+    assert res["fallback_triggered"] is False
+    assert res["fallback_reason"] is None
+
+
+def test_low_confidence_falls_back(monkeypatch):
+    monkeypatch.setattr(router, "CONFIDENCE_THRESHOLD", 0.70)
+    monkeypatch.setattr(router, "ROUTER_FAULT", "")
+    monkeypatch.setattr(router, "_anthropic",
+                        lambda: _client(json.dumps({"route": "docs_simple",
+                                                    "confidence": 0.55, "rationale": "unsure"})))
+    res = router.classify("is clickhouse fast?")
+    assert res["route"] == "fallback"
+    assert res["fallback_reason"] == "low_confidence"
+    assert res["fallback_triggered"] is True
+
+
+def test_out_of_scope_falls_back(monkeypatch):
+    monkeypatch.setattr(router, "ROUTER_FAULT", "")
+    monkeypatch.setattr(router, "_anthropic",
+                        lambda: _client(json.dumps({"route": "out_of_scope",
+                                                    "confidence": 0.9, "rationale": "poem"})))
+    res = router.classify("write me a poem")
+    assert res["route"] == "fallback"
+    assert res["fallback_reason"] == "out_of_scope"
+
+
+def test_unknown_route_is_registry_drift(monkeypatch):
+    monkeypatch.setattr(router, "ROUTER_FAULT", "")
+    monkeypatch.setattr(router, "_anthropic",
+                        lambda: _client(json.dumps({"route": "billing",
+                                                    "confidence": 0.99, "rationale": "drift"})))
+    res = router.classify("charge dispute")
+    assert res["route"] == "fallback"
+    assert res["fallback_reason"] == "unknown_route"
+
+
+def test_malformed_output_falls_back(monkeypatch):
+    monkeypatch.setattr(router, "ROUTER_FAULT", "")
+    monkeypatch.setattr(router, "_anthropic", lambda: _client("not json at all"))
+    res = router.classify("anything")
+    assert res["route"] == "fallback"
+    assert res["fallback_reason"] == "malformed_output"
+    assert res["confidence"] == 0.0
+
+
+def test_fenced_json_is_tolerated(monkeypatch):
+    monkeypatch.setattr(router, "ROUTER_FAULT", "")
+    fenced = "```json\n" + json.dumps({"route": "docs_complex", "confidence": 0.88,
+                                       "rationale": "comparative"}) + "\n```"
+    monkeypatch.setattr(router, "_anthropic", lambda: _client(fenced))
+    res = router.classify("compare X and Y")
+    assert res["route"] == "docs_complex"
+    assert res["confidence"] == 0.88
+
+
+def test_sql_blindness_fault_rewrites_prompt(monkeypatch):
+    """With ROUTER_FAULT=sql-blindness the analytics route is removed from the
+    prompt; the (stubbed) model then confidently returns docs_simple -> a
+    silent misroute, which is the demo's Act 3 signature failure."""
+    captured = {}
+
+    class C:
+        class messages:
+            @staticmethod
+            def create(**kw):
+                captured["prompt"] = kw["messages"][0]["content"]
+                return type("M", (), {"content": [type("B", (), {"text": json.dumps(
+                    {"route": "docs_simple", "confidence": 0.93, "rationale": "docs"})})()]})()
+
+    monkeypatch.setattr(router, "ROUTER_FAULT", "sql-blindness")
+    monkeypatch.setattr(router, "_anthropic", lambda: C())
+    res = router.classify("how many taxi rides in July 2015?")
+    assert "analytics_sql" not in captured["prompt"]  # route blinded out of the prompt
+    assert res["route"] == "docs_simple"  # confidently wrong
+
+
+def test_model_override_is_used(monkeypatch):
+    """The experiment runner varies model without touching handlers/threshold."""
+    captured = {}
+
+    class C:
+        class messages:
+            @staticmethod
+            def create(**kw):
+                captured["model"] = kw["model"]
+                return type("M", (), {"content": [type("B", (), {"text": json.dumps(
+                    {"route": "docs_simple", "confidence": 0.9, "rationale": "x"})})()]})()
+
+    monkeypatch.setattr(router, "ROUTER_FAULT", "")
+    monkeypatch.setattr(router, "_anthropic", lambda: C())
+    router.classify("what is a vector index?", model="claude-sonnet-4-6")
+    assert captured["model"] == "claude-sonnet-4-6"

--- a/demos/query-router/tests/test_server.py
+++ b/demos/query-router/tests/test_server.py
@@ -1,0 +1,65 @@
+"""FastAPI app construction + run() orchestration (pipeline + HTTP stubbed)."""
+
+from fastapi.testclient import TestClient
+
+import server
+
+
+def test_app_constructs():
+    assert server.app.title == "Query Router Demo"
+
+
+def test_run_merges_decision_and_result(monkeypatch):
+    monkeypatch.setattr(server, "classify", lambda q: {
+        "route": "docs_complex", "confidence": 0.9, "rationale": "comparative",
+        "fallback_triggered": False, "fallback_reason": None,
+        "router_observation_id": "obs-1", "router_trace_id": "tr-1"})
+    monkeypatch.setattr(server, "dispatch",
+                        lambda decision, q, sid: {"answer": "grounded answer", "handled_by": "docs_complex"})
+    out = server.run("compare X and Y", session_id="sess-x")
+    assert out["question"] == "compare X and Y"
+    assert out["route"] == "docs_complex"
+    assert out["handled_by"] == "docs_complex"
+    assert out["answer"] == "grounded answer"
+    assert out["session_id"] == "sess-x"
+    assert out["router_observation_id"] == "obs-1"
+
+
+def test_query_endpoint(monkeypatch):
+    monkeypatch.setattr(server, "classify", lambda q: {
+        "route": "analytics_sql", "confidence": 0.96, "rationale": "numbers",
+        "fallback_triggered": False, "fallback_reason": None})
+    monkeypatch.setattr(server, "dispatch",
+                        lambda decision, q, sid: {"answer": "42", "handled_by": "analytics_sql"})
+    client = TestClient(server.app)
+    r = client.post("/query", json={"question": "how many rides?"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["route"] == "analytics_sql"
+    assert body["handled_by"] == "analytics_sql"
+    assert body["session_id"].startswith("query-router-")
+
+
+def test_health_reports_handlers(monkeypatch):
+    def fake_get(url, timeout=None):
+        return type("R", (), {"status_code": 200})()
+
+    monkeypatch.setattr(server.httpx, "get", fake_get)
+    client = TestClient(server.app)
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert set(body["handlers"].keys()) == {"analytics_sql", "docs_simple", "docs_complex"}
+    assert all(v == "ok" for v in body["handlers"].values())
+
+
+def test_health_handles_unreachable(monkeypatch):
+    def fake_get(url, timeout=None):
+        raise Exception("boom")
+
+    monkeypatch.setattr(server.httpx, "get", fake_get)
+    client = TestClient(server.app)
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert all("unreachable" in v for v in r.json()["handlers"].values())

--- a/demos/text-to-sql/DEMO_SCRIPT.md
+++ b/demos/text-to-sql/DEMO_SCRIPT.md
@@ -23,10 +23,11 @@ live in Langfuse and ship by label, no redeploy.
 > **Honesty note (know this before you present):** the pipeline *reasons over*
 > the dataset catalog and often drafts SQL in its answers, but it does **not
 > execute** queries against ClickHouse — the MCP step retrieves the database
-> catalog as context. There is also **no HTTP endpoint**; port 8002 is mapped but
-> nothing listens. Demo it as what it is: a traced NL-analysis assistant with a
-> SQL-policy guardrail. If asked "does it run the SQL?" — "not in this demo; the
-> guardrail is exactly the layer you'd want *before* you let it."
+> catalog as context. Port 8002 now serves `/query` (a thin `server.py` FastAPI
+> wrapper), so the query-router front-door demo can dispatch to it; the CLI
+> (`python main.py`) is unchanged. Demo it as what it is: a traced NL-analysis
+> assistant with a SQL-policy guardrail. If asked "does it run the SQL?" — "not
+> in this demo; the guardrail is exactly the layer you'd want *before* you let it."
 
 ---
 

--- a/demos/text-to-sql/requirements.txt
+++ b/demos/text-to-sql/requirements.txt
@@ -9,3 +9,7 @@ langfuse>=3.0.0,<4.0.0
 # MCP client & utilities
 httpx>=0.27.0,<1.0.0
 python-dotenv>=1.0.0,<2.0.0
+
+# API server (server.py — makes port 8002 serve /query; CLI mode unchanged)
+fastapi>=0.115.0,<1.0.0
+uvicorn>=0.30.0,<1.0.0

--- a/demos/text-to-sql/server.py
+++ b/demos/text-to-sql/server.py
@@ -1,0 +1,87 @@
+"""
+Text-to-SQL Demo — FastAPI server.
+
+Endpoints:
+    GET  /health   -> liveness + Langfuse status
+    POST /query    -> {question, session_id?, trace_context?} -> {answer, session_id}
+
+Makes the already-mapped port 8002 real (mirrors demos/agentic-rag/server.py and
+demos/vector-rag/server.py; the query-router front door on :8008 dispatches
+here). When called standalone the trace is named `text-to-sql` (today's CLI
+behavior, unchanged); when the router passes `trace_context`, this run nests
+under the router's trace as a `text-to-sql-handler` agent observation
+(Langfuse SDK v3 distributed tracing). The CLI (`python main.py`) is untouched.
+"""
+
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from sql_pipeline import create_pipeline
+from langfuse_config import (
+    get_langfuse_client,
+    get_langfuse_handler,
+    is_langfuse_enabled,
+    langfuse_trace,
+)
+
+app = FastAPI(title="Text-to-SQL Demo", version="1.0.0")
+
+# Lazy singleton so the process starts fast and the pipeline is reused.
+_pipeline_singleton = None
+
+
+def _pipeline():
+    global _pipeline_singleton
+    if _pipeline_singleton is None:
+        _pipeline_singleton = create_pipeline()
+    return _pipeline_singleton
+
+
+class QueryRequest(BaseModel):
+    question: str
+    session_id: Optional[str] = None
+    trace_context: Optional[dict] = None  # {"trace_id","parent_span_id"} from the router
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "langfuse": is_langfuse_enabled()}
+
+
+@app.post("/query")
+def query(req: QueryRequest):
+    handler = get_langfuse_handler()
+    callbacks = [handler] if handler else None
+    client = get_langfuse_client()
+
+    if req.trace_context and client:
+        # Join the caller's trace: this observation and every CallbackHandler
+        # span under it nest into the router's trace (SDK v3 distributed tracing).
+        with client.start_as_current_observation(
+            as_type="agent", name="text-to-sql-handler",
+            trace_context=req.trace_context, input={"question": req.question},
+        ) as obs:
+            answer = _pipeline().query(req.question, callbacks=callbacks)
+            if obs:
+                obs.update(output=answer)
+    else:
+        # Standalone: today's CLI behavior — a self-owned `text-to-sql` trace.
+        with langfuse_trace():
+            answer = _pipeline().query(req.question, callbacks=callbacks)
+
+    # Non-destructive flush (never shutdown() — the singleton client is reused
+    # across requests) so the trace is exported promptly.
+    if client is not None:
+        try:
+            client.flush()
+        except Exception:
+            pass
+    return {"answer": answer, "session_id": req.session_id}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/demos/vector-rag/requirements.txt
+++ b/demos/vector-rag/requirements.txt
@@ -14,3 +14,7 @@ sentence-transformers>=3.0.0,<4.0.0
 
 # Langfuse - LLM observability
 langfuse>=3.0.0,<4.0.0
+
+# API server (server.py — makes port 8003 serve /query; CLI mode unchanged)
+fastapi>=0.115.0,<1.0.0
+uvicorn>=0.30.0,<1.0.0

--- a/demos/vector-rag/server.py
+++ b/demos/vector-rag/server.py
@@ -1,0 +1,89 @@
+"""
+Vector RAG Demo — FastAPI server.
+
+Endpoints:
+    GET  /health   -> liveness + Langfuse status
+    POST /query    -> {question, session_id?, trace_context?} -> {answer, session_id}
+
+Makes the already-mapped port 8003 real (mirrors demos/agentic-rag/server.py and
+demos/text-to-sql/server.py; the query-router front door on :8008 dispatches
+here for the `docs_simple` low-cost tier). When called standalone the trace is
+named `vector-rag` (today's CLI behavior, unchanged); when the router passes
+`trace_context`, this run nests under the router's trace as a
+`vector-rag-handler` agent observation (Langfuse SDK v3 distributed tracing).
+The CLI (`python main.py`) is untouched.
+"""
+
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from rag_pipeline import create_pipeline
+from langfuse_config import (
+    get_langfuse_client,
+    get_langfuse_handler,
+    is_langfuse_enabled,
+    langfuse_trace,
+)
+
+app = FastAPI(title="Vector RAG Demo", version="1.0.0")
+
+# Lazy singleton so the process starts fast; building the pipeline also indexes
+# the document corpus into ChromaDB, so we do it once and reuse it.
+_pipeline_singleton = None
+
+
+def _pipeline():
+    global _pipeline_singleton
+    if _pipeline_singleton is None:
+        _pipeline_singleton = create_pipeline()
+    return _pipeline_singleton
+
+
+class QueryRequest(BaseModel):
+    question: str
+    session_id: Optional[str] = None
+    trace_context: Optional[dict] = None  # {"trace_id","parent_span_id"} from the router
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "langfuse": is_langfuse_enabled()}
+
+
+@app.post("/query")
+def query(req: QueryRequest):
+    handler = get_langfuse_handler()
+    callbacks = [handler] if handler else None
+    client = get_langfuse_client()
+
+    if req.trace_context and client:
+        # Join the caller's trace: this observation and every CallbackHandler
+        # span under it nest into the router's trace (SDK v3 distributed tracing).
+        with client.start_as_current_observation(
+            as_type="agent", name="vector-rag-handler",
+            trace_context=req.trace_context, input={"question": req.question},
+        ) as obs:
+            answer = _pipeline().query(req.question, callbacks=callbacks)
+            if obs:
+                obs.update(output=answer)
+    else:
+        # Standalone: today's CLI behavior — a self-owned `vector-rag` trace.
+        with langfuse_trace():
+            answer = _pipeline().query(req.question, callbacks=callbacks)
+
+    # Non-destructive flush (never shutdown() — the singleton client is reused
+    # across requests) so the trace is exported promptly.
+    if client is not None:
+        try:
+            client.flush()
+        except Exception:
+            pass
+    return {"answer": answer, "session_id": req.session_id}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -171,6 +171,10 @@ services:
     build:
       context: ./demos/text-to-sql
     container_name: text-to-sql
+    # Long-running API server so :8002 actually serves /query (for the
+    # query-router front door). CLI mode is unchanged and overrides this:
+    #   docker compose --profile demo run --rm text-to-sql python main.py
+    command: uvicorn server:app --host 0.0.0.0 --port 8000
     ports:
       - "${TEXT_TO_SQL_PORT:-8002}:8000"
     environment:
@@ -196,6 +200,10 @@ services:
     build:
       context: ./demos/vector-rag
     container_name: vector-rag
+    # Long-running API server so :8003 actually serves /query (for the
+    # query-router front door). CLI mode is unchanged and overrides this:
+    #   docker compose --profile demo run --rm vector-rag python main.py
+    command: uvicorn server:app --host 0.0.0.0 --port 8000
     ports:
       - "${VECTOR_RAG_PORT:-8003}:8000"
     environment:
@@ -368,6 +376,49 @@ services:
     volumes:
       - ./demos/agentic-rag:/agentic-rag:ro
       - vector-rag-models:/root/.cache
+
+  # =============================================================================
+  # Query Router Demo — front-door classification-dispatch (Pattern 2: Routing)
+  # =============================================================================
+  # A thin front door on :8008 that classifies a question (its own `route-query`
+  # generation) and dispatches over HTTP to exactly one specialist handler —
+  # text-to-sql (analytics_sql), vector-rag (docs_simple), agentic-rag
+  # (docs_complex) — or an in-process fallback with HITL escalation. One Langfuse
+  # trace `route-and-dispatch` shows the router decision AND the chosen handler's
+  # nested subtree (SDK v3 distributed tracing).
+  #   API:  docker compose --profile demo up -d query-router
+  #   CLI:  docker compose --profile demo run --rm query-router python main.py
+  # depends_on is service_started (not healthy) on purpose: the router degrades
+  # to fallback if a handler is down (Act 2 of DEMO_SCRIPT).
+  # =============================================================================
+  query-router:
+    build:
+      context: ./demos/query-router
+    container_name: query-router
+    ports:
+      - "${QUERY_ROUTER_PORT:-8008}:8000"
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - ROUTER_MODEL=${ROUTER_MODEL:-claude-haiku-4-5}
+      - ROUTER_CONFIDENCE_THRESHOLD=${ROUTER_CONFIDENCE_THRESHOLD:-0.70}
+      # Set ROUTER_FAULT=sql-blindness for the seeded-misroute act (Act 3).
+      - ROUTER_FAULT=${ROUTER_FAULT:-}
+      # Handler registry — the existing demo services on the shared demo network.
+      - TEXT_TO_SQL_URL=http://text-to-sql:8000
+      - VECTOR_RAG_URL=http://vector-rag:8000
+      - AGENTIC_RAG_URL=http://agentic-rag:8000
+      # Langfuse instrumentation
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
+      - LANGFUSE_HOST=${LANGFUSE_INTERNAL_URL:-http://langfuse-web:3000}
+    depends_on:
+      - text-to-sql
+      - vector-rag
+      - agentic-rag
+    profiles:
+      - demo
+    volumes:
+      - ./demos/query-router:/app
 
   # =============================================================================
   # Test Scenarios - Export synthetic conversations for evaluation demos

--- a/evaluators/route-match.ts
+++ b/evaluators/route-match.ts
@@ -1,0 +1,83 @@
+/**
+ * Route Match — code evaluator (routing accuracy)
+ *
+ * Target: the router's `route-query` observation, primarily on EXPERIMENT runs
+ * of the `query-router-accuracy` dataset (offline). Works online too once a
+ * ground-truth route is available on the item.
+ *
+ * Why code, not an LLM judge: route equality is a deterministic check. A string
+ * comparison never hallucinates, costs nothing per evaluation, and gives the
+ * same verdict every time — exactly what you want for a routing-accuracy metric.
+ * (The soft/ambiguous cases are covered separately by the categorical
+ * `route-plausibility` LLM judge — see scripts/seed-router-judge.sh.)
+ *
+ * Scores:
+ *   route-match  (BOOLEAN)     — chosen route === expected route (only when an
+ *                                expected route exists, e.g. an experiment item)
+ *   route-chosen (CATEGORICAL) — the route the router actually chose (always)
+ */
+
+type EvaluationContext = {
+  observation: { input: any; output: any; metadata: any };
+  experiment: { itemExpectedOutput: any; itemMetadata: any } | undefined;
+};
+
+type Score = {
+  name: string;
+  value: number | string | boolean;
+  dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN" | "TEXT";
+  comment?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type EvaluationResult = { scores: Score[] };
+
+function asObject(value: any): Record<string, any> {
+  if (value == null) return {};
+  if (typeof value === "object") return value;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return typeof parsed === "object" && parsed !== null ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function routeOf(value: any): string {
+  const obj = asObject(value);
+  if (typeof obj.route === "string") return obj.route;
+  // Fall back to a bare string route (e.g. output === "analytics_sql").
+  if (typeof value === "string") return value.trim();
+  return "";
+}
+
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const chosen = routeOf(ctx.observation.output);
+
+  const scores: Score[] = [
+    {
+      name: "route-chosen",
+      value: chosen || "unknown",
+      dataType: "CATEGORICAL",
+      comment: `Router chose '${chosen || "unknown"}'.`,
+    },
+  ];
+
+  // route-match only makes sense when ground truth exists (experiment item).
+  if (ctx.experiment !== undefined && ctx.experiment.itemExpectedOutput != null) {
+    const expected = routeOf(ctx.experiment.itemExpectedOutput);
+    const correct = expected !== "" && chosen === expected;
+    scores.push({
+      name: "route-match",
+      value: correct,
+      dataType: "BOOLEAN",
+      comment: `Router chose '${chosen}', expected '${expected}'.`,
+      metadata: { chosen, expected },
+    });
+  }
+
+  return { scores };
+}

--- a/scripts/run-router-experiment.py
+++ b/scripts/run-router-experiment.py
@@ -79,7 +79,11 @@ def route_match(*, output, expected_output, **kwargs):
     return Evaluation(
         name="route-match",
         value=1.0 if output.get("route") == expected else 0.0,
-        data_type="NUMERIC",
+        # BOOLEAN to match evaluators/route-match.ts (the same-named `route-match`
+        # code evaluator seed-code-evaluators.sh wires onto this dataset): a score
+        # name binds to ONE data type in Langfuse, so the two must agree or one
+        # write is rejected / the experiment column becomes unusable.
+        data_type="BOOLEAN",
         comment=f"chose '{output.get('route')}', expected '{expected}'",
     )
 

--- a/scripts/run-router-experiment.py
+++ b/scripts/run-router-experiment.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Run the router-accuracy experiment — vary ONLY the router (prompt label + model);
+taxonomy, threshold, and handlers stay byte-identical.
+
+Default mode is CLASSIFICATION-ONLY: the task never dispatches a handler, which
+is the strongest possible variable isolation AND makes a 30-item run cost cents
+on Haiku. `--e2e` dispatches to the fixed running handler services for an
+end-to-end comparison (handlers must be up).
+
+Configurations compared (each differs from the others in exactly one axis):
+    prompt=baseline    model=claude-haiku-4-5    (is the few-shot prompt worth it?)
+    prompt=production  model=claude-haiku-4-5
+    prompt=production  model=claude-sonnet-4-6   (is a bigger router worth it?)
+
+Per-item score:  route-match (1.0 if chosen route == expected route)
+Run-level score: avg_route_accuracy (= 1 - misroute rate)
+
+CI: --ci exits 1 if avg_route_accuracy < 0.90 (the gate the DEMO_SCRIPT ties to
+"promote v2 to the production label" = Deploy).
+
+Usage:
+    python scripts/run-router-experiment.py                 # all configs, classification-only
+    python scripts/run-router-experiment.py --sample 30
+    python scripts/run-router-experiment.py --label production --ci
+    python scripts/run-router-experiment.py --e2e            # dispatch to live handlers
+
+Env: LANGFUSE_HOST/BASE_URL, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, ANTHROPIC_API_KEY.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "demos" / "query-router"))
+
+try:
+    from langfuse import Langfuse, Evaluation
+except ImportError:
+    print("Error: langfuse not installed. Run: pip install 'langfuse>=3.0,<4.0'", file=sys.stderr)
+    sys.exit(1)
+
+import router  # noqa: E402  (demos/query-router/router.py)
+
+DATASET_NAME = os.getenv("ROUTER_DATASET_NAME", "query-router-accuracy")
+CI_THRESHOLD = float(os.getenv("ROUTER_CI_THRESHOLD", "0.90"))
+
+# (prompt_label, model) — each config differs in exactly one axis.
+CONFIGS = [
+    ("baseline", "claude-haiku-4-5"),
+    ("production", "claude-haiku-4-5"),
+    ("production", "claude-sonnet-4-6"),
+]
+
+
+def _question(item):
+    inp = item.input
+    return inp.get("question") if isinstance(inp, dict) else str(inp)
+
+
+def make_task(prompt_label: str, model: str, e2e: bool):
+    def task(*, item, **kwargs):
+        # ONLY these two vary; taxonomy, threshold, handlers untouched.
+        decision = router.classify(_question(item), prompt_label=prompt_label, model=model)
+        out = {"route": decision["route"], "confidence": decision["confidence"]}
+        if e2e:
+            from handlers import dispatch  # local import: only needed in --e2e mode
+            result = dispatch(decision, _question(item), session_id="router-experiment")
+            out["handled_by"] = result.get("handled_by")
+            out["answer"] = result.get("answer")
+        return out
+    return task
+
+
+def route_match(*, output, expected_output, **kwargs):
+    expected = expected_output.get("route") if isinstance(expected_output, dict) else expected_output
+    return Evaluation(
+        name="route-match",
+        value=1.0 if output.get("route") == expected else 0.0,
+        data_type="NUMERIC",
+        comment=f"chose '{output.get('route')}', expected '{expected}'",
+    )
+
+
+def avg_route_accuracy(*, item_results, **kwargs):
+    vals = [e.value for r in item_results for e in r.evaluations
+            if e.name == "route-match" and e.value is not None]
+    return Evaluation(name="avg_route_accuracy",
+                      value=sum(vals) / len(vals) if vals else None,
+                      data_type="NUMERIC")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Router-accuracy experiment (vary only the router)")
+    ap.add_argument("--sample", type=int, default=None, help="run only the first N dataset items")
+    ap.add_argument("--label", default=None,
+                    help="run only one prompt label (baseline|production); default runs all configs")
+    ap.add_argument("--model", default=None, help="override the model for the --label run")
+    ap.add_argument("--e2e", action="store_true", help="dispatch to live handlers (end-to-end)")
+    ap.add_argument("--ci", action="store_true",
+                    help=f"exit 1 if any run's avg_route_accuracy < {CI_THRESHOLD}")
+    args = ap.parse_args()
+
+    host = os.getenv("LANGFUSE_HOST", os.getenv("LANGFUSE_BASE_URL", "http://localhost:3001"))
+    pk = os.getenv("LANGFUSE_PUBLIC_KEY", "pk-lf-1234567890")
+    sk = os.getenv("LANGFUSE_SECRET_KEY", "sk-lf-1234567890")
+    lf = Langfuse(public_key=pk, secret_key=sk, host=host)
+
+    try:
+        dataset = lf.get_dataset(DATASET_NAME)
+    except Exception as e:
+        print(f"ERROR loading dataset '{DATASET_NAME}': {e}\nRun scripts/seed-router-dataset.py first.")
+        sys.exit(1)
+
+    items = list(dataset.items)
+    if args.sample:
+        items = items[: args.sample]
+
+    configs = CONFIGS
+    if args.label:
+        configs = [(args.label, args.model or os.getenv("ROUTER_MODEL", "claude-haiku-4-5"))]
+
+    print(f"Router experiment on '{DATASET_NAME}' ({len(items)} items, "
+          f"{'e2e' if args.e2e else 'classification-only'})\n")
+
+    worst = 1.0
+    for label, model in configs:
+        result = lf.run_experiment(
+            name=DATASET_NAME,
+            run_name=f"router-prompt={label}-model={model}",
+            description=f"Router variant: prompt={label} model={model} "
+                        f"({'e2e dispatch' if args.e2e else 'classification-only'}).",
+            data=items,
+            task=make_task(label, model, args.e2e),
+            evaluators=[route_match],
+            run_evaluators=[avg_route_accuracy],
+            metadata={"varied_component": "router", "prompt_label": label,
+                      "router_model": model, "mode": "e2e" if args.e2e else "classification"},
+        )
+        acc = next((e.value for e in result.run_evaluations if e.name == "avg_route_accuracy"), None)
+        worst = min(worst, acc if acc is not None else 1.0)
+        print(f"  prompt={label:11s} model={model:20s} avg_route_accuracy="
+              f"{acc if acc is not None else 'n/a'}")
+        try:
+            print(result.format())
+        except Exception:
+            pass
+
+    lf.flush()
+    print(f"\nView: {host} -> Datasets -> {DATASET_NAME} -> Runs")
+
+    if args.ci and worst < CI_THRESHOLD:
+        print(f"\nCI GATE FAILED: worst avg_route_accuracy {worst:.3f} < {CI_THRESHOLD}")
+        sys.exit(1)
+    if args.ci:
+        print(f"\nCI GATE PASSED: worst avg_route_accuracy {worst:.3f} >= {CI_THRESHOLD}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed-code-evaluators.sh
+++ b/scripts/seed-code-evaluators.sh
@@ -123,6 +123,17 @@ else
     warn "Dataset coding-assistant-security not found — run 'python scripts/seed-datasets.py' then re-run this script"
 fi
 
+# query-router: deterministic exact-match routing accuracy on experiment runs of
+# the router-accuracy dataset (the soft/ambiguous cases go to the categorical
+# route-plausibility LLM judge — scripts/seed-router-judge.sh).
+ROUTER_DS=$(dataset_id "query-router-accuracy")
+if [ -n "$ROUTER_DS" ]; then
+    seed_evaluator "route-match" "route-match" "experiment" \
+        '[{"type":"stringOptions","value":["'"$ROUTER_DS"'"],"column":"experimentDatasetId","operator":"any of"}]' 1
+else
+    warn "Dataset query-router-accuracy not found — run 'python scripts/seed-router-dataset.py' then re-run this script"
+fi
+
 # The worker caches "project has no event/experiment evaluators" in Redis for
 # 10 minutes; clear it so freshly seeded evaluators pick up traffic right away.
 if docker ps --format '{{.Names}}' | grep -q "^${REDIS_CONTAINER}$"; then

--- a/scripts/seed-router-dataset.py
+++ b/scripts/seed-router-dataset.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Seed the `query-router-accuracy` dataset — a dedicated ROUTER-ONLY dataset
+(distinct from any handler dataset) so the classification step regression-tests
+fast and cheap, without specialist-quality noise burying router regressions.
+
+  input           = {"question": ...}
+  expected_output = {"route": "analytics_sql" | "docs_simple" | "docs_complex" | "fallback"}
+  metadata        = {"category": "clear" | "ambiguous" | "out_of_scope", ...}
+
+~30 items covering every route + ambiguous (a good router abstains -> fallback)
++ out_of_scope. Production misroutes are pinned separately, live, via
+source_observation_id (see demos/query-router/scripts/score_misroute.py).
+
+Usage:
+    python scripts/seed-router-dataset.py            # create/populate
+    python scripts/seed-router-dataset.py --dry-run  # preview only
+
+Env: LANGFUSE_HOST/BASE_URL, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY
+     (defaults: http://localhost:3001, pk-lf-1234567890, sk-lf-1234567890).
+"""
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+try:
+    from langfuse import Langfuse
+except ImportError:
+    print("Error: langfuse not installed. Run: pip install 'langfuse>=3.0,<4.0'", file=sys.stderr)
+    sys.exit(1)
+
+DATASET_NAME = os.getenv("ROUTER_DATASET_NAME", "query-router-accuracy")
+
+
+@dataclass
+class Item:
+    question: str
+    route: str
+    category: str
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+ITEMS: List[Item] = [
+    # ---- clear / analytics_sql (8) ----
+    Item("How many taxi rides were there in NYC in July 2015?", "analytics_sql", "clear"),
+    Item("What are the top 5 most-starred GitHub repositories this year?", "analytics_sql", "clear"),
+    Item("Which programming languages have the most Stack Overflow questions?", "analytics_sql", "clear"),
+    Item("What is the average taxi trip distance in New York City?", "analytics_sql", "clear"),
+    Item("How many PyPI downloads did numpy get last month?", "analytics_sql", "clear"),
+    Item("What are the highest-scored Hacker News stories this year?", "analytics_sql", "clear"),
+    Item("Which US airlines have the highest flight-delay rate?", "analytics_sql", "clear"),
+    Item("What are the most expensive areas for property in the UK?", "analytics_sql", "clear"),
+    # ---- clear / docs_simple (8) ----
+    Item("What is a vector index?", "docs_simple", "clear"),
+    Item("What does Langfuse's session view show?", "docs_simple", "clear"),
+    Item("What is ClickHouse and what is it used for?", "docs_simple", "clear"),
+    Item("What is OpenTelemetry?", "docs_simple", "clear"),
+    Item("What are vector embeddings?", "docs_simple", "clear"),
+    Item("What is retrieval-augmented generation (RAG)?", "docs_simple", "clear"),
+    Item("What is a materialized view in ClickHouse?", "docs_simple", "clear"),
+    Item("What does a Langfuse score represent?", "docs_simple", "clear"),
+    # ---- clear / docs_complex (6) ----
+    Item("Compare ClickHouse-native vector search with Chroma for RAG and when each wins.",
+         "docs_complex", "clear"),
+    Item("Walk through how CRAG-style self-correction reduces hallucinations, with the failure cases.",
+         "docs_complex", "clear"),
+    Item("How does ClickHouse compare to a traditional row-based database for observability "
+         "workloads, and where does it fall short?", "docs_complex", "clear"),
+    Item("Explain the tradeoffs between LLM-as-a-judge and code evaluators, with examples of "
+         "when each misleads you.", "docs_complex", "clear"),
+    Item("How do managed prompts, labels, and experiments fit together in the AI engineering loop?",
+         "docs_complex", "clear"),
+    Item("Contrast naive RAG with agentic RAG and describe how retrieval grading and reflection "
+         "change the results.", "docs_complex", "clear"),
+    # ---- ambiguous (6): 3 truly-mixed -> fallback (a good router abstains) ----
+    Item("Is ClickHouse fast?", "fallback", "ambiguous", {"mixed_intent": True}),
+    Item("Show me how RAG performs on real data.", "fallback", "ambiguous", {"mixed_intent": True}),
+    Item("Which is better, ClickHouse or Postgres?", "fallback", "ambiguous", {"mixed_intent": True}),
+    # ---- ambiguous (3 with a defensible expected route) ----
+    Item("How does NYC taxi ridership look over time?", "analytics_sql", "ambiguous"),
+    Item("What are embeddings good for?", "docs_simple", "ambiguous"),
+    Item("Give me an overview of ClickHouse vector search.", "docs_simple", "ambiguous"),
+    # ---- out_of_scope -> fallback (2) ----
+    Item("Write me a poem about databases.", "fallback", "out_of_scope"),
+    Item("What's the weather in Amsterdam?", "fallback", "out_of_scope"),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Seed the query-router-accuracy dataset")
+    ap.add_argument("--dry-run", action="store_true", help="preview items without creating")
+    args = ap.parse_args()
+
+    host = os.getenv("LANGFUSE_HOST", os.getenv("LANGFUSE_BASE_URL", "http://localhost:3001"))
+    pk = os.getenv("LANGFUSE_PUBLIC_KEY", "pk-lf-1234567890")
+    sk = os.getenv("LANGFUSE_SECRET_KEY", "sk-lf-1234567890")
+
+    print(f"Router dataset seeder -> {host}", file=sys.stderr)
+    print(f"  Dataset: {DATASET_NAME}  ({len(ITEMS)} items)", file=sys.stderr)
+
+    if args.dry_run:
+        print("  ** DRY RUN — nothing created **", file=sys.stderr)
+        for it in ITEMS:
+            print(f"    [{it.category:11s}] {it.route:13s} <- {it.question[:70]}", file=sys.stderr)
+        return
+
+    client = Langfuse(public_key=pk, secret_key=sk, host=host)
+    try:
+        client.create_dataset(
+            name=DATASET_NAME,
+            description="Router-only accuracy set: raw question -> expected route label. "
+                        "Regression-tests ONLY the classifier, independent of specialist quality.",
+            metadata={"source": "seed-router-dataset.py"},
+        )
+        print(f"  Created dataset: {DATASET_NAME}", file=sys.stderr)
+    except Exception as e:
+        if "already exists" in str(e).lower() or "409" in str(e):
+            print(f"  Dataset already exists: {DATASET_NAME} (adding items)", file=sys.stderr)
+        else:
+            print(f"  Warning creating dataset: {e}", file=sys.stderr)
+
+    created = 0
+    for it in ITEMS:
+        try:
+            client.create_dataset_item(
+                dataset_name=DATASET_NAME,
+                input={"question": it.question},
+                expected_output={"route": it.route},
+                metadata={"category": it.category, "route": it.route, **it.extra},
+            )
+            created += 1
+        except Exception as e:
+            print(f"    Error adding item: {e}", file=sys.stderr)
+
+    client.flush()
+    print(f"  Added {created}/{len(ITEMS)} items", file=sys.stderr)
+    print(f"\nVerify in Langfuse UI: {host} -> Datasets -> {DATASET_NAME}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed-router-history.py
+++ b/scripts/seed-router-history.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Seed ~300 backdated `route-and-dispatch` router traces over 14 days — NO LLM
+calls (direct batch ingestion via the public /api/public/ingestion endpoint), so
+the Router Ops dashboard tells its story on day one:
+
+  * Route distribution over time — a week-over-week DRIFT: docs_simple-heavy in
+    week 1, analytics_sql share doubling in week 2.
+  * Fallback rate — ~8% of traces divert to the in-process fallback + escalation.
+  * Avg router_confidence — realistic per-route distributions (high for clear
+    routes, low for fallback).
+  * Misroute rate — ~6% of reviewed traces carry routing_correct=0 (BOOLEAN),
+    clustered on a couple of days so the widget shows a visible dip.
+
+Each trace mirrors the live shape: a `route-query` generation (model
+claude-haiku-4-5) with {route, confidence, rationale} + metadata.route, a runtime
+router_confidence score, and either a dispatch-<route> span or a fallback-handler
+generation + escalate-to-human event.
+
+Usage:
+    python scripts/seed-router-history.py                 # 300 traces / 14 days
+    python scripts/seed-router-history.py --count 300 --days 14 --seed 42
+
+Env: LANGFUSE_HOST/BASE_URL, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY
+     (defaults: http://localhost:3001, pk-lf-1234567890, sk-lf-1234567890).
+"""
+
+import argparse
+import base64
+import json
+import os
+import random
+import sys
+import urllib.request
+import uuid
+from datetime import datetime, timedelta, timezone
+
+HOST = os.getenv("LANGFUSE_HOST", os.getenv("LANGFUSE_BASE_URL", "http://localhost:3001")).rstrip("/")
+PK = os.getenv("LANGFUSE_PUBLIC_KEY", "pk-lf-1234567890")
+SK = os.getenv("LANGFUSE_SECRET_KEY", "sk-lf-1234567890")
+_AUTH = base64.b64encode(f"{PK}:{SK}".encode()).decode()
+
+ROUTER_MODEL = os.getenv("ROUTER_MODEL", "claude-haiku-4-5")
+
+QUESTIONS = {
+    "analytics_sql": ["How many taxi rides in NYC last month?", "Top 5 starred GitHub repos this year?",
+                      "Average trip distance in NYC?", "Most downloaded PyPI packages?"],
+    "docs_simple": ["What is a vector index?", "What is ClickHouse?", "What are embeddings?",
+                    "What does the Langfuse session view show?"],
+    "docs_complex": ["Compare ClickHouse-native vectors with Chroma and when each wins.",
+                     "Walk through CRAG self-correction and its failure cases.",
+                     "Contrast naive RAG with agentic RAG end to end."],
+    "fallback": ["Is ClickHouse fast?", "Write me a poem about databases.",
+                 "What's the weather in Amsterdam?", "Show me how RAG performs on real data."],
+}
+FALLBACK_REASONS = ["low_confidence", "out_of_scope", "malformed_output", "handler_unreachable"]
+_uid = lambda: str(uuid.uuid4())
+
+
+def _iso(dt):
+    return dt.isoformat()
+
+
+def _post_batch(events):
+    body = json.dumps({"batch": events}).encode()
+    req = urllib.request.Request(
+        f"{HOST}/api/public/ingestion", data=body, method="POST",
+        headers={"Authorization": f"Basic {_AUTH}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.load(r)
+
+
+def _pick_route(rng, day_offset, days):
+    """Week-dependent route weights => visible drift (analytics_sql doubles in week 2)."""
+    if rng.random() < 0.08:
+        return "fallback"
+    older_half = day_offset >= days / 2  # older = week 1
+    if older_half:
+        weights = {"docs_simple": 0.55, "docs_complex": 0.25, "analytics_sql": 0.20}
+    else:
+        weights = {"analytics_sql": 0.40, "docs_simple": 0.38, "docs_complex": 0.22}
+    routes, w = zip(*weights.items())
+    return rng.choices(routes, weights=w, k=1)[0]
+
+
+def _confidence(rng, route):
+    if route == "fallback":
+        return round(rng.uniform(0.35, 0.68), 2)
+    return round(rng.uniform(0.80, 0.98), 2)
+
+
+def _build_trace(rng, days):
+    day_offset = rng.randint(0, days - 1)
+    base = datetime.now(timezone.utc) - timedelta(days=day_offset)
+    t0 = base.replace(hour=rng.randint(0, 23), minute=rng.randint(0, 59),
+                      second=rng.randint(0, 59), microsecond=0)
+    route = _pick_route(rng, day_offset, days)
+    conf = _confidence(rng, route)
+    question = rng.choice(QUESTIONS[route])
+    is_ambiguous = route == "fallback" or conf < 0.85
+
+    trace_id, gen_id = _uid(), _uid()
+    events = []
+
+    # root trace
+    events.append({"id": _uid(), "type": "trace-create", "timestamp": _iso(t0), "body": {
+        "id": trace_id, "timestamp": _iso(t0), "name": "route-and-dispatch",
+        "input": {"question": question}, "tags": ["query-router", "demo"],
+        "sessionId": f"query-router-{uuid.uuid4().hex[:8]}",
+        "userId": f"demo-user-{rng.randint(1, 25)}",
+        "metadata": {"synthetic": True}}})
+
+    # route-query generation
+    g0, g1 = t0, t0 + timedelta(milliseconds=rng.randint(200, 900))
+    events.append({"id": _uid(), "type": "generation-create", "timestamp": _iso(g1), "body": {
+        "id": gen_id, "traceId": trace_id, "name": "route-query", "model": ROUTER_MODEL,
+        "startTime": _iso(g0), "endTime": _iso(g1),
+        "input": {"question": question},
+        "output": {"route": route, "confidence": conf, "rationale": "synthetic classification"},
+        "metadata": {"route": route, "threshold": 0.70,
+                     "fallback_triggered": route == "fallback", "router_model": ROUTER_MODEL},
+        "usageDetails": {"input": rng.randint(120, 260), "output": rng.randint(20, 60)}}})
+
+    # runtime router_confidence score on the route-query observation
+    events.append({"id": _uid(), "type": "score-create", "timestamp": _iso(g1), "body": {
+        "id": _uid(), "traceId": trace_id, "observationId": gen_id,
+        "name": "router_confidence", "value": conf, "dataType": "NUMERIC",
+        "comment": "threshold=0.70"}})
+
+    t = g1
+    if route == "fallback":
+        reason = rng.choice(FALLBACK_REASONS)
+        f0, f1 = t, t + timedelta(milliseconds=rng.randint(300, 1200))
+        events.append({"id": _uid(), "type": "generation-create", "timestamp": _iso(f1), "body": {
+            "id": _uid(), "traceId": trace_id, "name": "fallback-handler", "model": ROUTER_MODEL,
+            "startTime": _iso(f0), "endTime": _iso(f1),
+            "input": {"question": question}, "output": "best-effort answer with caveat",
+            "metadata": {"route": "fallback"}}})
+        events.append({"id": _uid(), "type": "event-create", "timestamp": _iso(f1), "body": {
+            "id": _uid(), "traceId": trace_id, "name": "escalate-to-human", "startTime": _iso(f1),
+            "input": {"reason": reason, "confidence": conf}}})
+    else:
+        d0, d1 = t, t + timedelta(milliseconds=rng.randint(800, 6000))
+        events.append({"id": _uid(), "type": "span-create", "timestamp": _iso(d1), "body": {
+            "id": _uid(), "traceId": trace_id, "name": f"dispatch-{route}",
+            "startTime": _iso(d0), "endTime": _iso(d1),
+            "input": {"question": question}, "output": {"answer": "specialist answer"}}})
+
+    # Post-hoc routing_correct on ~30% "reviewed" traces; ~6% false overall, but
+    # clustered on 2 days so the misroute-rate widget shows a visible dip.
+    if rng.random() < 0.30:
+        cluster = day_offset in (8, 9)
+        false_rate = 0.45 if (cluster and is_ambiguous) else 0.06
+        correct = 0 if rng.random() < false_rate else 1
+        events.append({"id": _uid(), "type": "score-create", "timestamp": _iso(t0), "body": {
+            "id": _uid(), "traceId": trace_id, "observationId": gen_id,
+            "name": "routing_correct", "value": correct, "dataType": "BOOLEAN",
+            "comment": "human review (synthetic)" if correct else "misroute (synthetic)"}})
+
+    return events
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Seed backdated router history (no LLM calls)")
+    ap.add_argument("--count", type=int, default=300)
+    ap.add_argument("--days", type=int, default=14)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--batch-size", type=int, default=100)
+    args = ap.parse_args()
+
+    rng = random.Random(args.seed)
+    print(f"Seeding {args.count} router traces over {args.days} days -> {HOST}", file=sys.stderr)
+
+    pending, sent, errors = [], 0, 0
+    for _ in range(args.count):
+        pending.extend(_build_trace(rng, args.days))
+        if len(pending) >= args.batch_size * 6:
+            try:
+                resp = _post_batch(pending)
+                errors += len(resp.get("errors", []) or [])
+            except Exception as e:
+                print(f"  batch error: {e}", file=sys.stderr)
+                errors += 1
+            sent += 1
+            pending = []
+    if pending:
+        try:
+            resp = _post_batch(pending)
+            errors += len(resp.get("errors", []) or [])
+        except Exception as e:
+            print(f"  batch error: {e}", file=sys.stderr)
+            errors += 1
+        sent += 1
+
+    print(f"Done. {args.count} traces in {sent} batch POST(s); ingestion errors: {errors}", file=sys.stderr)
+    print(f"Build the Router Ops dashboard, then explore: {HOST} -> Traces (name=route-and-dispatch)",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed-router-judge.sh
+++ b/scripts/seed-router-judge.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Provision the observation-level, categorical LLM-as-a-Judge `route-plausibility`
+# for the query-router demo — a ground-truth-FREE proxy for *silent
+# misclassification*. It reads the router's own `route-query` generation
+# (question <- input.question, decision <- output {route, rationale}) and judges
+# whether the chosen route is plausible, emitting one of the taxonomy categories
+# ∪ {ambiguous}. A judged `ambiguous`, or a judged route != chosen route, is the
+# curation signal that feeds the router-accuracy dataset + annotation queue.
+#
+# Mechanism mirrors scripts/seed-agentic-rag-evaluators.sh: a Postgres upsert
+# into eval_templates + job_configurations (schema-coupled to the langfuse:3
+# image), sampling 0.25, time_scope=NEW (only NEW traffic is scored — regenerate
+# router traffic to see it), the default-eval-model reuse, and the Redis
+# evaluator-cache clear. Idempotent. Self-hosted only; prints UI steps in cloud.
+#
+# NOTE: the custom-template INSERT is schema-coupled to the langfuse image; it is
+# guarded so a schema mismatch prints UI guidance instead of aborting the stack.
+#
+# Usage: ./scripts/seed-router-judge.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; cd "$SCRIPT_DIR/.."
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; NC='\033[0m'
+ok(){ echo -e "  ${GREEN}✓${NC} $1"; }; warn(){ echo -e "  ${YELLOW}⚠${NC} $1"; }
+info(){ echo -e "  ${BLUE}ℹ${NC} $1"; }; fail(){ echo -e "  ${RED}✗${NC} $1"; exit 1; }
+[ -f .env ] && set -a && source .env && set +a
+
+PG="${LANGFUSE_POSTGRES_CONTAINER:-langfuse-postgres}"
+REDIS="${LANGFUSE_REDIS_CONTAINER:-langfuse-redis}"
+EVAL_MODEL="${LANGFUSE_EVAL_MODEL:-claude-haiku-4-5-20251001}"
+SCORE_NAME="route-plausibility"
+CATEGORIES="analytics_sql, docs_simple, docs_complex, out_of_scope, ambiguous"
+
+echo ""
+echo "Provisioning categorical LLM-as-a-Judge '${SCORE_NAME}' for query-router..."
+
+if [ "${DEPLOY_MODE:-self-hosted}" = "cloud" ]; then
+  warn "DEPLOY_MODE=cloud — create this judge in the Langfuse UI:"
+  echo "     Evaluators > New evaluator > Custom > target Observations, filter"
+  echo "       type=GENERATION, name any-of [route-query], tags any-of [query-router]"
+  echo "     Template (categorical): allowed categories = ${CATEGORIES}"
+  echo "       variables: question <- input.question ; decision <- output"
+  echo "       score name '${SCORE_NAME}', sampling 0.25, time scope NEW"
+  exit 0
+fi
+
+docker ps --format '{{.Names}}' | grep -q "^${PG}$" || fail "Postgres ${PG} not running (run ./setup.sh first)"
+pg(){ docker exec -i "$PG" sh -c 'psql -v ON_ERROR_STOP=1 -q -t -A -U "$POSTGRES_USER" -d "$POSTGRES_DB"'; }
+
+PID=$(echo "SELECT project_id FROM api_keys WHERE public_key='${LANGFUSE_PUBLIC_KEY:-pk-lf-1234567890}' LIMIT 1;" | pg)
+PID="${PID:-demo-project}"; ok "Project: ${PID}"
+
+# ── Default eval model (reuse the Anthropic connection setup.sh provisions) ──
+if [ "$(echo "SELECT count(*) FROM default_llm_models WHERE project_id='${PID}';" | pg)" = "0" ]; then
+  LLM_KEY_ID=$(echo "SELECT id FROM llm_api_keys WHERE project_id='${PID}' AND adapter='anthropic' LIMIT 1;" | pg)
+  if [ -n "$LLM_KEY_ID" ]; then
+    echo "INSERT INTO default_llm_models (id, project_id, llm_api_key_id, provider, adapter, model, model_params, created_at, updated_at)
+          SELECT 'default-eval-model-${PID}','${PID}','${LLM_KEY_ID}',provider,adapter,'${EVAL_MODEL}','{}'::jsonb,now(),now()
+          FROM llm_api_keys WHERE id='${LLM_KEY_ID}' ON CONFLICT (project_id) DO NOTHING;" | pg >/dev/null
+    ok "Default eval model set (${EVAL_MODEL})"
+  else
+    warn "No Anthropic LLM connection — run ./setup.sh first; the judge stays blocked until a default eval model exists"
+  fi
+else
+  ok "Default eval model already configured"
+fi
+
+TEMPLATE_ID="router-route-plausibility"
+JOB_ID="router-route-plausibility-job"
+
+# Judge prompt: reads {{question}} + {{decision}}, returns one category + reasoning.
+read -r -d '' JUDGE_PROMPT <<PROMPT || true
+You are auditing a query router. Given a user QUESTION and the router's DECISION
+(its chosen route + rationale), decide whether the chosen route is PLAUSIBLE.
+Answer with exactly ONE category:
+- analytics_sql : the question needs live numbers from datasets
+- docs_simple   : a single factual/definitional doc question
+- docs_complex  : multi-part / comparative / accuracy-critical doc question
+- out_of_scope  : small talk, unrelated domain, or unsafe
+- ambiguous     : the question genuinely spans routes or is too vague to route confidently
+
+Output the category that BEST fits the question. If it matches the router's
+chosen route the routing was plausible; if not (or 'ambiguous'), it is a
+misroute-risk worth review.
+
+QUESTION: {{question}}
+DECISION: {{decision}}
+PROMPT
+
+# output_schema: standard {score, reasoning} form; the score carries the chosen
+# category string (categorical). vars: question, decision.
+OUTPUT_SCHEMA='{"score":"One of: '"${CATEGORIES}"'","reasoning":"One sentence justification"}'
+MODEL_PARAMS='{"temperature":0,"max_tokens":256}'
+
+# Observation-level filter: the router's own route-query GENERATION on query-router traces.
+FILTER='[{"type":"stringOptions","value":["GENERATION"],"column":"type","operator":"any of"},{"type":"stringOptions","value":["route-query"],"column":"name","operator":"any of"},{"type":"arrayOptions","value":["query-router"],"column":"tags","operator":"any of"}]'
+MAPPING='[{"templateVariable":"question","langfuseObject":"event","selectedColumnId":"input","jsonSelector":"question"},{"templateVariable":"decision","langfuseObject":"event","selectedColumnId":"output"}]'
+
+# Create the custom template (guarded: a schema mismatch must not abort the stack).
+set +e
+docker exec -i "$PG" sh -c 'psql -v ON_ERROR_STOP=1 -q -t -A -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<SQL >/tmp/router_judge_tmpl.log 2>&1
+INSERT INTO eval_templates (id, project_id, name, version, prompt, provider, model, model_params, vars, output_schema, type, created_at, updated_at)
+VALUES ('${TEMPLATE_ID}', '${PID}', 'route-plausibility', 1, \$JUDGE\$${JUDGE_PROMPT}\$JUDGE\$, 'anthropic', '${EVAL_MODEL}', '${MODEL_PARAMS}'::jsonb, ARRAY['question','decision'], '${OUTPUT_SCHEMA}'::jsonb, 'LLM_AS_JUDGE', now(), now())
+ON CONFLICT (project_id, name, version) DO UPDATE SET prompt=EXCLUDED.prompt, model=EXCLUDED.model, model_params=EXCLUDED.model_params, vars=EXCLUDED.vars, output_schema=EXCLUDED.output_schema, updated_at=now();
+SQL
+TMPL_RC=$?
+set -e
+if [ "$TMPL_RC" != "0" ]; then
+  warn "Could not create the custom template via SQL (schema-coupled). Details: $(tr '\n' ' ' </tmp/router_judge_tmpl.log)"
+  info "Create it once in the UI (Evaluators > New evaluator > Custom): categorical, categories = ${CATEGORIES},"
+  info "  variables question<-input.question, decision<-output; then re-run this script to wire the job."
+  exit 0
+fi
+ok "route-plausibility template (categorical: ${CATEGORIES})"
+
+echo "INSERT INTO job_configurations (id, project_id, job_type, eval_template_id, score_name, filter, target_object, variable_mapping, sampling, delay, status, time_scope, created_at, updated_at)
+      VALUES ('${JOB_ID}','${PID}','EVAL','${TEMPLATE_ID}','${SCORE_NAME}','${FILTER}'::jsonb,'event','${MAPPING}'::jsonb,0.25,0,'ACTIVE',ARRAY['NEW'],now(),now())
+      ON CONFLICT (id) DO UPDATE SET eval_template_id=EXCLUDED.eval_template_id, score_name=EXCLUDED.score_name, filter=EXCLUDED.filter, variable_mapping=EXCLUDED.variable_mapping, sampling=0.25, status='ACTIVE', blocked_at=NULL, block_reason=NULL, block_message=NULL, updated_at=now();" | pg >/dev/null
+ok "${SCORE_NAME} → observation-level judge on route-query (sampling 0.25, time_scope=NEW)"
+
+# Clear the worker's "no evaluators" cache so the new config picks up traffic now.
+if docker ps --format '{{.Names}}' | grep -q "^${REDIS}$"; then
+  docker exec "$REDIS" redis-cli del \
+    "langfuse:eval:no-event-and-experiment-job-configs:${PID}" \
+    "langfuse:eval:no-trace-and-dataset-job-configs:${PID}" >/dev/null 2>&1 || true
+  ok "Cleared evaluator config cache"
+fi
+
+echo ""
+ok "route-plausibility seeded. Regenerate router traffic, then curate: a judged 'ambiguous'"
+echo "  (or a judged route != chosen route) is the signal that feeds the dataset + annotation queue."
+echo "  View: ${LANGFUSE_BASE_URL:-http://localhost:3001}/project/${PID}/evals"
+echo ""

--- a/scripts/seed-router-prompt.py
+++ b/scripts/seed-router-prompt.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Seed the Langfuse-managed router prompt for the Query Router demo.
+
+Creates `query-router-classifier` with two versions to showcase prompt
+management + versioning (same v1/v2 showcase shape as seed-langfuse-prompt.py):
+  v1  baseline               (taxonomy + JSON schema only, no label)
+  v2  few-shot + calibration (labeled `production`)
+
+The router pulls this prompt at runtime via
+langfuse.get_prompt("query-router-classifier", label="production"), links the
+version to the `route-query` generation, and falls back to a local template if
+Langfuse is unavailable. config.temperature=0.0 (routing wants determinism — a
+deliberate contrast with the demos' default TEMPERATURE=0.7).
+
+Idempotent-ish: re-running appends new versions. Usage:
+    LANGFUSE_HOST=http://localhost:3001 \
+    LANGFUSE_PUBLIC_KEY=pk-lf-1234567890 LANGFUSE_SECRET_KEY=sk-lf-1234567890 \
+    python scripts/seed-router-prompt.py
+"""
+
+import base64
+import json
+import os
+import urllib.request
+
+HOST = os.getenv("LANGFUSE_HOST", os.getenv("LANGFUSE_BASE_URL", "http://localhost:3001")).rstrip("/")
+PK = os.getenv("LANGFUSE_PUBLIC_KEY", "pk-lf-1234567890")
+SK = os.getenv("LANGFUSE_SECRET_KEY", "sk-lf-1234567890")
+NAME = os.getenv("ROUTER_PROMPT_NAME", "query-router-classifier")
+ROUTER_MODEL = os.getenv("ROUTER_MODEL", "claude-haiku-4-5")
+
+_auth = base64.b64encode(f"{PK}:{SK}".encode()).decode()
+
+
+def _create(body: dict) -> dict:
+    req = urllib.request.Request(
+        f"{HOST}/api/public/v2/prompts",
+        data=json.dumps(body).encode(),
+        headers={"Authorization": f"Basic {_auth}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.load(r)
+
+
+# v1 — baseline: taxonomy + JSON schema only.
+V1 = (
+    "You are the front-door router for a data-and-docs assistant. Classify the "
+    "question into exactly ONE route:\n"
+    "- analytics_sql : needs LIVE numbers from ClickHouse public datasets "
+    "(taxi rides, github stars, stackoverflow, prices, ...)\n"
+    "- docs_simple   : a single factual/definitional question answerable from docs\n"
+    "- docs_complex  : multi-part, comparative, or accuracy-critical doc questions "
+    "that merit retrieval verification\n"
+    "- out_of_scope  : none of the above (small talk, unrelated domains, unsafe asks)\n\n"
+    'Respond ONLY with JSON: {"route": "...", "confidence": 0.0-1.0, "rationale": "..."}\n\n'
+    "Question: {{question}}"
+)
+
+# v2 — few-shot + confidence calibration + explicit out_of_scope guidance.
+V2 = (
+    "You are the front-door router for a data-and-docs assistant. Classify the "
+    "question into exactly ONE route:\n"
+    "- analytics_sql : needs LIVE numbers from ClickHouse public datasets "
+    "(taxi rides, github stars, stackoverflow, prices, ...)\n"
+    "- docs_simple   : a single factual/definitional question answerable from docs\n"
+    "- docs_complex  : multi-part, comparative, or accuracy-critical doc questions "
+    "that merit retrieval verification\n"
+    "- out_of_scope  : none of the above (small talk, unrelated domains, unsafe asks)\n\n"
+    'Respond ONLY with JSON: {"route": "...", "confidence": 0.0-1.0, "rationale": "..."}\n\n'
+    "Calibration: confidence reflects P(correct route). If the question BOTH asks "
+    "for live numbers AND a conceptual explanation, pick the dominant intent and "
+    "LOWER the confidence. Mixed-intent or vague questions must score below 0.7. "
+    "Small talk, unrelated domains, or unsafe requests are out_of_scope.\n\n"
+    "Examples:\n"
+    'Q: "How many taxi rides in NYC in July 2015?"  -> {"route": "analytics_sql", "confidence": 0.96, "rationale": "asks for a live count from a dataset"}\n'
+    'Q: "What is a vector index?"  -> {"route": "docs_simple", "confidence": 0.93, "rationale": "single definitional doc question"}\n'
+    'Q: "Compare ClickHouse-native vectors with Chroma and when each wins."  -> {"route": "docs_complex", "confidence": 0.9, "rationale": "comparative, verification-worthy"}\n'
+    'Q: "Write me a poem about databases."  -> {"route": "out_of_scope", "confidence": 0.95, "rationale": "creative, unrelated to data/docs"}\n'
+    'Q: "Is ClickHouse fast?"  -> {"route": "docs_simple", "confidence": 0.5, "rationale": "vague — could mean docs or a benchmark number"}\n\n'
+    "Question: {{question}}"
+)
+
+CONFIG = {"model": ROUTER_MODEL, "temperature": 0.0}
+
+
+def main():
+    print(f"Seeding prompt '{NAME}' at {HOST} ...")
+    # v1 is labeled `baseline` (NOT production) so the experiment can fetch it by
+    # label to compare against production — the router only ever runs `production`.
+    v1 = _create({"name": NAME, "type": "text", "prompt": V1, "labels": ["baseline"],
+                  "config": CONFIG, "commitMessage": "Baseline router: taxonomy + JSON schema"})
+    print(f"  v{v1.get('version')} created (baseline)")
+    v2 = _create({"name": NAME, "type": "text", "prompt": V2, "labels": ["production"],
+                  "config": CONFIG,
+                  "commitMessage": "Few-shot + confidence calibration; promote to production"})
+    print(f"  v{v2.get('version')} created, labels={v2.get('labels')}")
+    print("Done. The router will use label=production; vary it in the experiment (v1 vs production).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Promotes **routing / classification-dispatch** into a thin new front-door demo,
`demos/query-router/`, that makes the router decision the star. It classifies a
question and dispatches over HTTP to three EXISTING demos as specialized
handlers, with confidence-threshold gating, an in-process fallback, and HITL
escalation:

| Route | Handler | Tier |
|---|---|---|
| `analytics_sql` | text-to-sql :8002 | live numbers (MCP catalog) |
| `docs_simple` | vector-rag :8003 | cheap single-shot doc lookup |
| `docs_complex` | agentic-rag :8006 | expensive self-correcting CRAG |
| `fallback` | in-process | out-of-scope / low-confidence / malformed / handler-down → best-effort + escalation |

Routing already existed *embedded* inside `agentic-rag` (`route_node`) and
`brand-promo-multi-agent` (`_classify_intent_node`); this puts confidence,
misroute scores, and a router experiment on the marquee instead.

### Two added `server.py` wrappers (closes a latent repo inconsistency)

`demos/text-to-sql/` and `demos/vector-rag/` had **no HTTP endpoint** (ports
8002/8003 mapped but nothing listened; agentic-rag's docstring already claimed
otherwise). This adds a ~45-line FastAPI `server.py` to each (lazy pipeline
singleton, `/health`, `/query`), gives both an explicit
`command: uvicorn server:app` in compose, and updates the text-to-sql honesty
note + agentic-rag docstring. **CLI mode (`python main.py`) is unchanged.**

## File tree

```
demos/query-router/                 NEW demo (container, host :8008)
  router.py            classify -> {route, confidence, rationale}; confidence gate
  handlers.py          route registry + HTTP dispatch + in-process fallback + escalation
  server.py            FastAPI /health + /query; run() = classify -> dispatch under one trace
  main.py              CLI batch (10 questions, every route + edge cases) + --interactive
  langfuse_config.py   v3 wiring (observe/scores/managed prompt/trace_context) — no-ops w/o keys
  scripts/score_misroute.py   record routing_correct as a POST-HOC score (+ pin to dataset)
  tests/               classifier / gating / dispatch / fallback / server (HTTP + Anthropic stubbed)
  Dockerfile · requirements.txt · requirements-dev.txt · pytest.ini · README.md · DEMO_SCRIPT.md

demos/text-to-sql/server.py         NEW  (makes :8002 serve /query; CLI unchanged)
demos/vector-rag/server.py          NEW  (makes :8003 serve /query; CLI unchanged)
demos/agentic-rag/{server,graph}.py MOD  trace_context passthrough -> nests under router (standalone unchanged)

scripts/seed-router-prompt.py       NEW  query-router-classifier v1 (baseline) + v2 (production)
scripts/seed-router-dataset.py      NEW  query-router-accuracy (~30 items) + --dry-run
scripts/run-router-experiment.py    NEW  vary ONLY the router; --sample/--label/--model/--e2e/--ci
scripts/seed-router-history.py      NEW  ~300 backdated traces / 14 days (drift + fallback + scores)
scripts/seed-router-judge.sh        NEW  categorical route-plausibility judge (sampling 0.25)
evaluators/route-match.ts           NEW  deterministic exact-match (route-match BOOLEAN + route-chosen CATEGORICAL)
scripts/seed-code-evaluators.sh     MOD  register route-match on the router dataset

docker-compose.yaml                 MOD  query-router service + uvicorn command on text-to-sql/vector-rag
.env.example                        MOD  QUERY_ROUTER_PORT / ROUTER_MODEL / ROUTER_CONFIDENCE_THRESHOLD / ROUTER_FAULT
demos/README.md · AI_ENGINEERING_LOOP.md · demos/text-to-sql/DEMO_SCRIPT.md   MOD  docs
```

## How the routing decision / confidence / misroute is visible in Langfuse

- **Router decision** — a `route-query` **generation** whose output is
  `{route, confidence, rationale}`, with `metadata.route` duplicated for
  dashboard dimensioning and a `prompt=` link to `query-router-classifier`.
- **Confidence** — a runtime `router_confidence` NUMERIC score on that
  observation (chartable, filterable — sort ascending to curate the dataset).
- **One trace, distributed** — `route-and-dispatch` (tags `[query-router, demo]`)
  shows the router decision AND exactly one `dispatch-<route>` agent span with
  the chosen handler's full existing subtree nested beneath it (SDK v3
  `trace_context={trace_id, parent_span_id}` in the handler POST body).
- **Fallback / HITL** — a `fallback-handler` generation + an `escalate-to-human`
  **event** carrying a machine-readable `reason` (`low_confidence | out_of_scope
  | unknown_route | malformed_output | handler_unreachable`).
- **Misroute** — recorded as a POST-HOC `routing_correct` (BOOLEAN) score on the
  `route-query` observation via `create_score` — never a retroactive tag (tags
  are immutable at creation). Fed into `query-router-accuracy` via
  `source_observation_id`.
- **Router Ops dashboard** — route-distribution-over-time (drift), fallback rate,
  avg confidence, misroute rate — seeded with 14 days of history so the widgets
  render on day one.

## Test plan

Validation ran in an isolated venv (langfuse 3.7.0, anthropic, fastapi, httpx,
pydantic, pytest); the shared Docker stack was NOT started (five agents share
this machine — downstream HTTP is stubbed, not live).

- `python -m py_compile` — all 18 new/changed `.py` files: **pass**.
- `pytest` on `demos/query-router/tests/` — **18 passed**: classifier
  (clear/low-confidence/out-of-scope/unknown-route/malformed/fenced-JSON/
  sql-blindness-fault/model-override), dispatch (success/unreachable/HTTP-error/
  fallback-no-HTTP), registry-keys-match-ROUTES, server `run()` merge, `/query`
  + `/health` via TestClient — all with Anthropic + `httpx` stubbed.
- FastAPI construct probes — `text-to-sql`, `vector-rag`, `agentic-rag`
  `server.py` each import, build the app, and answer `/health` + `/query`
  (incl. `trace_context` passthrough) with the heavy pipelines stubbed: **pass**.
- `route-match.ts` — ran under Node 24 type-stripping with 4 assertions
  (match/mismatch/no-experiment/stringified-JSON): **pass**.
- `docker-compose.yaml` — parses; `query-router` service present with correct
  ports/profile/depends_on/env; `text-to-sql` + `vector-rag` have the uvicorn
  `command`: **pass**.
- `bash -n` on `seed-router-judge.sh` + `seed-code-evaluators.sh`: **pass**.
- CLI scripts — `--help`/import smoke on dataset/history/experiment/score_misroute:
  **pass**; `seed-router-prompt.py` (no argparse) executed against the
  already-running local Langfuse and successfully seeded `query-router-classifier`
  v1+v2 — confirming the urllib/API path end-to-end.

Not run (needs the live stack / DB — out of scope per constraints): live HTTP
dispatch across services, the Postgres-seeded `route-plausibility` judge
(schema-coupled; guarded to print UI guidance on mismatch), and the Router Ops
dashboard render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
