### PR TITLE
demos: add slow-query-tuner (Pattern 7 — autonomous agent loop)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,13 @@ LITELLM_UPSTREAM_MODEL=anthropic/claude-sonnet-4-6
 # Dedicated ClickHouse (26.3) for the Agentic RAG native vector store
 CLICKHOUSE_VECTORS_HTTP_PORT=8125
 
+# Slow Query Tuner demo (Pattern #7 — autonomous agent loop)
+CLICKHOUSE_TUNING_HTTP_PORT=8126
+TUNER_MAX_TURNS=15               # backstop only — the agent normally stops itself first
+TUNER_MAX_BUDGET_USD=0.75        # backstop only — never remove, per the pattern guide
+TUNER_WATCHDOG_S=600
+TUNER_COMPACT_AFTER=6
+
 # Dashboard Settings
 DASHBOARD_CACHE_TTL=60
 

--- a/AI_ENGINEERING_LOOP.md
+++ b/AI_ENGINEERING_LOOP.md
@@ -34,6 +34,7 @@ it across the whole stack.
 | `librechat/` | Shared chat frontend | LibreChat native Langfuse tracing |
 | `demos/real-estate/` | Self-contained agentic concierge — the loop shown end-to-end in one place | Langfuse SDK |
 | `demos/brand-promo-multi-agent/` | Multi-agent promo-planning assistant (standalone): synthetic history, online + offline evals, persona dashboards | LangGraph + CrewAI + Langfuse `CallbackHandler` |
+| `demos/slow-query-tuner/` | Autonomous agent loop: open-ended query optimization against a live ClickHouse lab (Pattern #7) | Raw Anthropic tool-use + Langfuse SDK (typed observations) |
 
 ## Where each loop step lives
 
@@ -82,6 +83,36 @@ trace → monitor → dataset → experiment (models **and** prompts) → evalua
 **deploy a prompt by label** → repeat — with a presenter runbook. Start there to
 see the whole loop close in ~20 minutes, then map the same pattern onto the main
 stack using the table above.
+
+## The loop for an autonomous agent — `demos/slow-query-tuner/`
+
+Pattern #7 (open-ended plan-act-observe) maps onto the loop differently from a
+bounded pipeline, because the step count is agent-decided:
+
+- **Trace** — a variable-depth `tune-clickhouse-query` trace: `plan-next-action`
+  (generation) → `run-query`/`explain-query`/… (tool) → `assess-progress`
+  (evaluator), repeated as many times as the *agent* chooses. Short vs long runs
+  look visibly different in the Agent Graph Expanded view; the Aggregated view
+  collapses the loop to one cycle. Pause/resume reuses one `session_id`.
+- **Monitor** — the **headline**: a `max(totalCost)` Monitor on the trace name
+  catches runaway loops burning tokens (the `--runaway` beat trips it); a second
+  Monitor on the `turns_used` score catches "self-assessment failed, the backstop
+  stopped it". (Monitors are a Langfuse v4+ feature — `scripts/seed_monitors.py`
+  prints the exact UI fields on this v3 stack.)
+- **Datasets** — `query-tuner/goals`, ROOT-LEVEL items only (goal in, completion
+  criteria out): the same goal yields different valid trajectories, so per-step
+  ground truth would be actively wrong.
+- **Experiment** — `scripts/run_experiment.py` varies one component (system-prompt
+  `v1-naive` vs `v2-disciplined`) with caps + tool list pinned; outcome-graded
+  (pass_rate / avg_cost / avg_turns / cap_hit_rate), `--ci` gate.
+- **Evaluate** — step-level code scores on live observations
+  (`semantics_preserved`, `improvement_delta`), an app-assembled trajectory score
+  set (`turns_used`, `run_cost_usd`, `verified_speedup`, `task_completed`,
+  `trajectory_efficiency`), the deterministic `runaway-loop-guard.ts` code
+  evaluator, and an independent managed `goal_drift` judge.
+- **Deploy** — both system-prompt versions are Langfuse-managed;
+  `v2-disciplined` carries the `production` label (flipping the label is the
+  deploy beat, reused as the Experiment's variable).
 
 ## Honest scope (what's live vs documented)
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,6 +1,6 @@
 # Demos
 
-Seven independently runnable demos, each building on the same ClickHouse-backed
+Eight independently runnable demos, each building on the same ClickHouse-backed
 Langfuse stack. The container demos share the platform at the repo root
 (`docker-compose.yaml`, `setup.sh`, `scripts/`, `evaluators/`, `mcp-*/`); the
 standalone demos bring their own toolchain. For how they map to the AI
@@ -15,6 +15,7 @@ Engineering loop, see [`../AI_ENGINEERING_LOOP.md`](../AI_ENGINEERING_LOOP.md).
 | **[real-estate](real-estate/)** | Self-contained agentic concierge — the whole loop end-to-end in one place | ALL 5 + Deploy | `cd demos/real-estate && ./run_demo.sh` then `./run_portal.sh` · client script: [`DEMO_SCRIPT.md`](real-estate/DEMO_SCRIPT.md) |
 | **[brand-promo-multi-agent](brand-promo-multi-agent/)** | Multi-agent promo-planning assistant (LangGraph + CrewAI): synthetic history, online + offline evals, persona dashboards | Trace · Datasets · Experiment · Evaluate · Deploy | see [`DEMO_SCRIPT.md`](brand-promo-multi-agent/DEMO_SCRIPT.md) (client script) or [README](brand-promo-multi-agent/) |
 | **[langfuse-rls](langfuse-rls/)** | Attribute-based row-level-security prototype over Langfuse traces (Next.js): trace governance / access control | Governance (adjacent to the loop) | `cd demos/langfuse-rls && npm install && npm run dev` · client script: [`DEMO_SCRIPT.md`](langfuse-rls/DEMO_SCRIPT.md) |
+| **[slow-query-tuner](slow-query-tuner/)** | Autonomous agent loop: open-ended query optimization against a live ClickHouse lab — the agent decides when the query is fast enough; caps + kill switch + runaway Monitor as rails | Trace · Monitor · Datasets · Experiment · Evaluate | `docker compose --profile demo run --rm slow-query-tuner python main.py --query q1` · client script: [`DEMO_SCRIPT.md`](slow-query-tuner/DEMO_SCRIPT.md) |
 
 Each demo has its own README. **text-to-sql**, **vector-rag**, **agentic-rag**,
 and **litellm-gateway** run as containers in the root `docker-compose.yaml`

--- a/demos/slow-query-tuner/DEMO_SCRIPT.md
+++ b/demos/slow-query-tuner/DEMO_SCRIPT.md
@@ -1,0 +1,240 @@
+# Slow Query Tuner — Demo Script (Autonomous Agent Loop on ClickHouse)
+
+A ready-to-run demo of an **open-ended plan-act-observe agent** that optimizes a
+slow query against a **live ClickHouse** — deciding *for itself* when it is fast
+enough — fully observable in **Langfuse**, with caps, a kill switch, and a
+runaway-cost Monitor as the rails.
+
+- **Environment the agent acts on:** a disposable **ClickHouse 26.3** container
+  (`clickhouse-tuning`) with a deliberately pessimal 30M-row table
+- **Agent:** a raw Anthropic tool-use loop (`agent_loop.py`) — `plan → tool →
+  assess ↺`, step count agent-decided (2–15+)
+- **Observability backend:** Langfuse (`http://localhost:3001`), trace name
+  `tune-clickhouse-query`, tag `slow-query-tuner`
+- **No chat surface — by design** (an unbounded loop with a spend cap doesn't
+  belong behind a chat box)
+- **Run length:** ~25 min full; 12-min short path is Acts 1 + 2 + 4
+
+> Everything lives in `demos/slow-query-tuner/`. The bad-query catalog is
+> `queries.py`; the loop, termination judge, HITL gate and compaction are
+> `agent_loop.py`.
+
+---
+
+## How to run this script
+
+It's a **conversation, not a walkthrough**. Every act **frames** a problem the
+room already has, **shows** how the platform answers it, **lands** the benefit,
+then hands a **question** back to the room:
+
+- **Frame** — the problem, in their terms (say it *before* you touch the screen).
+- **Show** — the exact commands / clicks.
+- **Land** — the "so what": the benefit, not the feature.
+- **Ask** — an open question that maps it to their world.
+
+The short path is Acts 1 + 2 + 4 (the variable loop + the runaway/Monitor beat).
+Add 3, 5, 6 when there's appetite. Every act ends with a **Fallback** note —
+ingestion is async and the loop is non-deterministic, so have the fallback ready.
+
+---
+
+## 0 · Pre-flight (do this BEFORE the meeting)
+
+```bash
+# CRITICAL: clear leaked Langfuse keys — exported shell vars override .env and 401 silently.
+unset LANGFUSE_PUBLIC_KEY LANGFUSE_SECRET_KEY
+
+# Langfuse (+ its ClickHouse) and the disposable tuning lab (seeds ~30M rows in seconds).
+docker compose --profile langfuse up -d
+docker compose --profile demo up -d clickhouse-tuning
+docker compose --profile demo build slow-query-tuner
+
+# Confirm the lab is seeded (expect ~30,000,000).
+docker exec clickhouse-tuning clickhouse-client --user tuner_admin --password tuner_admin123 \
+  --query "SELECT count() FROM tuning_lab.web_events"
+
+# Prompts (v1-naive + v2-disciplined/production), root-level dataset, and MONITORS.
+docker compose --profile demo run --rm slow-query-tuner python scripts/seed_all.py
+./scripts/seed-code-evaluators.sh            # includes runaway-loop-guard.ts
+./scripts/seed-query-tuner-evaluators.sh      # the managed goal_drift judge
+
+# Clear any stale kill sentinels from a previous rehearsal.
+rm -f demos/slow-query-tuner/checkpoints/*.kill
+
+# Warm ingestion: one throwaway q1 run now.
+docker compose --profile demo run --rm slow-query-tuner python main.py --query q1
+```
+
+**Monitors caveat (read this).** Monitors are a Langfuse **v4+** feature; this
+stack pins Langfuse v3, so `seed_all.py` **prints the exact UI field values** for
+the two Monitors instead of creating them. If you want the live "alert fires on
+stage" beat, create them by hand in **Monitors → New Monitor** from those printed
+values before the meeting. If you can't, Act 4's Fallback (runaway cost vs a
+normal run, side by side) still lands the point.
+
+**Browser tabs ready:** Langfuse Traces (`:3001`, `demo@example.com` /
+`demodemo1!`), a pinned q1 trace (Agent Graph → Expanded), the Sessions view, and
+Monitors.
+
+---
+
+## Opening · Frame (no screen)
+
+"Yesterday's demos were workflows — the code knew the path. Today the code does
+**not** know the path. I'm going to hand an agent a slow query and a target, and
+it will decide how many steps it takes and when it's done. The question every one
+of you is already asking: *how do you let an agent decide when it's finished — and
+still sleep at night?* Three rails: verified self-termination, caps as a backstop,
+and a Monitor watching the fleet. Let's watch."
+
+---
+
+## Act 1 · The agent does an SA's job (short run)
+
+- **Frame.** "This is the job you'd hand a junior SA: here's a slow query, make it
+  5x faster, don't change what it returns. Nobody tells the agent *how*."
+- **Show.**
+  ```bash
+  docker compose --profile demo run --rm slow-query-tuner python main.py --query q1
+  ```
+  Narrate the live turns: `plan → explain-query` (full scan, String date parsed
+  per row) → `plan → run-query` (measured, e.g. 4.1s → 0.4s, equivalence ok) →
+  `plan → finish`. Call out the last line: **the controller re-ran the final SQL
+  itself and confirmed the speedup** before accepting.
+- **Land.** "Nobody told it three turns. The ground truth is the real ClickHouse
+  timing — it *cannot* claim a speedup it didn't measure, and I re-check the claim
+  independently. That's the difference between an agent that says it's done and
+  one that *is* done."
+- **Ask.** "What's your equivalent open-ended task — the one where the steps
+  genuinely aren't knowable up front?"
+- **Fallback.** If q1 self-terminates in 2 turns, great — that's the point (the
+  agent found it was already fast enough after one rewrite). If a turn hits an env
+  hiccup, note it surfaced as a `WARNING` observation and the loop continued.
+
+## Act 2 · Same code, different shape (long run + the graph)
+
+- **Frame.** "Same code, harder query. Watch the shape of the work change."
+- **Show.**
+  ```bash
+  docker compose --profile demo run --rm slow-query-tuner python main.py --query q2
+  ```
+  While it runs, open the q1 trace in Langfuse → **Agent Graph → Expanded**. When
+  q2 lands, put them **side by side**: a 3-node chain vs a 9-node chain, *same
+  trace name*. Then flip q2 to **Aggregated** — the loop collapses to
+  `plan-next-action → {tool} → assess-progress ↺` with repeat counts. Point at the
+  `semantics_preserved` span score going **red then green** on the turn the DB
+  rejected a candidate, and open a late `plan-next-action` **input** to show the
+  **compacted** turn summary ("turn 3: PREWHERE rewrite, 1.9s→0.9s, equiv ok").
+- **Land.** "Variable-length loops are unreadable as logs and legible as graphs —
+  Expanded to debug one run, Aggregated to answer *what does this agent do overall*
+  when the step count is unbounded. And it's all on ClickHouse."
+- **Ask.** "When your agents misbehave today, are you reading logs — or can you
+  see the shape of what they did?"
+- **Fallback.** q2's turn count varies run to run — **say so out loud**; that
+  variability *is* the pattern. If it self-terminates fast, re-run; if it's slow,
+  narrate the plateau while you talk.
+
+## Act 3 · Pause/resume (the sessions beat)
+
+- **Frame.** "Unbounded loops crash, or you kill them. Does your observability
+  survive the process dying?"
+- **Show.** Start `--query q2`; at ~turn 4 press **Ctrl-C**. It prints a checkpoint
+  message + a resume command. Then:
+  ```bash
+  docker compose --profile demo run --rm slow-query-tuner python main.py --resume <run_id>
+  ```
+  It restores and completes. Open **Sessions**: two traces, **one session**, the
+  full investigation replayed end to end.
+- **Land.** "State plus a reused `session_id` means the investigation is one
+  continuous thing in Langfuse, even though it spanned two processes."
+- **Ask.** "How do you resume — or even reconstruct — a long agent run today after
+  a restart?"
+- **Fallback.** If Ctrl-C timing is fiddly, use the kill switch instead:
+  `touch demos/slow-query-tuner/checkpoints/<run_id>.kill` mid-run.
+
+## Act 4 · The runaway — and the alert (THE beat)
+
+- **Frame.** "The pattern's nightmare is a \$400 overnight loop that never
+  stops. We're going to *cause* one — on purpose — and watch the rails catch it."
+- **Show.**
+  ```bash
+  docker compose --profile demo run --rm slow-query-tuner python main.py --runaway
+  ```
+  This pins the **naive v1 prompt** (no give-up rule), retargets q3 to an
+  impossible **50 ms**, raises the caps, and tags the trace `fault:runaway`.
+  Fast-scroll the churn: rewrite after rewrite, every `finish(success)` claim
+  **rejected** by the controller because it can't hit 50 ms. The app-side backstop
+  kills it at **`error_max_budget_usd`**. Now open Langfuse → **Monitors**: the
+  **"query-tuner runaway cost"** Monitor is in **alert** (warn/alert bands on the
+  cost chart); show the **"query-tuner turn count"** Monitor and the
+  `cap_terminated` score next to it.
+- **Land.** "The app-side cap saved *this* run locally. The Monitor — aggregating
+  in ClickHouse — is what tells you it *almost* happened, and whether it's
+  recurring across the fleet, and it renotifies until someone fixes the prompt.
+  That's the direct counterpart to 'never run an unattended loop without a cap.'"
+- **Ask.** "What would a runaway agent cost you before anyone noticed today?"
+- **Fallback.** Ingestion is async and Monitors are v4+ (see Pre-flight). If the
+  alert hasn't evaluated yet, or Monitors aren't created on this v3 stack: open the
+  runaway trace and a normal q1 trace and put their **total cost** side by side
+  (cents vs dollars), and show the `cap_terminated` / `turns_used` scores. Return
+  to the Monitor at Q&A.
+
+## Act 5 · Blocked ≠ failed (the HITL gate)
+
+- **Frame.** "Sometimes the honest answer is *this needs a schema change* — and an
+  agent shouldn't make irreversible changes on its own."
+- **Show.**
+  ```bash
+  docker compose --profile demo run --rm slow-query-tuner python main.py --query q3
+  ```
+  The agent exhausts rewrites (a needle query on an unsorted 30M-row table), then
+  calls `propose_ddl` with a projection + a rationale. **The terminal pauses for
+  y/n.** Approve it — the projection is applied through the *admin* connection (the
+  agent's own user can't), and a re-run meets the target →
+  `termination_reason=self_completed`. (Mention: deny → honest `self_gave_up`,
+  still a *good* termination.)
+- **Land.** "The agent knows the difference between 'I'm done,' 'I can't,' and 'I
+  need a human' — and each is a distinct, scored `termination_reason` you can chart
+  across the fleet."
+- **Ask.** "Where's the line in your world between what an agent may do and what
+  needs a human hand on the switch?"
+- **Fallback.** For an unattended rehearsal, add `--auto-approve-ddl` (approve) or
+  `--auto-deny-ddl` (the honest give-up). Materializing the projection on 30M rows
+  takes a few seconds — narrate it.
+
+## Act 6 (bonus) · Prove the prompt, don't vibe it
+
+- **Frame.** "We changed the prompt to add a give-up rule. Did it actually help,
+  or does it just feel better?"
+- **Show.**
+  ```bash
+  docker compose --profile demo run --rm slow-query-tuner python scripts/run_experiment.py --sample 2
+  ```
+  Two arms — `v1-naive` vs `v2-disciplined` — with **caps and the tool list pinned
+  identically**, so any delta is the prompt. Show `pass_rate`, `avg_turns`,
+  `avg_cost`, `cap_hit_rate`, and the `goal_drift` judge column in Langfuse →
+  Datasets → `query-tuner/goals` → Runs.
+- **Land.** "Outcome-graded — never step-matched, because the same goal has many
+  valid paths. Discipline in the prompt is *measurable*. Flip the `production`
+  label to that prompt and you've deployed it with no code change — the full
+  AI-engineering loop on one demo."
+- **Ask.** "How do you decide a prompt change is safe to ship today?"
+- **Fallback.** A full 3-item, 2-arm run is real API spend and minutes long; use
+  `--sample 1` to rehearse, and pre-run it so the Runs tab is populated.
+
+---
+
+## Appendix — what to point at in the trace
+
+| Beat | Where in Langfuse |
+|---|---|
+| Variable-length loop | Agent Graph **Expanded** (per run) vs **Aggregated** (the cycle) |
+| Ground truth | each `run-query` tool span output: `elapsed_ms`, `read_rows`, `result_signature` |
+| Self-termination verified | the `finish` span + `controller_verified` in its output |
+| Per-turn correctness | span scores `semantics_preserved` (red→green), `improvement_delta` |
+| Compaction | a late `plan-next-action` **input** (the folded turn summaries) |
+| Termination reasons | trace metadata `termination_reason` + the `cap_terminated` / `termination_class` scores |
+| Trajectory scores | trace scores `turns_used`, `run_cost_usd`, `verified_speedup`, `task_completed`, `trajectory_efficiency` |
+| Goal drift | the managed `goal_drift` judge score on the trace root |
+| Runaway | the `fault:runaway` trace + the cost/turn Monitors |
+| Pause/resume | Sessions view — two traces, one `qtune-…` session |

--- a/demos/slow-query-tuner/Dockerfile
+++ b/demos/slow-query-tuner/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl gcc python3-dev && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+# No HTTP server — this is a CLI agent. Compose passes the real command, e.g.:
+#   docker compose --profile demo run --rm slow-query-tuner python main.py --query q1
+# Default prints usage so an accidental bare run never spends on the API.
+CMD ["python", "main.py", "--help"]

--- a/demos/slow-query-tuner/README.md
+++ b/demos/slow-query-tuner/README.md
@@ -1,0 +1,175 @@
+# Slow Query Tuner — Autonomous Agent Loop (Pattern #7)
+
+An open-ended plan-act-observe agent handed a ClickHouse SA's bread-and-butter
+task: *"Here is a slow query. Make it at least 5x faster without changing what it
+returns. You decide how."*
+
+The agent runs a genuinely variable-length loop against a **live ClickHouse
+instance**: it `EXPLAIN`s the query, inspects the schema, rewrites the SQL,
+**executes each candidate for real and reads back the actual elapsed time / rows
+read / bytes read as ground truth**, verifies result-set equivalence with a
+deterministic probe, and keeps iterating — 3 turns for an easy query, 9+ for a
+hard one, **nobody knows in advance** — until *it* decides the target is met, the
+task is structurally blocked (and it proposes DDL through a human-approval gate),
+or a budget/turn/wall-clock backstop forcibly ends the run.
+
+This is the contrast demo to the repo's bounded loops (`real-estate` is
+`MAX_ITERS=5` single-turn Q&A; `agentic-rag` is a predefined graph). Here **the
+agent decides when it is done**, and the caps are a backstop, not the design.
+
+The ClickHouse double punchline: the *environment the agent acts on* is
+ClickHouse (real timings — the agent cannot hallucinate a speedup), and the
+*observability backend judging the agent* is ClickHouse (Langfuse v3).
+
+## What it demonstrates
+
+| Capability | How |
+|---|---|
+| **Open-ended autonomous loop** | Raw Anthropic tool-use API; the model emits one tool call per turn, no code path dictates the sequence. Step count 2–15+, run to run. |
+| **Environment ground truth** | Every `run-query` returns *measured* `elapsed_ms` / `read_rows` / `read_bytes` + a result signature from a live ClickHouse. Progress is validated against reality, not the model's text. |
+| **Result-equivalence probe** | An order-independent sha256 signature of the result set; the DB arbitrates equivalence. A rewrite that got fast by returning different rows fails `semantics_preserved`. |
+| **Self-assessed termination, verified** | The agent calls `finish`; the controller **independently re-executes** the final SQL + equivalence probe (median of 3) and rejects a false claim, bouncing it back as the next observation. |
+| **Backstops, not termination** | `MAX_TURNS`, `MAX_BUDGET_USD` (from real Anthropic usage), a wall-clock watchdog, and a kill sentinel. A run ending on one is recorded as a *failure mode* (`error_max_*` / `killed`). |
+| **Pause/resume as a session** | State checkpoints every turn; `--resume <run_id>` restores it in a fresh process reusing the same `session_id`, so Langfuse stitches both traces into one investigation. |
+| **HITL for irreversible actions** | `propose_ddl` pauses for human y/n; DDL runs only through a separate admin connection after approval. The read-only `tuner_agent` cannot write. |
+| **Runaway-cost Monitor** | `--runaway` deliberately trips the spend cap; a seeded Monitor on `max(totalCost)` per trace crosses its alert threshold. |
+| **First-class scores** | Trace scores `turns_used`, `run_cost_usd`, `verified_speedup`, `task_completed`, `trajectory_efficiency`; span scores `semantics_preserved`, `improvement_delta`; a managed `goal_drift` judge. |
+
+## Who it's for
+
+ClickHouse SAs and their prospects. Every prospect has a slow query; watching an
+agent do the SA's own job — safely, with rails you can point to — is the hook.
+The demo's opening frame is *"yesterday's demos were workflows; today the code
+does not know the path — how do you let an agent decide when it's done and still
+sleep at night?"*
+
+## Quick start
+
+```bash
+# 1. Bring up the disposable tuning lab (seeds ~30M rows in seconds) + build the app.
+docker compose --profile demo up -d clickhouse-tuning
+
+# 2. Seed managed prompts + the root-level dataset + monitors (idempotent).
+docker compose --profile demo run --rm slow-query-tuner python scripts/seed_all.py
+
+# 3. Run the agent on a query from the catalog.
+docker compose --profile demo run --rm slow-query-tuner python main.py --query q1   # short, self_completed
+docker compose --profile demo run --rm slow-query-tuner python main.py --query q2   # long (env error + plateau)
+docker compose --profile demo run --rm slow-query-tuner python main.py --query q3   # blocked -> propose_ddl (HITL)
+
+# 4. Trip the cost cap on purpose (the Monitor beat).
+docker compose --profile demo run --rm slow-query-tuner python main.py --runaway
+
+# Ad-hoc query:
+docker compose --profile demo run --rm slow-query-tuner python main.py --sql "SELECT ..." --target-ms 500
+```
+
+`setup.sh` runs step 2 automatically (guarded, idempotent, non-fatal).
+
+The demo **degrades gracefully with no Langfuse keys**: the loop still runs; all
+instrumentation no-ops.
+
+## The bad-query catalog
+
+| Id | Query (sins) | target | Designed outcome |
+|---|---|---|---|
+| **q1** easy | daily uniques for June: `count(DISTINCT user_id)` + `toDate(parseDateTimeBestEffortOrNull(ts_raw))` in WHERE | 800 ms | 2–4 turns; `event_date` + `uniq()`; clean **self_completed** (short-trace money shot) |
+| **q2** medium | top-10 URLs by avg duration, one country + month: `SELECT *` subquery, `lower(country)='us'`, string-date parse, global `ORDER BY` | 800 ms | 5–10 turns incl. an env error (memory limit) and a plateau; **self_completed** (long-trace + pause/resume vehicle) |
+| **q3** blocked | needle: one `user_id`, one date — physically needs a sort key/projection | 800 ms | agent exhausts rewrites → `propose_ddl(ADD PROJECTION …)` → **HITL** (approve → met; deny → honest `self_gave_up`). `--runaway` retargets to 50 ms + naive prompt → **error_max_budget_usd** |
+
+## How the loop is visible in Langfuse
+
+- **Agent Graph Expanded** — one run's exact think-act-observe sequence. q1 (3-node
+  chain) vs q2 (9-node chain) under the *same* trace name is the pattern's
+  defining visual.
+- **Agent Graph Aggregated** — the loop collapses to `plan-next-action → {tool} →
+  assess-progress ↺` with repeat counts: how you read an agent whose step count
+  is unbounded.
+- **Sessions** — a run paused (`termination_reason=killed`) and resumed share one
+  `session_id`, replayed as a single investigation.
+- **Monitors** — `max(totalCost)` per trace (runaway) and `max(turns_used)`
+  (backstop-stopped) across the fleet.
+
+## Why per-step datasets are the wrong call here
+
+The `query-tuner/goals` dataset has **root-level items only**: `input` = the goal,
+`expected_output` = completion *criteria*, never a step sequence. The same goal
+legitimately yields different valid trajectories run to run (PREWHERE-first or
+predicate-fix-first both reach the target). A per-step dataset would enshrine one
+arbitrary trajectory as "correct" and score a *better, shorter* path as a failure.
+Task completion belongs on the **root** of the trace. (Step-level *code* checks on
+live traces are still fine — see `semantics_preserved` / `improvement_delta`.)
+
+## When NOT to hand a pattern to end users
+
+There is **deliberately no LibreChat agent** for this demo. An unbounded loop with
+a spend cap does not belong behind a chat box where a user can fire it repeatedly;
+it belongs behind an operator-run CLI with explicit caps and a kill switch. That
+choice is itself part of the pattern's guardrail story.
+
+## Safety rails (the guardrail layer)
+
+- **Sandboxed identity**: the agent connects as `tuner_agent` — `SELECT` only,
+  `readonly=2` (may `SET` per-query settings, cannot write), quotas
+  `max_execution_time=30`, `max_memory_usage=4G`, `max_result_rows=10k`.
+- **App-side SQL-shape allow-list** (SELECT/WITH/EXPLAIN/SHOW, single statement)
+  in front of the grants — defense in depth, and clean error-as-observation.
+- **Dedicated throwaway container** (`clickhouse-tuning`) — blast radius = one lab.
+  Langfuse's own ClickHouse is never touched.
+- **DDL only through the human gate** — a separate `tuner_admin` connection is
+  opened *only* inside the approved `propose_ddl` path.
+- **Caps + kill switch** — env-tunable, never removable.
+
+## Files
+
+```
+main.py            CLI: --query / --sql / --runaway / --resume / --interactive / cap overrides
+agent_loop.py      THE PATTERN: plan-act-observe controller, finish-claim verification, HITL gate, compaction
+tools.py           six tool schemas + dispatcher (run_query, explain_query, get_schema, check_equivalence, propose_ddl, finish)
+ch_env.py          environment interface: tuner_agent (RO) + tuner_admin (DDL gate) clients, allow-list, timing, signatures
+budget.py          turn/cost/wall-clock caps + kill sentinel; Anthropic price table
+checkpoint.py      LoopState + per-run JSON state (save every turn; --resume reuses session_id)
+queries.py         bad-query catalog (q1/q2/q3) + expected-turn bands
+prompts.py         managed prompts (query-tuner-system v1/v2, query-tuner-goal) + local fallbacks
+langfuse_config.py v3 wiring (typed observe(), trace_context(), scores, get_prompt(), flush())
+sql/init/          tuning-lab schema, 30M-row seed, sandboxed users/grants
+scripts/           seed_prompts / seed_dataset / seed_monitors / seed_all / run_experiment / run_live_demo
+tests/             LLM-free + DB-free (budget, termination, checkpoint, ch_env)
+DEMO_SCRIPT.md     presenter runbook (Frame/Show/Land/Ask)
+```
+
+Root-level companions: `evaluators/runaway-loop-guard.ts` (seeded by
+`scripts/seed-code-evaluators.sh`) and `scripts/seed-query-tuner-evaluators.sh`
+(the managed goal-drift judge).
+
+## Configuration
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `TUNER_MAX_TURNS` | 15 | backstop only |
+| `TUNER_MAX_BUDGET_USD` | 0.75 | backstop only (real Anthropic usage) |
+| `TUNER_WATCHDOG_S` | 600 | wall-clock backstop |
+| `TUNER_COMPACT_AFTER` | 6 | compact turns older than this into summaries |
+| `CLICKHOUSE_TUNING_HTTP_PORT` | 8126 | host port for the tuning lab |
+| `ANTHROPIC_MODEL` | claude-sonnet-4-6 | the policy model |
+| `TEMPERATURE` | 0.2 | |
+
+## Testing
+
+```bash
+pip install -r requirements-dev.txt
+pytest            # LLM-free + DB-free: caps trip at boundaries, finish-claim
+                  # verification, checkpoint round-trip, SQL allow-list
+```
+
+## Notes / caveats
+
+- **Monitors are a Langfuse v4+ feature.** This stack pins Langfuse v3, which has
+  no Monitors API, so `scripts/seed_monitors.py` prints the exact UI field values
+  to paste into **Monitors → New Monitor**. Everything else (traces, scores,
+  sessions, agent graph, code evaluators, the managed judge) is native on v3.
+- **Cost calibration.** The runaway thresholds ($0.40 warn / $1.00 alert; caps
+  raised to $2.50) are spec defaults. Do one calibration pass against real Sonnet
+  pricing and bake the final numbers into `seed_monitors.py`.
+- **Non-determinism is the point.** q2's turn count varies run to run — say so out
+  loud; that variability *is* the pattern.

--- a/demos/slow-query-tuner/agent_loop.py
+++ b/demos/slow-query-tuner/agent_loop.py
@@ -272,7 +272,18 @@ def run(goal: Dict[str, Any], *, caps: Optional[budget.Caps] = None,
                         resp = _client().messages.create(
                             model=model, system=system_text, tools=tool_schemas,
                             messages=state.compacted_messages(compact_after),
-                            max_tokens=2000, temperature=TEMPERATURE)
+                            max_tokens=2000, temperature=TEMPERATURE,
+                            # The loop's contract is ONE tool call per turn
+                            # (extract_tool_call only dispatches the first
+                            # tool_use block and appends exactly one
+                            # tool_result). Without disabling parallel tool
+                            # use, the model can emit 2+ tool_use blocks in a
+                            # single turn; the extra block(s) get silently
+                            # dropped (never dispatched, never scored) and the
+                            # dangling tool_use id corrupts the message
+                            # history, crashing the NEXT call with a 400
+                            # ("tool_use ids were found without tool_result").
+                            tool_choice={"type": "auto", "disable_parallel_tool_use": True})
                     except Exception:
                         # Checkpoint already holds the last completed turn; surface
                         # the failure so the operator can --resume.

--- a/demos/slow-query-tuner/agent_loop.py
+++ b/demos/slow-query-tuner/agent_loop.py
@@ -222,6 +222,10 @@ def run(goal: Dict[str, Any], *, caps: Optional[budget.Caps] = None,
     """Execute (or resume) one tuning run as a single Langfuse trace."""
     caps = caps or budget.Caps()
     env = env or ch_env.TuningLabEnv()
+    # Re-read at call time (not just the import-time MODEL) so a per-run/per-arm
+    # ANTHROPIC_MODEL override (e.g. run_experiment.py's model pin) actually
+    # reaches the API call and the cost table.
+    model = os.getenv("ANTHROPIC_MODEL", MODEL)
     target_ms = int(goal["target_ms"])
     tool_schemas = tools.RUNAWAY_SCHEMAS if runaway else tools.SCHEMAS
     compact_after = 0 if runaway else COMPACT_AFTER   # runaway lets context grow (realistic)
@@ -266,7 +270,7 @@ def run(goal: Dict[str, Any], *, caps: Optional[budget.Caps] = None,
                                 input=state.compacted_messages(compact_after)) as gen:
                     try:
                         resp = _client().messages.create(
-                            model=MODEL, system=system_text, tools=tool_schemas,
+                            model=model, system=system_text, tools=tool_schemas,
                             messages=state.compacted_messages(compact_after),
                             max_tokens=2000, temperature=TEMPERATURE)
                     except Exception:
@@ -274,11 +278,11 @@ def run(goal: Dict[str, Any], *, caps: Optional[budget.Caps] = None,
                         # the failure so the operator can --resume.
                         checkpoint.save(state.run_id, state)
                         raise
-                    state.cost_usd += budget.cost_of(resp.usage, MODEL)
+                    state.cost_usd += budget.cost_of(resp.usage, model)
                     if gen is not None:
                         _root_update(gen,
                                      output=_text_of(resp) or "[tool_use]",
-                                     model=MODEL,
+                                     model=model,
                                      usage_details={"input_tokens": resp.usage.input_tokens,
                                                     "output_tokens": resp.usage.output_tokens},
                                      metadata={"turn": state.turn, "cost_so_far": round(state.cost_usd, 4),

--- a/demos/slow-query-tuner/agent_loop.py
+++ b/demos/slow-query-tuner/agent_loop.py
@@ -1,0 +1,384 @@
+"""
+THE PATTERN — an open-ended plan-act-observe controller.
+
+There is no predefined path. The agent (Anthropic tool-use API) emits ONE tool
+call per turn; no code decides the sequence. It gains ground truth from the live
+ClickHouse tuning lab on every action, and it decides FOR ITSELF when the target
+is met by calling `finish` — a claim the controller INDEPENDENTLY RE-EXECUTES
+before accepting. Turn/budget/watchdog caps and the kill switch are backstops
+only; a run ending on one of them is recorded as a failure mode.
+
+Termination reasons (trace metadata):
+  self_completed | self_gave_up | self_completed_implicit
+  blocked_hitl_denied
+  killed
+  error_max_turns | error_max_budget_usd | error_watchdog
+
+Instrumentation (per turn, low-cardinality names; turn # in metadata):
+  GENERATION plan-next-action -> TOOL <action> -> EVALUATOR assess-progress
+Five trace scores at the end + span scores (semantics_preserved, improvement_delta).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Any, Dict, List, Optional
+
+import budget
+import ch_env
+import checkpoint
+import langfuse_config as lf
+import prompts
+import tools
+from checkpoint import LoopState
+
+MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
+TEMPERATURE = float(os.getenv("TEMPERATURE", "0.2"))
+COMPACT_AFTER = int(os.getenv("TUNER_COMPACT_AFTER", "6"))
+TRACE_NAME = "tune-clickhouse-query"
+
+_anthropic = None
+
+
+def _client():
+    global _anthropic
+    if _anthropic is None:
+        import anthropic
+        _anthropic = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    return _anthropic
+
+
+@dataclass
+class Verdict:
+    ok: bool
+    measured_speedup: float = 1.0
+    measured_ms: Optional[float] = None
+    reason: str = ""
+
+
+@dataclass
+class RunResult:
+    termination_reason: str
+    verified_speedup: float
+    turns_used: int
+    cost_usd: float
+    final_sql: Optional[str]
+    summary: str
+    run_id: str
+    session_id: str
+
+
+# ------------------------------------------------------------------- HITL gate
+def hitl_approve(action: "tools.Action", mode: str) -> bool:
+    """Human-approval gate for propose_ddl. mode: prompt | auto-approve | auto-deny."""
+    if mode == "auto-approve":
+        return True
+    if mode == "auto-deny":
+        return False
+    ddl = action.args.get("ddl", "")
+    rationale = action.args.get("rationale", "")
+    print("\n" + "=" * 72)
+    print("HUMAN APPROVAL REQUIRED — the agent proposes a schema change:")
+    print(f"  Rationale: {rationale}")
+    print(f"  DDL:\n    {ddl}")
+    print("=" * 72)
+    try:
+        answer = input("Approve and apply this DDL? [y/N] ").strip().lower()
+    except EOFError:
+        return False
+    return answer in ("y", "yes")
+
+
+# --------------------------------------------------- finish-claim verification
+def verify_finish_claim(action: "tools.Action", env: "ch_env.TuningLabEnv",
+                        state: LoopState, target_ms: int) -> Verdict:
+    """Independently re-execute the agent's final SQL + equivalence probe. A
+    success claim is accepted only if the result set matches the baseline AND the
+    median measured latency meets the target. gave_up is always an acceptable
+    (honest) termination."""
+    status = action.args.get("status", "success")
+    final_sql = action.args.get("final_sql", "")
+
+    ok, reason = ch_env.sql_allowed(final_sql)
+    if not ok and status == "success":
+        return Verdict(ok=False, reason=f"final_sql {reason}")
+
+    # Measure the final SQL for real (median of 3) — the agent can't fake this.
+    samples: List[float] = []
+    last: Optional[ch_env.Obs] = None
+    for _ in range(3):
+        last = env.run_query(final_sql)
+        if not last.ok:
+            if status == "gave_up":
+                break
+            return Verdict(ok=False, reason=f"final_sql failed: {last.error}")
+        samples.append(last.elapsed_ms or 0.0)
+
+    if status == "gave_up":
+        # Conceding is a valid, honest termination. Record best speedup so far.
+        return Verdict(ok=True, measured_speedup=state.best_speedup,
+                       measured_ms=(median(samples) if samples else None),
+                       reason="agent conceded (structural blocker)")
+
+    med = median(samples) if samples else float("inf")
+    equivalent = (last is not None and last.signature == state.baseline_signature)
+    if not equivalent:
+        return Verdict(ok=False, reason="result set differs from the original query")
+    if state.baseline_ms:
+        speedup = state.baseline_ms / max(med, 0.001)
+    else:
+        speedup = 1.0
+    if med > target_ms:
+        return Verdict(ok=False, measured_speedup=speedup, measured_ms=med,
+                       reason=f"measured {med:.0f} ms > target {target_ms} ms (not met)")
+    return Verdict(ok=True, measured_speedup=speedup, measured_ms=med,
+                   reason=f"verified {med:.0f} ms <= target {target_ms} ms")
+
+
+# ------------------------------------------------------------------ summaries
+def _summary(turn: int, action: "tools.Action", obs: "ch_env.Obs") -> str:
+    if obs.is_error:
+        return f"turn {turn}: {action.span_name} -> ERROR {obs.error[:80]}"
+    if action.name == "run_query":
+        eq = "equiv ok" if obs.equivalent else "NOT equivalent"
+        return f"turn {turn}: run_query -> {obs.elapsed_ms:.0f} ms, {eq}"
+    if action.name == "explain_query":
+        return f"turn {turn}: explain_query -> plan inspected"
+    if action.name == "get_schema":
+        return f"turn {turn}: get_schema -> DDL inspected"
+    if action.name == "check_equivalence":
+        return f"turn {turn}: check_equivalence -> {'equivalent' if obs.equivalent else 'DIFFERENT'}"
+    if action.name == "propose_ddl":
+        return f"turn {turn}: propose_ddl approved -> {obs.text}"
+    return f"turn {turn}: {action.span_name}"
+
+
+def _root_update(root, **kwargs):
+    if root is not None:
+        try:
+            root.update(**kwargs)
+        except Exception:
+            pass
+
+
+# ----------------------------------------------------------------- finalize
+def finalize(root, state: LoopState, caps: budget.Caps, reason: str,
+             goal: Dict[str, Any], prompt_version: str,
+             verdict: Optional[Verdict] = None,
+             finish_summary: Optional[str] = None) -> RunResult:
+    if verdict is not None and verdict.ok:
+        state.best_speedup = max(state.best_speedup, verdict.measured_speedup)
+
+    is_error = reason.startswith("error_") or reason in ("killed", "blocked_hitl_denied")
+    turns_used = max(0, state.turn - 1) if is_error else state.turn
+    final_sql = state.best_sql
+
+    band = goal.get("expected_turn_band", [2, 12])
+    expected_hi = band[1] if band else 12
+    trajectory_efficiency = round(min(1.0, expected_hi / max(turns_used, 1)), 3)
+
+    # original_sql + summary live on the trace OUTPUT (flat) so the managed
+    # goal-drift judge (seed-query-tuner-evaluators.sh) can map to them directly.
+    summary_text = finish_summary or (verdict.reason if verdict else reason)
+    output = {"original_sql": goal.get("sql"), "final_sql": final_sql,
+              "verified_speedup": round(state.best_speedup, 2),
+              "termination_reason": reason, "summary": summary_text}
+    metadata = {"turns_used": turns_used, "cost_usd": round(state.cost_usd, 4),
+                "caps": caps.as_dict(), "prompt_version": prompt_version,
+                "run_id": state.run_id, "termination_reason": reason,
+                "plateau_turns": state.plateau}
+    _root_update(root, output=output, metadata=metadata)
+    lf.update_current_trace(output=output, metadata=metadata)
+
+    # Five first-class trace scores (Scores API).
+    lf.score_current_trace("turns_used", turns_used, data_type="NUMERIC",
+                           comment=f"reason={reason}")
+    lf.score_current_trace("run_cost_usd", round(state.cost_usd, 4), data_type="NUMERIC")
+    lf.score_current_trace("task_completed", int(reason == "self_completed"),
+                           data_type="BOOLEAN", comment=f"reason={reason}")
+    lf.score_current_trace("verified_speedup", round(state.best_speedup, 2), data_type="NUMERIC")
+    lf.score_current_trace("trajectory_efficiency", trajectory_efficiency, data_type="NUMERIC",
+                           comment=f"{turns_used} turns vs expected {band}; reason={reason}; "
+                                   f"plateau_turns={state.plateau}")
+
+    checkpoint.save(state.run_id, state)
+    lf.flush()
+
+    return RunResult(termination_reason=reason, verified_speedup=round(state.best_speedup, 2),
+                     turns_used=turns_used, cost_usd=round(state.cost_usd, 4),
+                     final_sql=final_sql, summary=(verdict.reason if verdict else reason),
+                     run_id=state.run_id, session_id=state.session_id)
+
+
+# --------------------------------------------------------------------- run
+def run(goal: Dict[str, Any], *, caps: Optional[budget.Caps] = None,
+        run_id: str, session_id: str, resume_state: Optional[LoopState] = None,
+        prompt_version: str = prompts.PRODUCTION_LABEL,
+        hitl_mode: str = "prompt", runaway: bool = False,
+        env: Optional["ch_env.TuningLabEnv"] = None) -> RunResult:
+    """Execute (or resume) one tuning run as a single Langfuse trace."""
+    caps = caps or budget.Caps()
+    env = env or ch_env.TuningLabEnv()
+    target_ms = int(goal["target_ms"])
+    tool_schemas = tools.RUNAWAY_SCHEMAS if runaway else tools.SCHEMAS
+    compact_after = 0 if runaway else COMPACT_AFTER   # runaway lets context grow (realistic)
+    tags = lf.DEFAULT_TAGS + (["fault:runaway"] if runaway else [])
+
+    system_text, system_prompt_obj = prompts.get_system_prompt(prompt_version)
+
+    # --- state: fresh or resumed ------------------------------------------
+    if resume_state is not None:
+        state = resume_state
+        state.t0 = __import__("time").monotonic()
+        state.sigint = False
+        print(f"Resumed run {run_id} at turn {state.turn} "
+              f"(cost so far ${state.cost_usd:.4f}, session {session_id})")
+    else:
+        # Measure the baseline for real — ground truth for speedup + equivalence.
+        base = env.run_query(goal["sql"])
+        baseline_ms = base.elapsed_ms if base.ok else None
+        baseline_sig = base.signature if base.ok else None
+        goal_prompt, _ = prompts.get_goal_prompt(
+            goal["sql"], target_ms, goal.get("schema_hint", ""), baseline_ms)
+        state = LoopState.fresh(run_id=run_id, session_id=session_id, goal=goal,
+                                goal_prompt=goal_prompt)
+        state.baseline_ms = baseline_ms
+        state.baseline_signature = baseline_sig
+
+    # --- SIGINT -> finish current turn, checkpoint, exit as `killed` -------
+    _install_sigint(state)
+
+    with lf.trace_context(TRACE_NAME, session_id=session_id, tags=tags):
+        with lf.observe(TRACE_NAME, as_type="agent", input={"goal": goal, "mode": prompt_version}) as root:
+            _root_update(root, input={"goal": goal, "mode": prompt_version})
+            lf.update_current_trace(input={"goal": goal, "mode": prompt_version})
+
+            while True:
+                stop = budget.check(state, caps)
+                if stop:
+                    return finalize(root, state, caps, stop, goal, prompt_version)
+
+                # ---- plan (generation) ----
+                with lf.observe("plan-next-action", as_type="generation",
+                                input=state.compacted_messages(compact_after)) as gen:
+                    try:
+                        resp = _client().messages.create(
+                            model=MODEL, system=system_text, tools=tool_schemas,
+                            messages=state.compacted_messages(compact_after),
+                            max_tokens=2000, temperature=TEMPERATURE)
+                    except Exception:
+                        # Checkpoint already holds the last completed turn; surface
+                        # the failure so the operator can --resume.
+                        checkpoint.save(state.run_id, state)
+                        raise
+                    state.cost_usd += budget.cost_of(resp.usage, MODEL)
+                    if gen is not None:
+                        _root_update(gen,
+                                     output=_text_of(resp) or "[tool_use]",
+                                     model=MODEL,
+                                     usage_details={"input_tokens": resp.usage.input_tokens,
+                                                    "output_tokens": resp.usage.output_tokens},
+                                     metadata={"turn": state.turn, "cost_so_far": round(state.cost_usd, 4),
+                                               "best_speedup": round(state.best_speedup, 2),
+                                               "plateau_turns": state.plateau})
+                        if system_prompt_obj is not None:
+                            _root_update(gen, prompt=system_prompt_obj)
+
+                action = tools.extract_tool_call(resp)
+                assistant_msg = tools.to_plain_assistant(resp)
+
+                # ---- end_turn with no tool call = implicit (lower-quality) finish ----
+                if action is None:
+                    return finalize(root, state, caps, "self_completed_implicit",
+                                    goal, prompt_version)
+
+                # ---- finish: verify the claim against the environment ----
+                if action.name == "finish":
+                    verdict = verify_finish_claim(action, env, state, target_ms)
+                    if verdict.ok:
+                        if action.args.get("status") == "success":
+                            state.best_sql = action.args.get("final_sql")
+                            reason = "self_completed"
+                        else:
+                            reason = "self_gave_up"
+                            if state.best_sql is None:
+                                state.best_sql = action.args.get("final_sql")
+                        return finalize(root, state, caps, reason, goal, prompt_version,
+                                        verdict, finish_summary=action.args.get("summary"))
+                    # False claim -> bounce back as the next observation.
+                    state.append_pair(assistant_msg, action.tool_use_id,
+                                      {"rejected": True, "reason": verdict.reason,
+                                       "hint": "your claim did not verify — keep going or give up honestly"},
+                                      f"turn {state.turn}: finish REJECTED — {verdict.reason}")
+                    state.plateau += 1
+                    state.turn += 1
+                    checkpoint.save(state.run_id, state)
+                    continue
+
+                # ---- propose_ddl: human-approval gate ----
+                if action.name == "propose_ddl":
+                    if not hitl_approve(action, hitl_mode):
+                        state.append_pair(assistant_msg, action.tool_use_id,
+                                          {"denied": True,
+                                           "hint": "human denied the DDL; try more rewrites or "
+                                                   "finish with status=gave_up naming the blocker"},
+                                          f"turn {state.turn}: propose_ddl DENIED by human")
+                        state.turn += 1
+                        checkpoint.save(state.run_id, state)
+                        continue
+                    # Approved -> apply via the ADMIN connection inside a tool span.
+                    with lf.observe(action.span_name, as_type="tool", input=action.args) as tspan:
+                        obs = env.apply_ddl(action.args.get("ddl", ""))
+                        _root_update(tspan, output=obs.public, metadata={"turn": state.turn},
+                                     level=("WARNING" if obs.is_error else None))
+                    state.append_pair(assistant_msg, action.tool_use_id, obs.public,
+                                      _summary(state.turn, action, obs))
+                    state.turn += 1
+                    checkpoint.save(state.run_id, state)
+                    continue
+
+                # ---- read-only environment tool ----
+                with lf.observe(action.span_name, as_type="tool", input=action.args) as tspan:
+                    obs = tools.dispatch(action, env, goal["sql"], state.baseline_signature)
+                    _root_update(tspan, output=obs.public, metadata={"turn": state.turn},
+                                 level=("WARNING" if obs.is_error else None))
+                    if action.name == "run_query" and obs.candidate_checked:
+                        lf.score_current_span("semantics_preserved", int(bool(obs.equivalent)),
+                                              data_type="BOOLEAN",
+                                              comment=("candidate result set matches baseline"
+                                                       if obs.equivalent else "candidate CHANGED the result set"))
+
+                # ---- assess progress (code evaluator, no LLM) ----
+                with lf.observe("assess-progress", as_type="evaluator") as ev:
+                    delta = state.record_progress(obs, candidate_sql=action.args.get("sql"))
+                    _root_update(ev, output={"improvement_delta": delta,
+                                             "best_speedup": round(state.best_speedup, 2),
+                                             "plateau_turns": state.plateau},
+                                 metadata={"turn": state.turn})
+                    lf.score_current_span("improvement_delta", round(delta, 3), data_type="NUMERIC",
+                                          comment=f"best_speedup={state.best_speedup:.2f}x, "
+                                                  f"plateau={state.plateau}")
+
+                state.append_pair(assistant_msg, action.tool_use_id, obs.public,
+                                  _summary(state.turn, action, obs))
+                state.turn += 1
+                checkpoint.save(state.run_id, state)
+
+
+def _text_of(resp) -> str:
+    return "".join(getattr(b, "text", "") for b in getattr(resp, "content", []) or []
+                   if getattr(b, "type", None) == "text").strip()
+
+
+def _install_sigint(state: LoopState) -> None:
+    def _handler(signum, frame):
+        state.sigint = True
+        print("\n[SIGINT] finishing current turn, then checkpointing…")
+    try:
+        signal.signal(signal.SIGINT, _handler)
+    except (ValueError, RuntimeError):
+        # Not in the main thread (e.g. under an experiment runner) — skip.
+        pass

--- a/demos/slow-query-tuner/budget.py
+++ b/demos/slow-query-tuner/budget.py
@@ -1,0 +1,88 @@
+"""
+Loop backstops — the control layer, NOT the termination mechanism.
+
+Per the pattern guide, an unattended loop must never omit a turn cap and a spend
+cap. This module provides three independent backstops plus a kill switch:
+
+  * turn counter        -> error_max_turns
+  * cumulative $ cost    -> error_max_budget_usd   (from real Anthropic usage)
+  * wall-clock watchdog  -> error_watchdog
+  * kill sentinel/SIGINT -> killed                 (checkpoint + resumable)
+
+`check()` runs BEFORE every turn. A run that ends on any of these is recorded as
+a FAILURE MODE, not normal termination — normal termination is the agent calling
+`finish` and the controller verifying the claim.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import checkpoint
+
+# Published USD-per-token prices (input, output). Cost is computed from REAL
+# Anthropic usage so the spend cap and the Langfuse cost Monitor agree. Native
+# cost tracking on the generation observations uses Langfuse's own price list;
+# this table is the app-side cap's ground truth. Update alongside pricing.
+_PRICES: Dict[str, Tuple[float, float]] = {
+    "claude-sonnet-4-6": (3.0e-6, 15.0e-6),
+    "claude-sonnet-4-5": (3.0e-6, 15.0e-6),
+    "claude-haiku-4-5": (1.0e-6, 5.0e-6),
+    "claude-opus-4-1": (15.0e-6, 75.0e-6),
+}
+_DEFAULT_PRICE = (3.0e-6, 15.0e-6)  # assume Sonnet-class if unknown
+
+
+@dataclass
+class Caps:
+    """Backstop limits. Env-tunable, never removable."""
+
+    max_turns: int = int(os.getenv("TUNER_MAX_TURNS", "15"))
+    max_budget_usd: float = float(os.getenv("TUNER_MAX_BUDGET_USD", "0.75"))
+    watchdog_s: float = float(os.getenv("TUNER_WATCHDOG_S", "600"))
+
+    def as_dict(self) -> Dict[str, float]:
+        return {"max_turns": self.max_turns, "max_budget_usd": self.max_budget_usd,
+                "watchdog_s": self.watchdog_s}
+
+
+def cost_of(usage, model: str) -> float:
+    """USD cost of one Anthropic response from its usage object/dict."""
+    in_rate, out_rate = _PRICES.get(model, _DEFAULT_PRICE)
+    it = _get(usage, "input_tokens")
+    ot = _get(usage, "output_tokens")
+    # Cache tokens, when present, are billed near input rate; approximate.
+    it += _get(usage, "cache_creation_input_tokens") + _get(usage, "cache_read_input_tokens")
+    return it * in_rate + ot * out_rate
+
+
+def check(state, caps: Caps) -> Optional[str]:
+    """Return a termination_reason if a backstop is tripped, else None.
+
+    Order matters: kill switch first (respected even at turn 0), then the caps.
+    """
+    if state.sigint or os.path.exists(checkpoint.kill_path(state.run_id)):
+        return "killed"
+    if state.turn > caps.max_turns:
+        return "error_max_turns"
+    if state.cost_usd >= caps.max_budget_usd:
+        return "error_max_budget_usd"
+    if (time.monotonic() - state.t0) >= caps.watchdog_s:
+        return "error_watchdog"
+    return None
+
+
+def _get(usage, attr: str) -> int:
+    if usage is None:
+        return 0
+    if isinstance(usage, dict):
+        v = usage.get(attr)
+    else:
+        v = getattr(usage, attr, None)
+    try:
+        return int(v or 0)
+    except (TypeError, ValueError):
+        return 0

--- a/demos/slow-query-tuner/ch_env.py
+++ b/demos/slow-query-tuner/ch_env.py
@@ -1,0 +1,244 @@
+"""
+Environment interface — the live ClickHouse tuning lab the agent acts on.
+
+Two connections:
+  * tuner_agent (read-only, quota'd) — every query the AGENT runs. This is the
+    ground truth: measured elapsed_ms / read_rows / read_bytes on every
+    execution, so the agent CANNOT hallucinate a speedup.
+  * tuner_admin — opened ONLY inside the human-approved propose_ddl path.
+
+Defense-in-depth: an app-side SQL-shape allow-list (SELECT/WITH/EXPLAIN/SHOW,
+single statement) sits in front of the grants. The grants are the real security
+boundary; the allow-list is a belt to the grants' suspenders and gives clean,
+demoable error-as-observation behaviour.
+
+clickhouse_connect is imported lazily so the module (and the unit tests, which
+mock the env) import with no driver and no live database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# Belt: allow only read-only single statements. Grants are the suspenders.
+_ALLOWED = re.compile(r"^\s*(SELECT|WITH|EXPLAIN|SHOW)\b", re.IGNORECASE)
+
+# Per-query safety settings the agent's connection always carries. readonly=2
+# lets the agent SET additional per-query settings but never write.
+SAFE_SETTINGS: Dict[str, Any] = {
+    "max_execution_time": int(os.getenv("TUNING_MAX_EXECUTION_TIME", "30")),
+    "max_result_rows": int(os.getenv("TUNING_MAX_RESULT_ROWS", "10000")),
+    "max_result_bytes": int(os.getenv("TUNING_MAX_RESULT_BYTES", "50000000")),
+}
+
+
+def sql_allowed(sql: str) -> "tuple[bool, Optional[str]]":
+    """Return (ok, reason). Rejects writes/DDL and multi-statement input.
+
+    Pure-python — no driver, no DB. Unit-tested directly.
+    """
+    if not sql or not sql.strip():
+        return False, "empty statement"
+    if not _ALLOWED.match(sql):
+        return False, "blocked by SQL-shape allow-list (SELECT/WITH/EXPLAIN/SHOW only)"
+    # Reject multi-statement input: a trailing ';' is fine, an interior one is not.
+    if ";" in sql.strip().rstrip(";"):
+        return False, "blocked by SQL-shape allow-list (single statement only)"
+    return True, None
+
+
+def result_signature(rows: List[Any]) -> str:
+    """Order-independent semantic signature of a result set.
+
+    The DB arbitrates equivalence, not a string match: two syntactically
+    different queries returning the same rows (in any order) hash identically.
+    """
+    try:
+        normalized = sorted(tuple(r) for r in rows)
+    except TypeError:
+        # Unsortable/heterogeneous rows: fall back to a stable repr per row.
+        normalized = sorted(repr(tuple(r)) for r in rows)
+    return hashlib.sha256(repr(normalized).encode()).hexdigest()[:16]
+
+
+@dataclass
+class Obs:
+    """One environment observation. `public` is the JSON-safe span/tool output."""
+
+    ok: bool
+    kind: str                       # query | explain | schema | equivalence | ddl
+    error: Optional[str] = None
+    elapsed_ms: Optional[float] = None
+    read_rows: Optional[int] = None
+    read_bytes: Optional[int] = None
+    rows_preview: List[Any] = field(default_factory=list)
+    signature: Optional[str] = None
+    text: Optional[str] = None      # EXPLAIN plan / schema DDL
+    # Controller-side equivalence bookkeeping (set by the caller for candidates).
+    candidate_checked: bool = False
+    equivalent: Optional[bool] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_error(self) -> bool:
+        return not self.ok
+
+    @classmethod
+    def error_obs(cls, msg: str, kind: str = "query") -> "Obs":
+        return cls(ok=False, kind=kind, error=msg)
+
+    @property
+    def public(self) -> Dict[str, Any]:
+        """Truncated, JSON-safe view for the trace + the model's next observation."""
+        if not self.ok:
+            return {"error": self.error, "kind": self.kind}
+        out: Dict[str, Any] = {"kind": self.kind}
+        if self.elapsed_ms is not None:
+            out["elapsed_ms"] = round(self.elapsed_ms, 1)
+        if self.read_rows is not None:
+            out["read_rows"] = self.read_rows
+        if self.read_bytes is not None:
+            out["read_bytes"] = self.read_bytes
+        if self.signature is not None:
+            out["result_signature"] = self.signature
+        if self.rows_preview:
+            out["rows_preview"] = [list(r) for r in self.rows_preview[:5]]
+        if self.text is not None:
+            out["text"] = self.text[:2000]
+        if self.candidate_checked:
+            out["equivalent_to_baseline"] = self.equivalent
+        out.update(self.extra)
+        return out
+
+
+class TuningLabEnv:
+    """Live ClickHouse tuning lab, sandboxed as tuner_agent (+ admin gate)."""
+
+    def __init__(self) -> None:
+        self.host = os.getenv("TUNING_CH_HOST", "clickhouse-tuning")
+        self.port = int(os.getenv("TUNING_CH_PORT", "8123"))
+        self.db = os.getenv("TUNING_CH_DB", "tuning_lab")
+        self.agent_user = os.getenv("TUNING_CH_AGENT_USER", "tuner_agent")
+        self.agent_password = os.getenv("TUNING_CH_AGENT_PASSWORD", "tuner_agent123")
+        self.admin_user = os.getenv("TUNING_CH_ADMIN_USER", "tuner_admin")
+        self.admin_password = os.getenv("TUNING_CH_ADMIN_PASSWORD", "tuner_admin123")
+        self._agent = None
+        self._admin = None
+
+    # -- connections ---------------------------------------------------------
+    def _client(self, user: str, password: str):
+        import clickhouse_connect  # lazy: keeps module import driver-free
+        return clickhouse_connect.get_client(
+            host=self.host, port=self.port, database=self.db,
+            username=user, password=password,
+        )
+
+    def _agent_client(self):
+        if self._agent is None:
+            self._agent = self._client(self.agent_user, self.agent_password)
+        return self._agent
+
+    def _admin_client(self):
+        """Admin connection — opened ONLY from the approved propose_ddl path."""
+        if self._admin is None:
+            self._admin = self._client(self.admin_user, self.admin_password)
+        return self._admin
+
+    # -- read-only agent surface --------------------------------------------
+    def run_query(self, sql: str, settings: Optional[Dict[str, Any]] = None) -> Obs:
+        """Execute a candidate/baseline query and MEASURE it. Errors are returned
+        as observations (never raised) so the environment can fail independently
+        of the model and the error becomes the next turn's observation."""
+        ok, reason = sql_allowed(sql)
+        if not ok:
+            return Obs.error_obs(reason or "blocked", kind="query")
+        merged = {**SAFE_SETTINGS, **(settings or {})}
+        t0 = time.perf_counter()
+        try:
+            res = self._agent_client().query(sql, settings=merged)
+        except Exception as e:  # env fails independently of the model
+            return Obs.error_obs(f"{type(e).__name__}: {str(e)[:400]}", kind="query")
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        summary = getattr(res, "summary", {}) or {}
+        rows = list(res.result_rows)
+        return Obs(
+            ok=True, kind="query",
+            elapsed_ms=elapsed_ms,
+            read_rows=_as_int(summary.get("read_rows")),
+            read_bytes=_as_int(summary.get("read_bytes")),
+            rows_preview=rows[:5],
+            signature=result_signature(rows),
+        )
+
+    def explain_query(self, sql: str) -> Obs:
+        stripped = sql.strip().rstrip(";")
+        # Accept a bare SELECT and wrap it, or an already-EXPLAIN statement.
+        explain_sql = stripped if _ALLOWED.match(stripped) and stripped.upper().startswith("EXPLAIN") \
+            else f"EXPLAIN indexes = 1 {stripped}"
+        ok, reason = sql_allowed(explain_sql)
+        if not ok:
+            return Obs.error_obs(reason or "blocked", kind="explain")
+        try:
+            res = self._agent_client().query(explain_sql)
+        except Exception as e:
+            return Obs.error_obs(f"{type(e).__name__}: {str(e)[:400]}", kind="explain")
+        plan = "\n".join(str(r[0]) for r in res.result_rows)
+        full_scan = "tuple()" in plan or "PrimaryKey" not in plan
+        return Obs(ok=True, kind="explain", text=plan, extra={"full_scan_suspected": full_scan})
+
+    def get_schema(self, table: str = "web_events") -> Obs:
+        sql = f"SHOW CREATE TABLE {self.db}.{table}"
+        ok, reason = sql_allowed(sql)
+        if not ok:
+            return Obs.error_obs(reason or "blocked", kind="schema")
+        try:
+            res = self._agent_client().query(sql)
+        except Exception as e:
+            return Obs.error_obs(f"{type(e).__name__}: {str(e)[:400]}", kind="schema")
+        ddl = res.result_rows[0][0] if res.result_rows else ""
+        return Obs(ok=True, kind="schema", text=str(ddl))
+
+    def signature_of(self, sql: str) -> Obs:
+        """Run a query purely to capture its result signature (for equivalence)."""
+        return self.run_query(sql)
+
+    def check_equivalence(self, baseline_sql: str, candidate_sql: str) -> Obs:
+        """Deterministic result-set equivalence probe: run both, compare
+        order-independent signatures. The DB arbitrates, not the model."""
+        base = self.run_query(baseline_sql)
+        if not base.ok:
+            return Obs.error_obs(f"baseline failed: {base.error}", kind="equivalence")
+        cand = self.run_query(candidate_sql)
+        if not cand.ok:
+            return Obs.error_obs(f"candidate failed: {cand.error}", kind="equivalence")
+        equivalent = base.signature == cand.signature
+        return Obs(
+            ok=True, kind="equivalence",
+            candidate_checked=True, equivalent=equivalent,
+            signature=cand.signature,
+            extra={"baseline_signature": base.signature,
+                   "candidate_signature": cand.signature,
+                   "equivalent": equivalent},
+        )
+
+    # -- admin / DDL gate ----------------------------------------------------
+    def apply_ddl(self, ddl: str) -> Obs:
+        """Execute a DDL statement via the ADMIN connection. Callers MUST only
+        reach this after the human-approval gate has approved the action."""
+        try:
+            self._admin_client().command(ddl)
+        except Exception as e:
+            return Obs.error_obs(f"{type(e).__name__}: {str(e)[:400]}", kind="ddl")
+        return Obs(ok=True, kind="ddl", text=f"applied: {ddl[:200]}")
+
+
+def _as_int(v) -> Optional[int]:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None

--- a/demos/slow-query-tuner/checkpoint.py
+++ b/demos/slow-query-tuner/checkpoint.py
@@ -1,0 +1,169 @@
+"""
+Durable per-run state + the pause/resume contract.
+
+`LoopState` is the working memory of one tuning run. It is JSON-serialisable
+(messages are stored as plain content-block dicts, never SDK objects) and is
+written to `checkpoints/<run_id>.json` after EVERY turn, so:
+
+  * a SIGINT / kill-sentinel / crash mid-loop loses at most the in-flight turn;
+  * `--resume <run_id>` restores it in a FRESH process and — crucially — reuses
+    the stored `session_id`, so Langfuse stitches the paused and resumed traces
+    into one continuous investigation in the Sessions view.
+
+LoopState lives here (not in agent_loop) so both `budget` and `agent_loop` can
+depend on it without an import cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+def checkpoint_dir() -> str:
+    """Directory for run state + kill sentinels. Volume-mounted in the container
+    (survives `run --rm`). Overridable via TUNER_CHECKPOINT_DIR (tests use a tmp
+    dir)."""
+    d = os.getenv("TUNER_CHECKPOINT_DIR", "checkpoints")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def state_path(run_id: str) -> str:
+    return os.path.join(checkpoint_dir(), f"{run_id}.json")
+
+
+def kill_path(run_id: str) -> str:
+    """`touch checkpoints/<run_id>.kill` is the external kill switch."""
+    return os.path.join(checkpoint_dir(), f"{run_id}.kill")
+
+
+def exists(run_id: str) -> bool:
+    return os.path.exists(state_path(run_id))
+
+
+@dataclass
+class LoopState:
+    run_id: str
+    session_id: str
+    goal: Dict[str, Any]
+    goal_prompt: str                                    # initial user-message text
+    messages: List[Dict[str, Any]] = field(default_factory=list)   # raw turn pairs
+    summaries: List[str] = field(default_factory=list)             # one line per pair
+    turn: int = 1
+    cost_usd: float = 0.0
+    best_speedup: float = 1.0
+    best_sql: Optional[str] = None
+    plateau: int = 0
+    baseline_ms: Optional[float] = None
+    baseline_signature: Optional[str] = None
+    # Runtime-only (never serialised): wall-clock start + SIGINT flag.
+    t0: float = field(default_factory=time.monotonic, compare=False)
+    sigint: bool = field(default=False, compare=False)
+
+    # -- construction --------------------------------------------------------
+    @classmethod
+    def fresh(cls, *, run_id: str, session_id: str, goal: Dict[str, Any],
+              goal_prompt: str) -> "LoopState":
+        return cls(run_id=run_id, session_id=session_id, goal=goal,
+                   goal_prompt=goal_prompt)
+
+    # -- message assembly ----------------------------------------------------
+    def goal_user_message(self, extra: str = "") -> Dict[str, Any]:
+        content = self.goal_prompt + (("\n\n" + extra) if extra else "")
+        return {"role": "user", "content": content}
+
+    def append_pair(self, assistant_msg: Dict[str, Any], tool_use_id: str,
+                    tool_result: Any, summary: str) -> None:
+        """Append one (assistant tool_use, user tool_result) pair + its summary.
+        Keeps tool_use/tool_result pairing intact so compaction can slice whole
+        pairs safely."""
+        self.messages.append(assistant_msg)
+        content = tool_result if isinstance(tool_result, str) else json.dumps(tool_result, default=str)
+        self.messages.append({
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": content}],
+        })
+        self.summaries.append(summary)
+
+    def compacted_messages(self, compact_after: int) -> List[Dict[str, Any]]:
+        """Context-rot mitigation: fold turns older than `compact_after` into
+        one-line summaries carried on the goal message; keep the most recent
+        pairs verbatim. Visible in the `plan-next-action` input during a demo."""
+        pairs = len(self.messages) // 2
+        if compact_after <= 0 or pairs <= compact_after:
+            return [self.goal_user_message()] + list(self.messages)
+        compacted = pairs - compact_after
+        summary_lines = "\n".join(f"- {s}" for s in self.summaries[:compacted])
+        head = self.goal_user_message(
+            "Progress so far (compacted; every timing was measured against the live DB):\n"
+            + summary_lines
+        )
+        recent = self.messages[compacted * 2:]
+        return [head] + list(recent)
+
+    # -- progress bookkeeping -----------------------------------------------
+    def record_progress(self, obs, candidate_sql: Optional[str] = None) -> float:
+        """Update best_speedup + plateau counter from an observation; return the
+        per-turn improvement_delta (0 for non-improving / info-gathering turns)."""
+        is_candidate = (getattr(obs, "ok", False) and getattr(obs, "kind", None) == "query"
+                        and getattr(obs, "candidate_checked", False))
+        if not is_candidate or not self.baseline_ms:
+            return 0.0
+        if obs.equivalent and obs.elapsed_ms:
+            speedup = self.baseline_ms / max(obs.elapsed_ms, 0.001)
+            if speedup > self.best_speedup + 1e-9:
+                delta = speedup - self.best_speedup
+                self.best_speedup = speedup
+                self.best_sql = candidate_sql
+                self.plateau = 0
+                return round(delta, 4)
+        # Ran a candidate but it did not improve (slower/equal or non-equivalent).
+        self.plateau += 1
+        return 0.0
+
+    # -- serialisation -------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "session_id": self.session_id,
+            "goal": self.goal,
+            "goal_prompt": self.goal_prompt,
+            "messages": self.messages,
+            "summaries": self.summaries,
+            "turn": self.turn,
+            "cost_usd": self.cost_usd,
+            "best_speedup": self.best_speedup,
+            "best_sql": self.best_sql,
+            "plateau": self.plateau,
+            "baseline_ms": self.baseline_ms,
+            "baseline_signature": self.baseline_signature,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "LoopState":
+        return cls(
+            run_id=d["run_id"], session_id=d["session_id"], goal=d["goal"],
+            goal_prompt=d["goal_prompt"], messages=d.get("messages", []),
+            summaries=d.get("summaries", []), turn=d.get("turn", 1),
+            cost_usd=d.get("cost_usd", 0.0), best_speedup=d.get("best_speedup", 1.0),
+            best_sql=d.get("best_sql"), plateau=d.get("plateau", 0),
+            baseline_ms=d.get("baseline_ms"), baseline_signature=d.get("baseline_signature"),
+        )
+
+
+def save(run_id: str, state: LoopState) -> None:
+    """Atomic write (temp + rename) so a crash mid-write never corrupts state."""
+    path = state_path(run_id)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(state.to_dict(), f, ensure_ascii=False, indent=2, default=str)
+    os.replace(tmp, path)
+
+
+def load(run_id: str) -> LoopState:
+    with open(state_path(run_id), "r", encoding="utf-8") as f:
+        return LoopState.from_dict(json.load(f))

--- a/demos/slow-query-tuner/checkpoints/.gitignore
+++ b/demos/slow-query-tuner/checkpoints/.gitignore
@@ -1,0 +1,4 @@
+# Run state + kill sentinels are runtime artifacts — keep the directory (so the
+# volume mount + `run --rm` resume path works), ignore its contents.
+*
+!.gitignore

--- a/demos/slow-query-tuner/langfuse_config.py
+++ b/demos/slow-query-tuner/langfuse_config.py
@@ -1,0 +1,154 @@
+"""
+Langfuse instrumentation for the Slow Query Tuner demo (v3 SDK).
+
+Cloned from demos/agentic-rag/langfuse_config.py — same house conventions:
+
+- Typed observations (`agent` / `generation` / `tool` / `evaluator`) via
+  `observe()`; the non-`span`/`generation` types are what make Langfuse render
+  the Agent Graph.
+- `trace_context()` sets a stable, low-cardinality trace name + session_id +
+  tags via `propagate_attributes`, so a run that pauses and resumes in a fresh
+  process reuses one `session_id` and stitches into a single Langfuse session.
+- Everything is a NO-OP when Langfuse keys are absent, so the loop still runs
+  (graceful degradation — house convention).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import contextmanager
+from typing import Optional
+
+LANGFUSE_ENABLED = bool(
+    os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY")
+)
+
+DEFAULT_TAGS = ["slow-query-tuner", "demo"]
+
+
+def is_langfuse_enabled() -> bool:
+    return LANGFUSE_ENABLED
+
+
+def get_client():
+    if not LANGFUSE_ENABLED:
+        return None
+    try:
+        from langfuse import get_client as _gc
+        return _gc()
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse client unavailable: {e}")
+        return None
+
+
+def new_session_id() -> str:
+    """Session id for a tuning run. Reused verbatim on --resume so the paused
+    and resumed traces land in one Langfuse session."""
+    return f"qtune-{uuid.uuid4().hex[:8]}"
+
+
+@contextmanager
+def trace_context(name: str, session_id: Optional[str] = None, tags=None, user_id=None):
+    """Set trace name / session / tags for everything emitted within the block."""
+    if not LANGFUSE_ENABLED:
+        yield
+        return
+    try:
+        from langfuse import propagate_attributes
+        with propagate_attributes(
+            trace_name=name,
+            session_id=session_id,
+            user_id=user_id,
+            tags=tags or DEFAULT_TAGS,
+        ):
+            yield
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse trace context failed: {e}")
+        yield
+
+
+@contextmanager
+def observe(name: str, as_type: str = "span", input=None):
+    """Create a typed observation (agent | generation | tool | evaluator | ...).
+
+    Yields the observation handle (or None). Call `.update(output=..., prompt=...,
+    metadata=..., level=...)` on it. The non-default `as_type` values are what
+    trigger Langfuse's agentic Agent Graph rendering.
+    """
+    client = get_client()
+    if client is None:
+        yield None
+        return
+    try:
+        with client.start_as_current_observation(as_type=as_type, name=name, input=input) as obs:
+            yield obs
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse observation '{name}' failed: {e}")
+        yield None
+
+
+def update_current_trace(**kwargs):
+    """Set trace-level input/output/metadata on the active trace."""
+    client = get_client()
+    if client is None:
+        return
+    try:
+        client.update_current_trace(**kwargs)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse update_current_trace failed: {e}")
+
+
+def score_current_trace(name: str, value, comment: Optional[str] = None, data_type="NUMERIC"):
+    """Attach a trace-level evaluation score (one per run: turns_used, etc.)."""
+    client = get_client()
+    if client is None:
+        return
+    try:
+        client.score_current_trace(name=name, value=value, comment=comment, data_type=data_type)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse trace score '{name}' failed: {e}")
+
+
+def score_current_span(name: str, value, comment: Optional[str] = None, data_type="NUMERIC"):
+    """Attach a span-level score to the active observation.
+
+    Use for step-level verdicts that can repeat within a run (semantics_preserved
+    on each candidate run-query span, improvement_delta on each assess-progress).
+    """
+    client = get_client()
+    if client is None:
+        return
+    try:
+        client.score_current_span(name=name, value=value, comment=comment, data_type=data_type)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse span score '{name}' failed: {e}")
+
+
+def get_prompt(name: str, label: str = "production"):
+    """Fetch a managed prompt from Langfuse (Prompt management).
+
+    Returns the Langfuse prompt object (`.compile(**vars)`, links to traces) or
+    None if Langfuse is unavailable / the prompt isn't seeded — callers fall back
+    to a local template so the agent always runs.
+    """
+    client = get_client()
+    if client is None:
+        return None
+    try:
+        return client.get_prompt(name, label=label)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse get_prompt('{name}') unavailable, using local fallback: {e}")
+        return None
+
+
+def flush():
+    """Flush (never shutdown — get_client() is a process-global singleton)."""
+    client = get_client()
+    if client is None:
+        return
+    try:
+        if hasattr(client, "flush"):
+            client.flush()
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Langfuse flush failed: {e}")

--- a/demos/slow-query-tuner/main.py
+++ b/demos/slow-query-tuner/main.py
@@ -1,0 +1,159 @@
+"""
+Slow Query Tuner — CLI.
+
+Examples:
+    python main.py --query q1                     # short self-terminating run
+    python main.py --query q2                     # long run (env error + plateau)
+    python main.py --query q3                     # blocked -> propose_ddl (HITL)
+    python main.py --query q3 --auto-approve-ddl   # scripted HITL beat (approve)
+    python main.py --runaway                       # deliberate runaway -> cost cap
+    python main.py --resume run-abcd1234           # resume a paused/killed run
+    python main.py --sql "SELECT ..." --target-ms 500
+    python main.py --interactive
+
+The loop length is agent-decided; MAX_TURNS / MAX_BUDGET_USD / watchdog are
+backstops only (override with --max-turns / --max-budget-usd / --watchdog-s).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+
+import agent_loop
+import budget
+import checkpoint
+import langfuse_config as lf
+import prompts
+import queries
+
+
+def new_run_id() -> str:
+    return f"run-{uuid.uuid4().hex[:8]}"
+
+
+def _build_goal(qid: str) -> dict:
+    g = queries.get_goal(qid)
+    goal = g.as_dict()
+    goal["schema_hint"] = queries.SCHEMA_HINT
+    return goal
+
+
+def _caps_from_args(args, runaway: bool) -> budget.Caps:
+    caps = budget.Caps()
+    if runaway:
+        # --runaway only RAISES caps (never removes them): an impossible target +
+        # the naive prompt churn until the spend cap kills it.
+        caps.max_turns = 25
+        caps.max_budget_usd = 2.50
+    if args.max_turns is not None:
+        caps.max_turns = args.max_turns
+    if args.max_budget_usd is not None:
+        caps.max_budget_usd = args.max_budget_usd
+    if args.watchdog_s is not None:
+        caps.watchdog_s = args.watchdog_s
+    return caps
+
+
+def _hitl_mode(args) -> str:
+    if args.auto_approve_ddl:
+        return "auto-approve"
+    if args.auto_deny_ddl:
+        return "auto-deny"
+    return "prompt"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Autonomous slow-query tuning agent")
+    ap.add_argument("--query", choices=sorted(queries.CATALOG), help="Bad-query catalog id")
+    ap.add_argument("--sql", help="Ad-hoc SQL to tune (with --target-ms)")
+    ap.add_argument("--target-ms", type=int, help="Target latency for --sql")
+    ap.add_argument("--runaway", action="store_true",
+                    help="Deliberate runaway (naive prompt + impossible target) -> trips the cost cap")
+    ap.add_argument("--resume", metavar="RUN_ID", help="Resume a paused/killed run by run_id")
+    ap.add_argument("--interactive", action="store_true", help="Prompt for SQL + target")
+    ap.add_argument("--prompt-version", default=None,
+                    help="System prompt version/label (v1-naive | v2-disciplined | production)")
+    ap.add_argument("--auto-approve-ddl", action="store_true", help="Scripted demo: approve DDL")
+    ap.add_argument("--auto-deny-ddl", action="store_true", help="Batch/CI: deny DDL")
+    ap.add_argument("--max-turns", type=int, default=None, help="Backstop override")
+    ap.add_argument("--max-budget-usd", type=float, default=None, help="Backstop override")
+    ap.add_argument("--watchdog-s", type=float, default=None, help="Backstop override")
+    args = ap.parse_args()
+
+    if not lf.is_langfuse_enabled():
+        print("NOTE: Langfuse keys not set — the loop runs, all instrumentation no-ops.")
+
+    # ---- resume path -----------------------------------------------------
+    if args.resume:
+        if not checkpoint.exists(args.resume):
+            print(f"ERROR: no checkpoint for run_id '{args.resume}' in {checkpoint.checkpoint_dir()}",
+                  file=sys.stderr)
+            return 1
+        state = checkpoint.load(args.resume)
+        caps = _caps_from_args(args, runaway=False)
+        result = agent_loop.run(state.goal, caps=caps, run_id=args.resume,
+                                session_id=state.session_id, resume_state=state,
+                                prompt_version=args.prompt_version or prompts.PRODUCTION_LABEL,
+                                hitl_mode=_hitl_mode(args))
+        return _report(result)
+
+    # ---- resolve goal ----------------------------------------------------
+    runaway = args.runaway
+    if runaway:
+        goal = _build_goal("q3")
+        goal["target_ms"] = queries.RUNAWAY_TARGET_MS
+        prompt_version = "v1-naive"
+        hitl_mode = "auto-deny"
+    elif args.interactive:
+        sql = input("SQL to tune:\n> ").strip()
+        target = int(input("Target latency (ms): ").strip() or "800")
+        goal = {"id": "adhoc", "sql": sql, "target_ms": target,
+                "expected_turn_band": [2, 15], "schema_hint": queries.SCHEMA_HINT}
+        prompt_version = args.prompt_version or prompts.PRODUCTION_LABEL
+        hitl_mode = _hitl_mode(args)
+    elif args.sql:
+        goal = {"id": "adhoc", "sql": args.sql,
+                "target_ms": args.target_ms or 800,
+                "expected_turn_band": [2, 15], "schema_hint": queries.SCHEMA_HINT}
+        prompt_version = args.prompt_version or prompts.PRODUCTION_LABEL
+        hitl_mode = _hitl_mode(args)
+    elif args.query:
+        goal = _build_goal(args.query)
+        prompt_version = args.prompt_version or prompts.PRODUCTION_LABEL
+        hitl_mode = _hitl_mode(args)
+    else:
+        ap.error("provide --query, --sql, --runaway, --resume, or --interactive")
+        return 2
+
+    caps = _caps_from_args(args, runaway=runaway)
+    run_id = new_run_id()
+    session_id = lf.new_session_id()
+    print(f"run_id={run_id}  session_id={session_id}  caps={caps.as_dict()}  "
+          f"prompt={prompt_version}{'  [RUNAWAY]' if runaway else ''}")
+
+    result = agent_loop.run(goal, caps=caps, run_id=run_id, session_id=session_id,
+                            prompt_version=prompt_version, hitl_mode=hitl_mode,
+                            runaway=runaway)
+    return _report(result)
+
+
+def _report(result: "agent_loop.RunResult") -> int:
+    print("\n" + "-" * 72)
+    print(f"termination_reason : {result.termination_reason}")
+    print(f"turns_used         : {result.turns_used}")
+    print(f"verified_speedup   : {result.verified_speedup}x")
+    print(f"run_cost_usd       : ${result.cost_usd}")
+    print(f"summary            : {result.summary}")
+    if result.final_sql:
+        print(f"final_sql          :\n{result.final_sql}")
+    print("-" * 72)
+    if result.termination_reason == "killed":
+        print(f"Resume with: python main.py --resume {result.run_id}")
+        return 130
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/slow-query-tuner/prompts.py
+++ b/demos/slow-query-tuner/prompts.py
@@ -1,0 +1,120 @@
+"""
+Managed prompts — the Deploy node of the loop.
+
+Two prompts live in Langfuse Prompt Management (seeded idempotently by
+scripts/seed_prompts.py), each with a hard-coded local fallback so the agent
+runs on a fresh clone / with Langfuse down:
+
+  query-tuner-system   v1-naive          — no plateau/give-up doctrine (the
+                                            Experiment's losing arm + runaway fuel)
+                       v2-disciplined     — adds re-measure + plateau give-up
+                       (label `production` == v2-disciplined)
+  query-tuner-goal     v1                 — per-run user message ({{sql}},
+                                            {{target_ms}}, {{schema_hint}}, {{baseline_ms}})
+
+The running app fetches by LABEL and links the fetched version to the plan
+generations, so promoting a label is a deploy with no code change.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+import langfuse_config as lf
+
+SYSTEM_PROMPT_NAME = "query-tuner-system"
+GOAL_PROMPT_NAME = "query-tuner-goal"
+
+PRODUCTION_LABEL = "production"       # -> v2-disciplined
+V1_LABEL = "v1-naive"
+V2_LABEL = "v2-disciplined"
+
+# --- shared tool doctrine (both system versions) -----------------------------
+_COMMON = (
+    "You are a ClickHouse query-tuning agent. You are given a slow SQL query and a target "
+    "latency in milliseconds. Your job: produce a query that returns the SAME result set and "
+    "meets the target — or conclude it cannot be met with query rewrites alone.\n"
+    "\n"
+    "You act on a LIVE ClickHouse instance through tools. Doctrine:\n"
+    "- NEVER claim a speedup you have not measured. Run every candidate with run_query and read "
+    "the actual elapsed_ms — the database is the ground truth, not your reasoning.\n"
+    "- Every run_query candidate is auto-checked for result-set equivalence; verify equivalence "
+    "before you call finish. A query that got fast by returning different rows is WRONG.\n"
+    "- The table has ORDER BY tuple() (no sort key). Common wins: use the properly-typed "
+    "event_date instead of parsing ts_raw, PREWHERE on selective predicates, drop needless "
+    "SELECT * subqueries / global ORDER BY, and swap count(DISTINCT x) for uniq(x).\n"
+    "- Call finish(status, final_sql, claimed_speedup, summary) when you are done. Your claim "
+    "is independently re-executed by the controller and rejected if it does not verify.\n"
+)
+
+# --- v1-naive: no self-discipline -> keeps trying forever on hard queries ----
+V1_NAIVE = _COMMON + (
+    "\nKeep trying rewrites until the target is met.\n"
+)
+
+# --- v2-disciplined (production): re-measure + plateau give-up ---------------
+V2_DISCIPLINED = _COMMON + (
+    "\nDiscipline (this is what makes stopping GOOD):\n"
+    "- Before calling finish(status=success), re-run the final query at least twice to confirm "
+    "the timing is stable, and confirm equivalence.\n"
+    "- If improvement_delta is ~0 for 3 consecutive turns you are plateaued: either propose_ddl "
+    "with a concrete schema change and rationale, or call finish(status=gave_up) naming the true "
+    "structural blocker. Do NOT thrash on rewrites that don't help.\n"
+    "- Prefer the fewest changes that reach the target; stop as soon as it is met.\n"
+)
+
+# --- goal template (user message) --------------------------------------------
+GOAL_TEMPLATE = (
+    "Optimize this query to run in <= {{target_ms}} ms while returning the identical result set.\n"
+    "\n"
+    "Original query:\n{{sql}}\n"
+    "\n"
+    "Measured baseline: {{baseline_ms}} ms.\n"
+    "\n"
+    "{{schema_hint}}\n"
+    "\n"
+    "Investigate with the tools, then finish when the target is verifiably met or you can prove "
+    "it needs a schema change."
+)
+
+
+def _local_compile(text: str, **vars: Any) -> str:
+    for k, v in vars.items():
+        text = text.replace("{{" + k + "}}", str(v))
+    return text
+
+
+def _managed_or_fallback(name: str, label: str, fallback: str,
+                         **vars: Any) -> Tuple[str, Optional[Any]]:
+    """Return (compiled_text, prompt_obj_or_None). The obj (when non-None) is
+    passed to the plan generation so the version links to the trace."""
+    obj = lf.get_prompt(name, label=label)
+    if obj is not None:
+        try:
+            return obj.compile(**vars), obj
+        except Exception:
+            pass
+    return _local_compile(fallback, **vars), None
+
+
+_SYSTEM_FALLBACK = {
+    V1_LABEL: V1_NAIVE,
+    V2_LABEL: V2_DISCIPLINED,
+    PRODUCTION_LABEL: V2_DISCIPLINED,
+}
+
+
+def get_system_prompt(version: str = PRODUCTION_LABEL) -> Tuple[str, Optional[Any]]:
+    """Fetch the system prompt for a version/label. `version` is one of
+    'production', 'v2-disciplined', 'v1-naive'."""
+    fallback = _SYSTEM_FALLBACK.get(version, V2_DISCIPLINED)
+    return _managed_or_fallback(SYSTEM_PROMPT_NAME, version, fallback)
+
+
+def get_goal_prompt(sql: str, target_ms: int, schema_hint: str,
+                    baseline_ms) -> Tuple[str, Optional[Any]]:
+    return _managed_or_fallback(
+        GOAL_PROMPT_NAME, "production", GOAL_TEMPLATE,
+        sql=sql.strip(), target_ms=target_ms, schema_hint=schema_hint,
+        baseline_ms=("unknown" if baseline_ms is None else round(baseline_ms, 1)),
+    )

--- a/demos/slow-query-tuner/pytest.ini
+++ b/demos/slow-query-tuner/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -q

--- a/demos/slow-query-tuner/queries.py
+++ b/demos/slow-query-tuner/queries.py
@@ -1,0 +1,135 @@
+"""
+Bad-query catalog — engineered so specific queries reliably produce specific
+demo moments (short self-terminating run / long run / blocked-or-runaway run).
+
+Each query is a real, deliberately-pessimal SELECT against tuning_lab.web_events
+(see sql/init/01_schema.sql). The agent gets ONLY the SQL + a target latency; it
+must produce a semantically-equivalent query that meets the target, or explain
+why it can't without schema changes.
+
+`expected_turn_band` is consumed by `trajectory_efficiency` scoring and dataset
+metadata. It is a soft expectation, never a hard assertion — the whole point of
+the pattern is that the real turn count is not knowable in advance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+
+@dataclass(frozen=True)
+class Goal:
+    """One tuning objective handed to the agent."""
+
+    sql: str
+    target_ms: int
+    id: str = "adhoc"
+    expected_turn_band: Tuple[int, int] = (2, 12)
+    designed_outcome: str = ""
+
+    def as_dict(self) -> Dict:
+        return {
+            "id": self.id,
+            "sql": self.sql,
+            "target_ms": self.target_ms,
+            "expected_turn_band": list(self.expected_turn_band),
+        }
+
+
+# --- Q1 EASY -----------------------------------------------------------------
+# Daily unique users for June. Sins: parses a String date in the WHERE (blocks
+# any index use, forces per-row parse) and count(DISTINCT) (exact, expensive).
+# Fix path: use event_date, swap count(DISTINCT) -> uniq(). 2-4 turns, clean
+# self_completed — the short-trace money shot.
+Q1_SQL = """\
+SELECT toDate(parseDateTimeBestEffortOrNull(ts_raw)) AS day,
+       count(DISTINCT user_id) AS uniques
+FROM tuning_lab.web_events
+WHERE toDate(parseDateTimeBestEffortOrNull(ts_raw)) BETWEEN '2024-06-01' AND '2024-06-30'
+GROUP BY day
+ORDER BY day
+"""
+
+# --- Q2 MEDIUM ---------------------------------------------------------------
+# Top-10 URLs by average duration for US traffic in June. Sins: SELECT * in a
+# subquery (materialises every column), lower(country)='us' (function-wrapped
+# predicate), string-date parse, a global ORDER BY. Fix path is multi-step and
+# order-independent: PREWHERE / country='US' / event_date rewrite / drop the
+# subquery. 5-10 turns incl. an env error and a plateau — the long-trace and
+# pause/resume vehicle.
+Q2_SQL = """\
+SELECT url, avg(duration_ms) AS avg_dur, count() AS n
+FROM (
+    SELECT *
+    FROM tuning_lab.web_events
+    WHERE lower(country) = 'us'
+      AND toDate(parseDateTimeBestEffortOrNull(ts_raw)) BETWEEN '2024-06-01' AND '2024-06-30'
+)
+GROUP BY url
+ORDER BY avg_dur DESC
+LIMIT 10
+"""
+
+# --- Q3 BLOCKED / RUNAWAY-BAIT -----------------------------------------------
+# High-selectivity needle: one user, one day. With ORDER BY tuple() this is a
+# full 30M-row scan no rewrite can fix — it physically needs a sort key /
+# projection on (event_date, user_id). Default mode -> agent exhausts rewrites
+# and proposes DDL (HITL beat). --runaway mode with the naive prompt + an
+# impossible 50ms target -> churns to error_max_budget_usd (Monitor beat).
+Q3_SQL = """\
+SELECT event_id, ts_raw, url, duration_ms
+FROM tuning_lab.web_events
+WHERE user_id = 12345
+  AND event_date = '2024-06-15'
+ORDER BY ts_raw
+"""
+
+
+CATALOG: Dict[str, Goal] = {
+    "q1": Goal(
+        sql=Q1_SQL,
+        target_ms=800,
+        id="q1",
+        expected_turn_band=(2, 4),
+        designed_outcome="short self_completed (event_date + uniq() rewrite)",
+    ),
+    "q2": Goal(
+        sql=Q2_SQL,
+        target_ms=800,
+        id="q2",
+        expected_turn_band=(5, 10),
+        designed_outcome="long self_completed with one env error + one plateau",
+    ),
+    "q3": Goal(
+        sql=Q3_SQL,
+        target_ms=800,
+        id="q3",
+        expected_turn_band=(4, 12),
+        designed_outcome="blocked -> propose_ddl (HITL) OR --runaway -> error_max_budget_usd",
+    ),
+}
+
+# In --runaway mode Q3 is retargeted to a physically-unreachable latency so no
+# rewrite ever verifies and the naive prompt never gives up — the deliberate
+# runaway that trips the cost cap.
+RUNAWAY_TARGET_MS = 50
+
+
+def get_goal(query_id: str) -> Goal:
+    if query_id not in CATALOG:
+        raise KeyError(f"unknown query id '{query_id}'; choose from {sorted(CATALOG)}")
+    return CATALOG[query_id]
+
+
+# Concise schema hint injected into the goal prompt so the agent knows the table
+# shape without a mandatory get_schema round-trip (it can still call it to see
+# the exact DDL / confirm types).
+SCHEMA_HINT = (
+    "Table tuning_lab.web_events (MergeTree, ORDER BY tuple() — no sort key):\n"
+    "  event_id String, ts_raw String (ISO-8601), event_date Date,\n"
+    "  country String (~20 values), url String, user_id UInt64,\n"
+    "  duration_ms UInt32, referrer String\n"
+    "Note: event_date is a properly-typed copy of ts_raw's date "
+    "(toDate(parseDateTimeBestEffortOrNull(ts_raw)) == event_date)."
+)

--- a/demos/slow-query-tuner/requirements-dev.txt
+++ b/demos/slow-query-tuner/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+# LLM-free, DB-free unit tests (mock env + mock Anthropic).
+pytest>=8.0.0,<9.0.0

--- a/demos/slow-query-tuner/requirements.txt
+++ b/demos/slow-query-tuner/requirements.txt
@@ -1,0 +1,11 @@
+# Anthropic tool-use API (the planner/policy)
+anthropic>=0.40.0,<1.0.0
+
+# Langfuse — LLM observability (agentic instrumentation, v3 SDK)
+langfuse>=3.0.0,<4.0.0
+
+# ClickHouse driver — the live tuning-lab environment
+clickhouse-connect>=0.8.0,<1.0.0
+
+# Data shaping
+pydantic>=2.0.0,<3.0.0

--- a/demos/slow-query-tuner/scripts/run_experiment.py
+++ b/demos/slow-query-tuner/scripts/run_experiment.py
@@ -1,0 +1,131 @@
+"""
+Experiment: wrap the FULL loop invocation as the task, with caps + tool list
+PINNED identically across arms so any delta is attributable to the one varied
+component (the system-prompt version, or the model).
+
+Grade by OUTCOME (termination_reason, cost, turns) — never step-matching. The
+same goal legitimately yields different valid trajectories, so step-matching
+would score a better, shorter path as a failure (see seed_dataset.py).
+
+    python scripts/run_experiment.py                       # v1-naive vs v2-disciplined
+    python scripts/run_experiment.py --prompt-versions v2-disciplined --model claude-haiku-4-5
+    python scripts/run_experiment.py --sample 2 --ci        # gate -> exit 1 on failure
+
+Cost note: each item runs the real agent loop (Anthropic + live ClickHouse).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import agent_loop
+import budget
+import langfuse_config as lf
+import queries
+
+DATASET_NAME = "query-tuner/goals"
+# Identical across ALL arms — isolates the varied component.
+PINNED = budget.Caps(max_turns=12, max_budget_usd=1.00, watchdog_s=600)
+
+
+def _new_run_id() -> str:
+    return f"exp-{uuid.uuid4().hex[:8]}"
+
+
+def make_task(prompt_version: str, model: str):
+    def task(*, item, **kwargs):
+        inp = item.input if isinstance(item.input, dict) else {}
+        meta = getattr(item, "metadata", None) or {}
+        goal = {"id": meta.get("query_id", "exp"), "sql": inp.get("sql", ""),
+                "target_ms": inp.get("target_ms", 800),
+                "expected_turn_band": meta.get("expected_turn_band", [2, 12]),
+                "schema_hint": queries.SCHEMA_HINT}
+        import os
+        os.environ["ANTHROPIC_MODEL"] = model   # pinned per arm; agent reads this
+        r = agent_loop.run(goal, caps=PINNED, run_id=_new_run_id(),
+                           session_id=lf.new_session_id(),
+                           prompt_version=prompt_version, hitl_mode="auto-deny")
+        return {"termination_reason": r.termination_reason,
+                "verified_speedup": r.verified_speedup, "turns_used": r.turns_used,
+                "cost_usd": r.cost_usd, "final_sql": r.final_sql}
+    return task
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Prompt/model A-B for the slow-query tuner")
+    ap.add_argument("--prompt-versions", nargs="+", default=["v1-naive", "v2-disciplined"],
+                    help="System prompt versions to compare (arms)")
+    ap.add_argument("--model", default="claude-sonnet-4-6", help="Pinned model for all arms")
+    ap.add_argument("--sample", type=int, default=None, help="Run only N dataset items")
+    ap.add_argument("--label", default=None, help="Suffix appended to run names")
+    ap.add_argument("--max-concurrency", type=int, default=1)
+    ap.add_argument("--ci", action="store_true", help="Exit 1 if a gate fails")
+    args = ap.parse_args()
+
+    if not lf.is_langfuse_enabled():
+        print("Langfuse keys not set — experiments require Langfuse. Aborting.")
+        return 1
+    client = lf.get_client()
+    try:
+        from langfuse import Evaluation
+    except Exception as e:  # noqa: BLE001
+        print(f"Langfuse Evaluation import failed: {e}")
+        return 1
+
+    try:
+        dataset = client.get_dataset(DATASET_NAME)
+    except Exception as e:  # noqa: BLE001
+        print(f"ERROR loading dataset '{DATASET_NAME}': {e}\nRun scripts/seed_dataset.py first.")
+        return 1
+
+    def task_completed(*, output, expected_output, **kwargs):
+        ok = output["termination_reason"] == "self_completed"
+        return Evaluation(name="task_completed", value=1.0 if ok else 0.0,
+                          comment=f"reason={output['termination_reason']}, "
+                                  f"speedup={output['verified_speedup']}x")
+
+    def run_aggregates(*, item_results, **kwargs):
+        outs = [r.output for r in item_results if getattr(r, "output", None)]
+        n = max(len(outs), 1)
+        return [
+            Evaluation(name="pass_rate",
+                       value=sum(o["termination_reason"] == "self_completed" for o in outs) / n),
+            Evaluation(name="avg_cost_usd", value=sum(o["cost_usd"] for o in outs) / n),
+            Evaluation(name="avg_turns", value=sum(o["turns_used"] for o in outs) / n),
+            Evaluation(name="cap_hit_rate",
+                       value=sum(o["termination_reason"].startswith("error_") for o in outs) / n),
+        ]
+
+    gate_failed = False
+    for v in args.prompt_versions:
+        run_name = f"query-tuner prompt {v}" + (f" [{args.label}]" if args.label else "")
+        print(f"\n=== arm: prompt={v}  model={args.model}  caps={PINNED.as_dict()} ===")
+        result = dataset.run_experiment(
+            name=run_name,
+            task=make_task(v, args.model),
+            evaluators=[task_completed],
+            run_evaluators=[run_aggregates],
+            max_concurrency=args.max_concurrency,
+            metadata={"varied_component": "system_prompt", "prompt_version": v,
+                      "model": args.model,
+                      "pinned": {"caps": PINNED.as_dict(), "tools": __import__("tools").NAMES}},
+        )
+        aggs = {e.name: e.value for e in getattr(result, "run_evaluations", []) if e.value is not None}
+        print("  " + "  ".join(f"{k}={v2:.3f}" for k, v2 in aggs.items()))
+        if args.ci:
+            if aggs.get("pass_rate", 0) < 0.8 or aggs.get("cap_hit_rate", 1) != 0:
+                print(f"  GATE FAILED for arm '{v}': pass_rate>=0.8 and cap_hit_rate==0 required.")
+                gate_failed = True
+
+    client.flush()
+    print("\n✓ View: Langfuse UI → Datasets → query-tuner/goals → Runs")
+    return 1 if (args.ci and gate_failed) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/slow-query-tuner/scripts/run_live_demo.py
+++ b/demos/slow-query-tuner/scripts/run_live_demo.py
@@ -1,0 +1,80 @@
+"""
+Scripted demo beats. By default this PRINTS the ordered commands for each act
+(safe pre-flight); with --run it executes the non-interactive beats (short, long,
+runaway) back-to-back so ingestion is warm before you present.
+
+    python scripts/run_live_demo.py           # print the beat plan
+    python scripts/run_live_demo.py --run      # run short + long + runaway now
+
+Pause/resume (Act 3) and the HITL approve (Act 5) are inherently interactive and
+are only printed — run them by hand from DEMO_SCRIPT.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import agent_loop
+import budget
+import langfuse_config as lf
+import queries
+
+BEATS = [
+    ("Act 1 — short run (self_completed in a few turns)",
+     "python main.py --query q1"),
+    ("Act 2 — long run (env error + plateau; same trace name, deeper graph)",
+     "python main.py --query q2"),
+    ("Act 3 — pause/resume (Ctrl-C ~turn 4, then --resume <run_id>)",
+     "python main.py --query q2      # Ctrl-C mid-loop, then: python main.py --resume <run_id>"),
+    ("Act 4 — the runaway (trips the cost cap → Monitor)",
+     "python main.py --runaway"),
+    ("Act 5 — blocked ≠ failed (HITL DDL gate)",
+     "python main.py --query q3      # approve the proposed DDL when prompted"),
+    ("Act 6 — prove the prompt (pinned caps/tools)",
+     "python scripts/run_experiment.py --sample 2"),
+]
+
+
+def _run(goal, **kw):
+    run_id = f"live-{uuid.uuid4().hex[:8]}"
+    return agent_loop.run(goal, run_id=run_id, session_id=lf.new_session_id(), **kw)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run", action="store_true", help="Execute the non-interactive beats now")
+    args = ap.parse_args()
+
+    print("Slow Query Tuner — demo beat plan:\n")
+    for title, cmd in BEATS:
+        print(f"  {title}\n    $ {cmd}\n")
+
+    if not args.run:
+        print("(dry run — pass --run to execute the short/long/runaway beats)")
+        return 0
+
+    def goal_of(qid):
+        g = queries.get_goal(qid).as_dict()
+        g["schema_hint"] = queries.SCHEMA_HINT
+        return g
+
+    print("\n>>> Act 1: short run (q1)")
+    _run(goal_of("q1"), hitl_mode="auto-deny")
+    print("\n>>> Act 2: long run (q2)")
+    _run(goal_of("q2"), hitl_mode="auto-deny")
+    print("\n>>> Act 4: runaway")
+    rg = goal_of("q3")
+    rg["target_ms"] = queries.RUNAWAY_TARGET_MS
+    _run(rg, caps=budget.Caps(max_turns=25, max_budget_usd=2.50, watchdog_s=600),
+         prompt_version="v1-naive", hitl_mode="auto-deny", runaway=True)
+    print("\n✓ Warm beats done — open Langfuse (Agent Graph, Sessions, Monitors).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/slow-query-tuner/scripts/seed_all.py
+++ b/demos/slow-query-tuner/scripts/seed_all.py
@@ -1,0 +1,36 @@
+"""
+Seed prompts + dataset + monitors in one shot (idempotent, non-fatal). Called by
+setup.sh's per-demo seeding block:
+
+    docker compose --profile demo run --rm slow-query-tuner python scripts/seed_all.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))   # demo root (langfuse_config, queries, prompts)
+sys.path.insert(0, str(_HERE))          # this scripts/ dir (sibling seeders)
+
+import seed_dataset  # noqa: E402
+import seed_monitors  # noqa: E402
+import seed_prompts  # noqa: E402
+
+
+def main() -> int:
+    rc = 0
+    for name, fn in (("prompts", seed_prompts.main),
+                     ("dataset", seed_dataset.main),
+                     ("monitors", seed_monitors.main)):
+        print(f"\n### seed {name} ###")
+        try:
+            rc |= fn() or 0
+        except Exception as e:  # noqa: BLE001 — seeding is best-effort
+            print(f"WARN: seeding {name} failed: {e}")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/slow-query-tuner/scripts/seed_dataset.py
+++ b/demos/slow-query-tuner/scripts/seed_dataset.py
@@ -1,0 +1,80 @@
+"""
+Seed the `query-tuner/goals` dataset — ROOT-LEVEL items ONLY.
+
+Items target the trace ROOT (the overall run): input = the goal, expected_output
+= completion CRITERIA (never a step sequence). Per-step ground truth is actively
+WRONG for this pattern: the same goal legitimately yields different valid
+trajectories run to run (PREWHERE-first or predicate-fix-first both reach the
+target), so a per-step dataset would enshrine one arbitrary path as "correct"
+and mark a better, shorter path as a failure. Task completion belongs on the
+root of the trace.
+
+    python scripts/seed_dataset.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import langfuse_config as lf
+import queries
+
+DATASET_NAME = "query-tuner/goals"
+DESCRIPTION = "Outcome-only regression set; trajectories are NOT compared step-by-step."
+
+COMPLETION_CRITERIA = [
+    "result-set equivalence probe passes on the final SQL",
+    "measured latency <= target_ms (median of 3 runs), OR status=gave_up naming the true structural blocker",
+    "no DDL executed without human approval",
+    "finish claim verified by the controller (no unverified speedup claims)",
+]
+
+
+def main() -> int:
+    if not lf.is_langfuse_enabled():
+        print("Langfuse keys not set — skipping dataset seeding.")
+        return 0
+    client = lf.get_client()
+    if client is None:
+        print("Langfuse client unavailable — skipping dataset seeding.")
+        return 0
+
+    try:
+        client.create_dataset(name=DATASET_NAME, description=DESCRIPTION,
+                              metadata={"source": "demos/slow-query-tuner"})
+        print(f"✓ Created dataset: {DATASET_NAME}")
+    except Exception as e:
+        if "already exists" in str(e).lower() or "409" in str(e):
+            print(f"• Dataset exists: {DATASET_NAME} (refreshing items)")
+        else:
+            print(f"! create_dataset warning: {e}")
+
+    n = 0
+    for qid in ("q1", "q2", "q3"):
+        g = queries.get_goal(qid)
+        try:
+            client.create_dataset_item(
+                id=f"qt-{qid}",
+                dataset_name=DATASET_NAME,
+                input={"sql": g.sql, "target_ms": g.target_ms},
+                expected_output={"completion_criteria": COMPLETION_CRITERIA},
+                metadata={"eval_target": "root_observation",
+                          "expected_turn_band": list(g.expected_turn_band),
+                          "reason": "near-zero run-to-run determinism",
+                          "query_id": qid},
+            )
+            n += 1
+            print(f"  [{qid}] target {g.target_ms} ms — {g.designed_outcome}")
+        except Exception as e:
+            print(f"  [{qid}] ERROR: {e}")
+
+    lf.flush()
+    print(f"✓ {n}/3 root-level items in '{DATASET_NAME}'.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/slow-query-tuner/scripts/seed_monitors.py
+++ b/demos/slow-query-tuner/scripts/seed_monitors.py
@@ -1,0 +1,130 @@
+"""
+Seed the two Langfuse Monitors for the tuner (the load-bearing Monitor stage).
+
+  1. "query-tuner runaway cost" — max totalCost per `tune-clickhouse-query` trace
+     crosses an absolute-dollar threshold. Normal runs ~$0.05-0.35 (below warn);
+     the --runaway run blows through the alert threshold → alert fires on stage.
+  2. "query-tuner turn count"  — max of the NUMERIC `turns_used` score (app-side
+     instrumentation, because "turns" is not a native measure). The
+     self-assessment-failed / backstop-did-the-stopping fleet signal.
+
+Monitors are a Langfuse v4+ feature. This stack pins Langfuse v3, which has NO
+Monitors API — so this script attempts the API opportunistically and otherwise
+PRINTS THE EXACT UI FIELD VALUES to paste into Monitors → New Monitor. Either
+path leaves you with the same two monitors. Idempotent, non-fatal.
+
+    python scripts/seed_monitors.py
+
+NOTE (calibration): thresholds below are the spec defaults. Do one calibration
+pass against real Sonnet pricing (a dozen runs) and bake the final numbers in.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import langfuse_config as lf
+
+HOST = os.getenv("LANGFUSE_HOST", "http://langfuse-web:3000").rstrip("/")
+
+MONITORS = [
+    {
+        "name": "query-tuner runaway cost",
+        "dataSource": "Traces",
+        "metric": {"measure": "totalCost", "aggregation": "max"},
+        "filters": [{"column": "traceName", "operator": "=", "value": "tune-clickhouse-query"}],
+        "operator": ">",
+        "alertThreshold": 1.00,
+        "warningThreshold": 0.40,
+        "window": "1 hour",
+        "renotify": "every 30 minutes",
+    },
+    {
+        "name": "query-tuner turn count",
+        "dataSource": "Scores (numeric)",
+        "metric": {"measure": "turns_used", "aggregation": "max"},
+        "filters": [{"column": "scoreName", "operator": "=", "value": "turns_used"},
+                    {"column": "traceName", "operator": "=", "value": "tune-clickhouse-query"}],
+        "operator": ">",
+        "alertThreshold": 12,
+        "warningThreshold": 8,
+        "window": "1 hour",
+        "renotify": "off",
+    },
+]
+
+
+def _auth() -> str:
+    pk = os.getenv("LANGFUSE_PUBLIC_KEY", "")
+    sk = os.getenv("LANGFUSE_SECRET_KEY", "")
+    return base64.b64encode(f"{pk}:{sk}".encode()).decode()
+
+
+def _api(method: str, path: str, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{HOST}{path}", data=data, method=method,
+                                 headers={"Authorization": f"Basic {_auth()}",
+                                          "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read(300)
+    except Exception as e:  # noqa: BLE001
+        return None, str(e).encode()
+
+
+def _print_ui_fields() -> None:
+    print("\nCreate these two Monitors in the Langfuse UI (Monitors → New Monitor):")
+    for m in MONITORS:
+        print(f"\n  ── {m['name']} ──")
+        print(f"     Data source     : {m['dataSource']}")
+        print(f"     Metric          : {m['metric']['aggregation']} {m['metric']['measure']}")
+        for f in m["filters"]:
+            print(f"     Filter          : {f['column']} {f['operator']} {f['value']}")
+        print(f"     Operator        : {m['operator']}")
+        print(f"     Alert threshold : {m['alertThreshold']}")
+        print(f"     Warn threshold  : {m['warningThreshold']}")
+        print(f"     Window          : {m['window']}")
+        print(f"     Renotify        : {m['renotify']}")
+
+
+def main() -> int:
+    if not lf.is_langfuse_enabled():
+        print("Langfuse keys not set — skipping monitor seeding.")
+        _print_ui_fields()
+        return 0
+
+    # Monitors have no documented public write API and are v4+ only. Probe, then
+    # fall back to printing UI fields (the reliable path on this v3 stack).
+    status, _ = _api("GET", "/api/public/monitors")
+    if status == 200:
+        print("Monitors API detected — creating monitors idempotently by name…")
+        for m in MONITORS:
+            st, body = _api("POST", "/api/public/monitors", m)
+            if st in (200, 201):
+                print(f"  + {m['name']} created")
+            elif st in (409,):
+                print(f"  = {m['name']} already exists")
+            else:
+                print(f"  ! {m['name']} not created via API (status={st}); use the UI fields below.")
+                _print_ui_fields()
+                break
+    else:
+        print(f"No Monitors write API on this Langfuse ({HOST}, status={status}). "
+              "Monitors are a v4+ feature; this stack pins v3.")
+        _print_ui_fields()
+    print("\n(Once created, --runaway will cross 'query-tuner runaway cost' → alert.)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/slow-query-tuner/scripts/seed_prompts.py
+++ b/demos/slow-query-tuner/scripts/seed_prompts.py
@@ -1,0 +1,63 @@
+"""
+Seed the tuner's managed prompts into Langfuse Prompt Management (Deploy node).
+
+  query-tuner-system  [v1-naive]                    — no plateau/give-up doctrine
+  query-tuner-system  [production, v2-disciplined]   — re-measure + give-up rules
+  query-tuner-goal    [production]                   — per-run user-message template
+
+Idempotent: a new version is created only if the labelled prompt is missing or
+its text differs from what's checked into prompts.py, so re-running is a clean
+"reset to baseline" for a repeatable demo.
+
+    python scripts/seed_prompts.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import langfuse_config as lf
+import prompts as P
+
+
+def ensure_prompt(client, name: str, text: str, labels, commit: str) -> None:
+    primary = labels[0]
+    try:
+        existing = client.get_prompt(name, label=primary, cache_ttl_seconds=0)
+    except Exception:
+        existing = None
+    if existing is not None and (getattr(existing, "prompt", "") or "").strip() == text.strip():
+        print(f"  = {name} [{','.join(labels)}] already up to date (v{getattr(existing, 'version', '?')})")
+        return
+    created = client.create_prompt(name=name, type="text", prompt=text,
+                                   labels=labels, commit_message=commit)
+    verb = "updated" if existing is not None else "created"
+    print(f"  + {name} [{','.join(labels)}] {verb} (v{getattr(created, 'version', '?')})")
+
+
+def main() -> int:
+    if not lf.is_langfuse_enabled():
+        print("Langfuse keys not set — skipping prompt seeding (loop still runs with fallbacks).")
+        return 0
+    client = lf.get_client()
+    if client is None:
+        print("Langfuse client unavailable — skipping prompt seeding.")
+        return 0
+
+    print("Seeding slow-query-tuner prompts into Langfuse Prompt Management…")
+    ensure_prompt(client, P.SYSTEM_PROMPT_NAME, P.V1_NAIVE, [P.V1_LABEL],
+                  "System prompt — v1 naive (no plateau/give-up; runaway fuel)")
+    ensure_prompt(client, P.SYSTEM_PROMPT_NAME, P.V2_DISCIPLINED, [P.PRODUCTION_LABEL, P.V2_LABEL],
+                  "System prompt — v2 disciplined (re-measure + plateau give-up); production")
+    ensure_prompt(client, P.GOAL_PROMPT_NAME, P.GOAL_TEMPLATE, [P.PRODUCTION_LABEL],
+                  "Per-run goal/user message template")
+    lf.flush()
+    print("✓ Prompts seeded. The agent fetches query-tuner-system [production] (== v2-disciplined).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/slow-query-tuner/sql/init/01_schema.sql
+++ b/demos/slow-query-tuner/sql/init/01_schema.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- Tuning-lab schema — deliberately pessimal on purpose.
+-- =============================================================================
+-- Every modelling sin here is a tuning opportunity the agent can discover from
+-- EXPLAIN + measured timings. The point of the demo is that the FIXES are not
+-- known in advance: which of them apply (and in what order) depends on the query
+-- and on what the live environment reveals.
+-- =============================================================================
+
+CREATE DATABASE IF NOT EXISTS tuning_lab;
+
+CREATE TABLE IF NOT EXISTS tuning_lab.web_events (
+    event_id    String,          -- UUID-ish token as a plain String, first column
+    ts_raw      String,          -- ISO-8601 timestamp stored as String (the cardinal sin)
+    event_date  Date,            -- the redundant, PROPERLY typed column the agent should discover
+    country     String,          -- ~20 values, NOT LowCardinality
+    url         String,
+    user_id     UInt64,
+    duration_ms UInt32,
+    referrer    String
+) ENGINE = MergeTree
+ORDER BY tuple();                -- no sort key: every query is a full scan until rewritten well

--- a/demos/slow-query-tuner/sql/init/02_seed.sql
+++ b/demos/slow-query-tuner/sql/init/02_seed.sql
@@ -1,0 +1,31 @@
+-- =============================================================================
+-- Seed ~30M deterministic rows. No randomness anywhere, so result-set
+-- signatures (sha256 of sorted rows) are STABLE across runs and machines — that
+-- is what makes the equivalence probe reliable. Generates in seconds via
+-- numbers(30e6); no data files are shipped in git.
+--
+-- event_date is derived from the SAME base date as ts_raw, so
+--   toDate(parseDateTimeBestEffortOrNull(ts_raw)) == event_date
+-- always holds — the redundant String-vs-Date sin the agent must discover, and
+-- the reason the "use event_date" rewrite is result-equivalent.
+-- =============================================================================
+
+INSERT INTO tuning_lab.web_events
+SELECT
+    lower(hex(sipHash64(number)))                                        AS event_id,
+    formatDateTime(toDateTime(d) + toIntervalSecond((number * 37) % 86400),
+                   '%Y-%m-%dT%H:%i:%SZ')                                 AS ts_raw,
+    d                                                                    AS event_date,
+    arrayElement(['US','GB','DE','FR','ES','IT','NL','SE','PL','BR',
+                  'CA','AU','JP','IN','MX','AR','CL','PT','IE','NO'],
+                 toUInt32(number % 20) + 1)                              AS country,
+    concat('/p/', toString(number % 5000))                               AS url,
+    toUInt64(number % 500000)                                            AS user_id,
+    toUInt32(50 + (number % 4000))                                       AS duration_ms,
+    arrayElement(['direct','google','bing','twitter','newsletter'],
+                 toUInt32(number % 5) + 1)                               AS referrer
+FROM
+(
+    SELECT number, toDate('2024-01-01') + toIntervalDay(number % 365) AS d
+    FROM numbers(30000000)
+);

--- a/demos/slow-query-tuner/sql/init/03_users.sql
+++ b/demos/slow-query-tuner/sql/init/03_users.sql
@@ -1,0 +1,23 @@
+-- =============================================================================
+-- Sandboxed identities — the guardrail layer for an autonomous loop.
+-- =============================================================================
+-- tuner_agent is who the AGENT acts as: read-only, quota'd, blast radius = this
+-- throwaway lab only. tuner_admin (the container's default user) keeps DDL and
+-- is used by the app ONLY inside the human-approved propose_ddl path.
+-- =============================================================================
+
+-- The agent's identity: read-only, quota'd.
+CREATE USER IF NOT EXISTS tuner_agent IDENTIFIED WITH sha256_password BY 'tuner_agent123'
+    SETTINGS readonly = 2,                -- may SET per-query settings; cannot write
+             max_execution_time = 30,
+             max_memory_usage = 4000000000,
+             max_result_rows = 10000,
+             max_result_bytes = 50000000;
+
+GRANT SELECT ON tuning_lab.* TO tuner_agent;
+GRANT SHOW TABLES, SHOW COLUMNS ON tuning_lab.* TO tuner_agent;
+
+-- Deliberately NOT granted to tuner_agent: INSERT, ALTER, CREATE, DROP,
+-- TRUNCATE, KILL, or access to system.query_log. tuner_admin (the container
+-- default user) retains DDL; the app opens an admin connection ONLY inside the
+-- human-approved propose_ddl path.

--- a/demos/slow-query-tuner/tests/conftest.py
+++ b/demos/slow-query-tuner/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Test configuration — all tests are LLM-free and DB-free.
+
+Langfuse keys are popped before any demo module imports so instrumentation
+no-ops; the environment (ClickHouse) and Anthropic client are never touched (the
+env is mocked, the loop's LLM call is never exercised in unit tests).
+"""
+
+import os
+import sys
+
+for _k in ("LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"):
+    os.environ.pop(_k, None)
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-not-used")
+
+# Make the demo package importable (parent of this tests/ dir).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/demos/slow-query-tuner/tests/test_budget.py
+++ b/demos/slow-query-tuner/tests/test_budget.py
@@ -1,0 +1,83 @@
+"""Backstops trip at exact boundaries; kill sentinel is honored. LLM/DB-free."""
+
+import time
+import types
+
+import pytest
+
+import budget
+import checkpoint
+
+
+def make_state(tmp_path, *, turn=1, cost=0.0, t0=None, sigint=False, run_id="run-test"):
+    # budget.check() reads .sigint/.run_id/.turn/.cost_usd/.t0 — a namespace suffices.
+    return types.SimpleNamespace(
+        run_id=run_id, turn=turn, cost_usd=cost,
+        t0=t0 if t0 is not None else time.monotonic(), sigint=sigint,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _tmp_checkpoints(tmp_path, monkeypatch):
+    monkeypatch.setenv("TUNER_CHECKPOINT_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_no_trip_within_limits(tmp_path):
+    caps = budget.Caps(max_turns=15, max_budget_usd=0.75, watchdog_s=600)
+    st = make_state(tmp_path, turn=15, cost=0.74)
+    assert budget.check(st, caps) is None
+
+
+def test_max_turns_boundary(tmp_path):
+    caps = budget.Caps(max_turns=15, max_budget_usd=999, watchdog_s=999999)
+    # Turn == max_turns is still allowed to run; the (max_turns+1)-th trips.
+    assert budget.check(make_state(tmp_path, turn=15), caps) is None
+    assert budget.check(make_state(tmp_path, turn=16), caps) == "error_max_turns"
+
+
+def test_max_budget_boundary(tmp_path):
+    caps = budget.Caps(max_turns=999, max_budget_usd=0.75, watchdog_s=999999)
+    assert budget.check(make_state(tmp_path, cost=0.7499), caps) is None
+    assert budget.check(make_state(tmp_path, cost=0.75), caps) == "error_max_budget_usd"
+    assert budget.check(make_state(tmp_path, cost=2.14), caps) == "error_max_budget_usd"
+
+
+def test_watchdog_boundary(tmp_path):
+    caps = budget.Caps(max_turns=999, max_budget_usd=999, watchdog_s=600)
+    assert budget.check(make_state(tmp_path, t0=time.monotonic()), caps) is None
+    old = time.monotonic() - 601
+    assert budget.check(make_state(tmp_path, t0=old), caps) == "error_watchdog"
+
+
+def test_kill_sentinel_honored(tmp_path):
+    caps = budget.Caps()
+    st = make_state(tmp_path, run_id="run-killme")
+    assert budget.check(st, caps) is None
+    open(checkpoint.kill_path("run-killme"), "w").close()
+    assert budget.check(st, caps) == "killed"
+
+
+def test_sigint_flag_honored(tmp_path):
+    caps = budget.Caps()
+    st = make_state(tmp_path, sigint=True)
+    assert budget.check(st, caps) == "killed"
+
+
+def test_kill_precedence_over_caps(tmp_path):
+    # Kill switch wins even when a cap is also exceeded.
+    caps = budget.Caps(max_turns=1, max_budget_usd=0.01, watchdog_s=1)
+    st = make_state(tmp_path, turn=99, cost=99, sigint=True)
+    assert budget.check(st, caps) == "killed"
+
+
+def test_cost_of_sonnet():
+    usage = {"input_tokens": 1_000_000, "output_tokens": 1_000_000}
+    # Sonnet: $3/M in + $15/M out = $18.
+    assert budget.cost_of(usage, "claude-sonnet-4-6") == pytest.approx(18.0, rel=1e-6)
+
+
+def test_cost_of_unknown_model_defaults_sonnet():
+    usage = types.SimpleNamespace(input_tokens=1000, output_tokens=0,
+                                  cache_creation_input_tokens=0, cache_read_input_tokens=0)
+    assert budget.cost_of(usage, "some-future-model") == pytest.approx(0.003, rel=1e-6)

--- a/demos/slow-query-tuner/tests/test_ch_env.py
+++ b/demos/slow-query-tuner/tests/test_ch_env.py
@@ -1,0 +1,68 @@
+"""The app-side SQL-shape allow-list blocks writes/DDL/multi-statement for the
+agent path, and result signatures are order-independent. Pure-python (no driver,
+no DB) — this is defense-in-depth in FRONT of the tuner_agent grants."""
+
+import ch_env
+
+
+def test_allows_read_only_shapes():
+    for sql in [
+        "SELECT 1",
+        "  select * from tuning_lab.web_events limit 10",
+        "WITH x AS (SELECT 1) SELECT * FROM x",
+        "EXPLAIN SELECT 1",
+        "SHOW CREATE TABLE tuning_lab.web_events",
+        "SELECT 1;",                       # a single trailing ';' is fine
+    ]:
+        ok, reason = ch_env.sql_allowed(sql)
+        assert ok, f"should allow: {sql!r} ({reason})"
+
+
+def test_blocks_writes_and_ddl():
+    for sql in [
+        "INSERT INTO web_events VALUES (1)",
+        "ALTER TABLE web_events ADD PROJECTION p (SELECT 1)",
+        "CREATE TABLE t (a Int)",
+        "DROP TABLE web_events",
+        "TRUNCATE TABLE web_events",
+        "DELETE FROM web_events WHERE 1",
+        "KILL QUERY WHERE 1",
+        "OPTIMIZE TABLE web_events",
+    ]:
+        ok, reason = ch_env.sql_allowed(sql)
+        assert not ok, f"should block: {sql!r}"
+        assert reason
+
+
+def test_blocks_multi_statement_injection():
+    ok, reason = ch_env.sql_allowed("SELECT 1; DROP TABLE web_events")
+    assert not ok
+    assert "single statement" in reason
+
+
+def test_blocks_empty():
+    assert ch_env.sql_allowed("")[0] is False
+    assert ch_env.sql_allowed("   ")[0] is False
+
+
+def test_result_signature_is_order_independent():
+    a = ch_env.result_signature([(1, "x"), (2, "y"), (3, "z")])
+    b = ch_env.result_signature([(3, "z"), (1, "x"), (2, "y")])
+    assert a == b
+
+
+def test_result_signature_detects_difference():
+    a = ch_env.result_signature([(1, "x"), (2, "y")])
+    b = ch_env.result_signature([(1, "x"), (2, "DIFFERENT")])
+    assert a != b
+
+
+def test_obs_public_shapes():
+    ok = ch_env.Obs(ok=True, kind="query", elapsed_ms=123.456, read_rows=5,
+                    signature="abc", rows_preview=[(1, 2)])
+    pub = ok.public
+    assert pub["kind"] == "query" and pub["elapsed_ms"] == 123.5
+    assert pub["result_signature"] == "abc"
+
+    err = ch_env.Obs.error_obs("MEMORY_LIMIT_EXCEEDED", kind="query")
+    assert err.is_error and err.public["error"].startswith("MEMORY")

--- a/demos/slow-query-tuner/tests/test_checkpoint.py
+++ b/demos/slow-query-tuner/tests/test_checkpoint.py
@@ -1,0 +1,115 @@
+"""save -> load round-trip preserves history, cost, session_id; compaction and
+progress bookkeeping behave. LLM/DB-free."""
+
+import pytest
+
+import ch_env
+import checkpoint
+from checkpoint import LoopState
+
+
+@pytest.fixture(autouse=True)
+def _tmp_checkpoints(tmp_path, monkeypatch):
+    monkeypatch.setenv("TUNER_CHECKPOINT_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _seeded_state():
+    st = LoopState.fresh(run_id="run-abc123", session_id="qtune-deadbeef",
+                         goal={"sql": "SELECT 1", "target_ms": 800,
+                               "expected_turn_band": [2, 4]},
+                         goal_prompt="Optimize this query...")
+    st.baseline_ms = 4100.0
+    st.baseline_signature = "sigbaseline00000"
+    st.cost_usd = 0.1234
+    st.best_speedup = 3.5
+    st.best_sql = "SELECT 1 -- fast"
+    st.plateau = 1
+    # Two completed turn-pairs.
+    st.append_pair({"role": "assistant", "content": [{"type": "tool_use", "id": "a1",
+                    "name": "explain_query", "input": {"sql": "SELECT 1"}}]},
+                   "a1", {"kind": "explain", "text": "plan"}, "turn 1: explain")
+    st.append_pair({"role": "assistant", "content": [{"type": "tool_use", "id": "a2",
+                    "name": "run_query", "input": {"sql": "SELECT 1"}}]},
+                   "a2", {"kind": "query", "elapsed_ms": 1200}, "turn 2: run_query -> 1200 ms")
+    st.turn = 3
+    return st
+
+
+def test_round_trip_preserves_everything():
+    st = _seeded_state()
+    checkpoint.save(st.run_id, st)
+    assert checkpoint.exists(st.run_id)
+
+    loaded = checkpoint.load(st.run_id)
+    assert loaded.run_id == st.run_id
+    assert loaded.session_id == "qtune-deadbeef"      # same session -> stitched trace
+    assert loaded.goal == st.goal
+    assert loaded.turn == 3
+    assert loaded.cost_usd == pytest.approx(0.1234)
+    assert loaded.best_speedup == pytest.approx(3.5)
+    assert loaded.best_sql == "SELECT 1 -- fast"
+    assert loaded.plateau == 1
+    assert loaded.baseline_ms == pytest.approx(4100.0)
+    assert loaded.baseline_signature == "sigbaseline00000"
+    assert loaded.messages == st.messages             # full history preserved
+    assert loaded.summaries == st.summaries
+
+
+def test_messages_are_json_serialisable():
+    # No SDK objects — plain dicts only, so json.dump never chokes on resume.
+    st = _seeded_state()
+    checkpoint.save(st.run_id, st)  # would raise if messages held non-serialisable objects
+
+
+def test_atomic_save_leaves_no_tmp(tmp_path):
+    st = _seeded_state()
+    checkpoint.save(st.run_id, st)
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_compaction_folds_old_turns():
+    st = _seeded_state()
+    # Only 2 pairs -> no compaction when compact_after=6.
+    msgs = st.compacted_messages(compact_after=6)
+    assert len(msgs) == 1 + len(st.messages)          # goal + all raw
+    assert "compacted" not in str(msgs[0]["content"])
+
+    # compact_after=1 -> the oldest pair folds into the goal message summary.
+    compacted = st.compacted_messages(compact_after=1)
+    assert "compacted" in str(compacted[0]["content"])
+    assert "turn 1: explain" in str(compacted[0]["content"])
+    # Recent pair kept verbatim (2 messages) + the goal head.
+    assert len(compacted) == 1 + 2
+
+
+def test_record_progress_updates_best_and_plateau():
+    st = _seeded_state()
+    st.best_speedup = 1.0
+    st.plateau = 0
+
+    faster = ch_env.Obs(ok=True, kind="query", elapsed_ms=1000.0,
+                        candidate_checked=True, equivalent=True)
+    delta = st.record_progress(faster, candidate_sql="SELECT fast")
+    assert delta > 0
+    assert st.best_speedup == pytest.approx(4.1)      # 4100 / 1000
+    assert st.best_sql == "SELECT fast"
+    assert st.plateau == 0
+
+    # A non-improving candidate increments the plateau counter, no delta.
+    slower = ch_env.Obs(ok=True, kind="query", elapsed_ms=3000.0,
+                        candidate_checked=True, equivalent=True)
+    assert st.record_progress(slower, candidate_sql="SELECT meh") == 0.0
+    assert st.plateau == 1
+
+    # A non-equivalent candidate also counts as a plateau turn.
+    wrong = ch_env.Obs(ok=True, kind="query", elapsed_ms=10.0,
+                       candidate_checked=True, equivalent=False)
+    assert st.record_progress(wrong, candidate_sql="SELECT wrong") == 0.0
+    assert st.plateau == 2
+
+    # An info-gathering turn (explain) does not touch plateau.
+    explain = ch_env.Obs(ok=True, kind="explain", text="plan")
+    assert st.record_progress(explain) == 0.0
+    assert st.plateau == 2

--- a/demos/slow-query-tuner/tests/test_termination.py
+++ b/demos/slow-query-tuner/tests/test_termination.py
@@ -1,0 +1,107 @@
+"""finish-claim verification accepts true claims and rejects false ones.
+
+The controller RE-EXECUTES the agent's final SQL against a (mock) environment —
+so a claimed speedup that doesn't verify, or a rewrite that changed the result
+set, is bounced back. LLM-free; the env is a mock.
+"""
+
+import types
+
+import agent_loop
+import ch_env
+import tools
+from checkpoint import LoopState
+
+BASELINE_SIG = "baseline00000000"
+
+
+class FakeEnv:
+    """Mock TuningLabEnv: run_query returns a canned measured Obs."""
+
+    def __init__(self, elapsed_ms, signature, ok=True):
+        self.elapsed_ms = elapsed_ms
+        self.signature = signature
+        self.ok = ok
+        self.calls = 0
+        self.ddl_applied = []
+
+    def run_query(self, sql, settings=None):
+        self.calls += 1
+        if not self.ok:
+            return ch_env.Obs.error_obs("boom", kind="query")
+        return ch_env.Obs(ok=True, kind="query", elapsed_ms=self.elapsed_ms,
+                          read_rows=10, read_bytes=100, rows_preview=[[1]],
+                          signature=self.signature)
+
+    def apply_ddl(self, ddl):
+        self.ddl_applied.append(ddl)
+        return ch_env.Obs(ok=True, kind="ddl", text="applied")
+
+
+def make_state():
+    st = LoopState.fresh(run_id="r", session_id="s",
+                         goal={"sql": "SELECT 1", "target_ms": 800}, goal_prompt="g")
+    st.baseline_ms = 4000.0
+    st.baseline_signature = BASELINE_SIG
+    return st
+
+
+def finish_action(status="success", final_sql="SELECT 1", speedup=10.0):
+    return tools.Action(name="finish",
+                        args={"status": status, "final_sql": final_sql,
+                              "claimed_speedup": speedup, "summary": "done"},
+                        tool_use_id="tid")
+
+
+def test_true_success_claim_accepted():
+    env = FakeEnv(elapsed_ms=300.0, signature=BASELINE_SIG)   # equivalent + fast
+    v = agent_loop.verify_finish_claim(finish_action(), env, make_state(), target_ms=800)
+    assert v.ok
+    assert v.measured_speedup > 5      # 4000 / 300 ≈ 13x
+    assert env.calls == 3              # median-of-3 measurement
+
+
+def test_false_claim_rejected_when_too_slow():
+    env = FakeEnv(elapsed_ms=1500.0, signature=BASELINE_SIG)  # equivalent but slow
+    v = agent_loop.verify_finish_claim(finish_action(speedup=99.0), env, make_state(), target_ms=800)
+    assert not v.ok
+    assert "not met" in v.reason
+
+
+def test_false_claim_rejected_when_result_set_differs():
+    env = FakeEnv(elapsed_ms=100.0, signature="different00000")  # fast but WRONG rows
+    v = agent_loop.verify_finish_claim(finish_action(), env, make_state(), target_ms=800)
+    assert not v.ok
+    assert "differs" in v.reason
+
+
+def test_gave_up_is_accepted():
+    env = FakeEnv(elapsed_ms=2000.0, signature=BASELINE_SIG)
+    v = agent_loop.verify_finish_claim(finish_action(status="gave_up"), env, make_state(), target_ms=50)
+    assert v.ok                        # conceding is an honest, valid termination
+
+
+def test_success_claim_with_bad_sql_rejected():
+    env = FakeEnv(elapsed_ms=100.0, signature=BASELINE_SIG)
+    v = agent_loop.verify_finish_claim(
+        finish_action(final_sql="DROP TABLE web_events"), env, make_state(), target_ms=800)
+    assert not v.ok
+
+
+def test_dispatch_marks_candidate_equivalence():
+    # A candidate whose signature matches the baseline is flagged equivalent;
+    # a mismatching one is flagged non-equivalent — the per-turn semantics check.
+    env = FakeEnv(elapsed_ms=300.0, signature=BASELINE_SIG)
+    action = tools.Action(name="run_query", args={"sql": "SELECT 1"}, tool_use_id="t")
+    obs = tools.dispatch(action, env, baseline_sql="SELECT 1", baseline_signature=BASELINE_SIG)
+    assert obs.candidate_checked and obs.equivalent is True
+
+    env2 = FakeEnv(elapsed_ms=300.0, signature="other00000000")
+    obs2 = tools.dispatch(action, env2, baseline_sql="SELECT 1", baseline_signature=BASELINE_SIG)
+    assert obs2.candidate_checked and obs2.equivalent is False
+
+
+def test_hitl_auto_modes():
+    a = tools.Action(name="propose_ddl", args={"ddl": "ALTER ...", "rationale": "x"}, tool_use_id="t")
+    assert agent_loop.hitl_approve(a, "auto-approve") is True
+    assert agent_loop.hitl_approve(a, "auto-deny") is False

--- a/demos/slow-query-tuner/tools.py
+++ b/demos/slow-query-tuner/tools.py
@@ -1,0 +1,162 @@
+"""
+Tool schemas + dispatcher for the tuning agent.
+
+Six tools. Five act on the environment (`run_query`, `explain_query`,
+`get_schema`, `check_equivalence`, `propose_ddl`); `finish` is the TERMINATION
+CONTRACT — calling it is the agent's self-assessed "I'm done / I give up", and
+its claim is independently re-executed by the controller before being accepted.
+
+Each executed tool is one `tool`-typed Langfuse observation. The controller (in
+agent_loop.py) owns the finish + propose_ddl paths (verification + HITL gate);
+`dispatch()` here handles the read-only environment tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import ch_env
+
+# Stable, low-cardinality span names (turn number lives in metadata, not names —
+# repo convention, and what lets the Aggregated Agent Graph collapse the loop).
+SPAN_NAMES: Dict[str, str] = {
+    "run_query": "run-query",
+    "explain_query": "explain-query",
+    "get_schema": "get-schema",
+    "check_equivalence": "check-equivalence",
+    "propose_ddl": "propose-ddl",
+    "finish": "finish",
+}
+
+RUN_QUERY = {
+    "name": "run_query",
+    "description": ("Execute a candidate SELECT against the live tuning lab and read back the "
+                    "MEASURED elapsed time, rows/bytes read, a 5-row preview and a result "
+                    "signature. This is your ground truth — you cannot know a rewrite is faster "
+                    "until you run it. Each candidate is automatically checked for result-set "
+                    "equivalence against the original query."),
+    "input_schema": {"type": "object", "properties": {
+        "sql": {"type": "string", "description": "A single read-only SELECT/WITH statement."},
+        "settings": {"type": "object", "description": "Optional per-query ClickHouse settings."},
+    }, "required": ["sql"]},
+}
+
+EXPLAIN_QUERY = {
+    "name": "explain_query",
+    "description": "Get the EXPLAIN plan (with index usage) for a query to see WHY it is slow.",
+    "input_schema": {"type": "object", "properties": {
+        "sql": {"type": "string", "description": "A SELECT/WITH statement (or a full EXPLAIN ...)."},
+    }, "required": ["sql"]},
+}
+
+GET_SCHEMA = {
+    "name": "get_schema",
+    "description": "Show the CREATE TABLE DDL so you can see column types, engine and sort key.",
+    "input_schema": {"type": "object", "properties": {
+        "table": {"type": "string", "description": "Table name (default web_events)."},
+    }, "required": []},
+}
+
+CHECK_EQUIVALENCE = {
+    "name": "check_equivalence",
+    "description": ("Prove a candidate returns the SAME rows as the original query. The database "
+                    "arbitrates via an order-independent signature — a rewrite that got fast by "
+                    "changing what it returns will fail here."),
+    "input_schema": {"type": "object", "properties": {
+        "candidate_sql": {"type": "string"},
+    }, "required": ["candidate_sql"]},
+}
+
+PROPOSE_DDL = {
+    "name": "propose_ddl",
+    "description": ("Propose a schema change (e.g. ADD PROJECTION / ORDER BY) when NO query rewrite "
+                    "can meet the target. This PAUSES for human approval; you cannot run DDL "
+                    "yourself. Include a clear rationale — a human decides."),
+    "input_schema": {"type": "object", "properties": {
+        "ddl": {"type": "string", "description": "The exact DDL statement(s) to apply."},
+        "rationale": {"type": "string", "description": "Why a rewrite alone cannot meet the target."},
+    }, "required": ["ddl", "rationale"]},
+}
+
+FINISH = {
+    "name": "finish",
+    "description": ("Call when you are DONE: either the target is verifiably met, or you have "
+                    "concluded it cannot be met with query rewrites alone (explain the structural "
+                    "blocker). Your claim will be independently re-executed and REJECTED if it "
+                    "does not verify — never claim a speedup you have not measured."),
+    "input_schema": {"type": "object", "properties": {
+        "status": {"type": "string", "enum": ["success", "gave_up"]},
+        "final_sql": {"type": "string", "description": "The query you are submitting as final."},
+        "claimed_speedup": {"type": "number", "description": "Your measured speedup vs the original."},
+        "summary": {"type": "string", "description": "What you changed and why (or the blocker)."},
+    }, "required": ["status", "final_sql", "summary"]},
+}
+
+# Full tool set, and the subset available in the naive/runaway configuration
+# (no schema-change escape hatch — the runaway fuel).
+SCHEMAS: List[Dict[str, Any]] = [
+    RUN_QUERY, EXPLAIN_QUERY, GET_SCHEMA, CHECK_EQUIVALENCE, PROPOSE_DDL, FINISH,
+]
+RUNAWAY_SCHEMAS: List[Dict[str, Any]] = [
+    RUN_QUERY, EXPLAIN_QUERY, GET_SCHEMA, CHECK_EQUIVALENCE, FINISH,
+]
+NAMES: List[str] = [t["name"] for t in SCHEMAS]
+
+
+@dataclass
+class Action:
+    name: str
+    args: Dict[str, Any]
+    tool_use_id: str
+
+    @property
+    def span_name(self) -> str:
+        return SPAN_NAMES.get(self.name, self.name)
+
+
+def extract_tool_call(resp) -> Optional[Action]:
+    """Return the first tool_use block as an Action, or None (end_turn)."""
+    for block in getattr(resp, "content", []) or []:
+        if getattr(block, "type", None) == "tool_use":
+            return Action(name=block.name, args=dict(block.input or {}), tool_use_id=block.id)
+    return None
+
+
+def to_plain_assistant(resp) -> Dict[str, Any]:
+    """Convert an Anthropic response into a plain-dict assistant message so it is
+    JSON-serialisable (checkpointing) and re-sendable to the API on resume."""
+    content: List[Dict[str, Any]] = []
+    for block in getattr(resp, "content", []) or []:
+        btype = getattr(block, "type", None)
+        if btype == "text" and (block.text or "").strip():
+            content.append({"type": "text", "text": block.text})
+        elif btype == "tool_use":
+            content.append({"type": "tool_use", "id": block.id, "name": block.name,
+                            "input": dict(block.input or {})})
+    if not content:
+        content = [{"type": "text", "text": "(no content)"}]
+    return {"role": "assistant", "content": content}
+
+
+def dispatch(action: Action, env: "ch_env.TuningLabEnv", baseline_sql: str,
+             baseline_signature: Optional[str]) -> "ch_env.Obs":
+    """Execute a read-only environment tool. finish/propose_ddl are handled by
+    the controller (verification / HITL) and never reach here."""
+    if action.name == "run_query":
+        sql = action.args.get("sql", "")
+        obs = env.run_query(sql, settings=action.args.get("settings"))
+        # Auto-verify candidate equivalence against the original query's signature
+        # so every candidate execution carries a semantics_preserved verdict.
+        if obs.ok and baseline_signature is not None:
+            obs.candidate_checked = True
+            obs.equivalent = (obs.signature == baseline_signature)
+            obs.extra["candidate_sql"] = sql
+        return obs
+    if action.name == "explain_query":
+        return env.explain_query(action.args.get("sql", ""))
+    if action.name == "get_schema":
+        return env.get_schema(action.args.get("table", "web_events"))
+    if action.name == "check_equivalence":
+        return env.check_equivalence(baseline_sql, action.args.get("candidate_sql", ""))
+    return ch_env.Obs.error_obs(f"unknown tool '{action.name}'", kind="query")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -389,6 +389,11 @@ services:
       - CLICKHOUSE_DB=tuning_lab
       - CLICKHOUSE_USER=tuner_admin
       - CLICKHOUSE_PASSWORD=tuner_admin123
+      # Without this, the ClickHouse docker entrypoint creates tuner_admin with
+      # access_management=0 (its default for a non-"default" CLICKHOUSE_USER),
+      # so 03_users.sql's CREATE USER/GRANT for tuner_agent fails with
+      # ACCESS_DENIED and the agent's read-only identity is never created.
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -370,6 +370,81 @@ services:
       - vector-rag-models:/root/.cache
 
   # =============================================================================
+  # ClickHouse Tuning Lab — dedicated sandbox for the slow-query-tuner agent
+  # =============================================================================
+  # Disposable CH 26.3 with a deliberately pessimal 30M-row table. The agent's
+  # user (tuner_agent) is SELECT-only with hard quotas; tuner_admin exists only
+  # for seeding and the human-approved DDL path. Langfuse's own ClickHouse is
+  # never touched (same isolation rationale as clickhouse-vectors).
+  # =============================================================================
+  clickhouse-tuning:
+    image: clickhouse/clickhouse-server:26.3
+    container_name: clickhouse-tuning
+    restart: unless-stopped
+    profiles:
+      - demo
+    ports:
+      - "${CLICKHOUSE_TUNING_HTTP_PORT:-8126}:8123"
+    environment:
+      - CLICKHOUSE_DB=tuning_lab
+      - CLICKHOUSE_USER=tuner_admin
+      - CLICKHOUSE_PASSWORD=tuner_admin123
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - clickhouse-tuning-data:/var/lib/clickhouse
+      - ./demos/slow-query-tuner/sql/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--user", "tuner_admin", "--password", "tuner_admin123", "--query", "SELECT 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # =============================================================================
+  # Slow Query Tuner — Autonomous Agent Loop (open-ended plan-act-observe)
+  # =============================================================================
+  # Pattern #7: the agent EXPLAINs/rewrites/re-runs a slow query against the
+  # live tuning lab and decides FOR ITSELF when it is fast enough. Turn count is
+  # unknown in advance; MAX_TURNS / MAX_BUDGET_USD / watchdog are backstops only.
+  # --runaway deliberately trips the Langfuse cost Monitor.
+  #   docker compose --profile demo run --rm slow-query-tuner python main.py --query q1
+  # =============================================================================
+  slow-query-tuner:
+    build:
+      context: ./demos/slow-query-tuner
+    container_name: slow-query-tuner
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-sonnet-4-6}
+      - TEMPERATURE=${TEMPERATURE:-0.2}
+      # Loop backstops (safety rails, NOT the termination mechanism)
+      - TUNER_MAX_TURNS=${TUNER_MAX_TURNS:-15}
+      - TUNER_MAX_BUDGET_USD=${TUNER_MAX_BUDGET_USD:-0.75}
+      - TUNER_WATCHDOG_S=${TUNER_WATCHDOG_S:-600}
+      - TUNER_COMPACT_AFTER=${TUNER_COMPACT_AFTER:-6}
+      # Tuning-lab environment (agent acts as the sandboxed read-only user)
+      - TUNING_CH_HOST=clickhouse-tuning
+      - TUNING_CH_PORT=8123
+      - TUNING_CH_DB=tuning_lab
+      - TUNING_CH_AGENT_USER=tuner_agent
+      - TUNING_CH_AGENT_PASSWORD=tuner_agent123
+      - TUNING_CH_ADMIN_USER=tuner_admin          # used ONLY inside the approved-DDL path
+      - TUNING_CH_ADMIN_PASSWORD=tuner_admin123
+      # Langfuse instrumentation
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
+      - LANGFUSE_HOST=${LANGFUSE_INTERNAL_URL:-http://langfuse-web:3000}
+    profiles:
+      - demo
+    depends_on:
+      clickhouse-tuning:
+        condition: service_healthy
+    volumes:
+      - ./demos/slow-query-tuner:/app     # includes ./checkpoints — state survives `run --rm` for --resume
+
+  # =============================================================================
   # Test Scenarios - Export synthetic conversations for evaluation demos
   # =============================================================================
   # Exports pre-crafted prompt/response pairs that demonstrate evaluation failures:
@@ -607,5 +682,7 @@ volumes:
   langfuse-clickhouse-data:
   # Dedicated ClickHouse for the Agentic RAG native vector store
   clickhouse-vectors-data:
+  # Disposable ClickHouse for the slow-query-tuner tuning lab
+  clickhouse-tuning-data:
   # Model cache shared by vector-rag and agentic-rag (sentence-transformers downloads)
   vector-rag-models:

--- a/evaluators/runaway-loop-guard.ts
+++ b/evaluators/runaway-loop-guard.ts
@@ -1,0 +1,86 @@
+/**
+ * Runaway Loop Guard — code evaluator (live observations)
+ *
+ * Target: the AGENT root observation of `tune-clickhouse-query` traces
+ * (demos/slow-query-tuner). Why code, not LLM-as-a-judge: whether a run ended on
+ * a backstop is a deterministic fact recorded in the trace, not a judgement.
+ *
+ * The autonomous-loop failure mode is a run that never self-terminates and gets
+ * stopped by a cap (error_max_turns / error_max_budget_usd / error_watchdog).
+ * This flags exactly those so the turn-count Monitor and dashboards can slice on
+ * them ("self-assessment failed, the backstop did the stopping").
+ *
+ * Scores:
+ *   cap_terminated       (BOOLEAN)     — run ended on a backstop, not on finish
+ *   termination_class    (CATEGORICAL) — self_completed | self_gave_up |
+ *                                        implicit | blocked | killed | capped | unknown
+ */
+
+type EvaluationContext = {
+  observation: { input: any; output: any; metadata: any };
+  experiment: { itemExpectedOutput: any; itemMetadata: any } | undefined;
+};
+
+type Score = {
+  name: string;
+  value: number | string | boolean;
+  dataType: "NUMERIC" | "CATEGORICAL" | "BOOLEAN" | "TEXT";
+  comment?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type EvaluationResult = { scores: Score[] };
+
+function asObject(value: any): Record<string, any> {
+  if (value == null) return {};
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" ? value : {};
+}
+
+function classOf(reason: string): string {
+  if (reason.startsWith("error_")) return "capped";
+  if (reason === "self_completed") return "self_completed";
+  if (reason === "self_gave_up") return "self_gave_up";
+  if (reason === "self_completed_implicit") return "implicit";
+  if (reason === "blocked_hitl_denied") return "blocked";
+  if (reason === "killed") return "killed";
+  return "unknown";
+}
+
+function evaluate(ctx: EvaluationContext): EvaluationResult {
+  const meta = asObject(ctx.observation.metadata);
+  const out = asObject(ctx.observation.output);
+  const reason: string =
+    meta.termination_reason || out.termination_reason || "unknown";
+
+  const capped = reason.startsWith("error_");
+
+  return {
+    scores: [
+      {
+        name: "cap_terminated",
+        value: capped,
+        dataType: "BOOLEAN",
+        comment: capped
+          ? `Run stopped by a backstop (${reason}) — self-assessment failed.`
+          : `Run self-terminated (${reason}).`,
+      },
+      {
+        name: "termination_class",
+        value: classOf(reason),
+        dataType: "CATEGORICAL",
+        comment: `termination_reason=${reason}`,
+        metadata: {
+          turns_used: meta.turns_used,
+          cost_usd: meta.cost_usd,
+        },
+      },
+    ],
+  };
+}

--- a/scripts/seed-code-evaluators.sh
+++ b/scripts/seed-code-evaluators.sh
@@ -105,6 +105,12 @@ seed_evaluator "credential-leak-guard" "credential-leak" "event" \
 seed_evaluator "response-structure-check" "structure-clean" "event" \
     '[{"type":"stringOptions","value":["GENERATION"],"column":"type","operator":"any of"},{"type":"stringOptions","value":["text-to-sql","vector-rag"],"column":"traceName","operator":"any of"}]' 0
 
+# slow-query-tuner (Pattern #7): flag runs that ended on a backstop instead of
+# self-terminating. Targets the AGENT root observation of tune-clickhouse-query
+# traces; emits cap_terminated (BOOLEAN) + termination_class (CATEGORICAL).
+seed_evaluator "runaway-loop-guard" "cap-terminated" "event" \
+    '[{"type":"stringOptions","value":["AGENT"],"column":"type","operator":"any of"},{"type":"stringOptions","value":["tune-clickhouse-query"],"column":"traceName","operator":"any of"}]' 0
+
 # ─── Experiment evaluators (target: dataset experiment runs) ────────────────
 
 QUALITY_DS=$(dataset_id "coding-assistant-quality")

--- a/scripts/seed-query-tuner-evaluators.sh
+++ b/scripts/seed-query-tuner-evaluators.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Provision an INDEPENDENT managed LLM-as-a-Judge for the slow-query-tuner demo:
+# GOAL DRIFT on the root observation. This complements the loop's own in-run code
+# scores (semantics_preserved, improvement_delta, the 5 trace scores). Goal drift
+# is the one metric that needs an LLM — it catches the classic autonomous-loop
+# failure of optimizing latency by quietly changing the question.
+#
+# The judge receives {original_sql, final_sql, summary} (all flat on the
+# tune-clickhouse-query trace OUTPUT) and scores `goal_drift` 0-1: does the final
+# query still answer the SAME business question the original did?
+#
+# Mechanism mirrors scripts/seed-agentic-rag-evaluators.sh: create a project
+# eval_template + a job_configuration via Postgres upsert (schema-coupled to the
+# langfuse:3 image), time_scope=NEW so only new traces are scored. Idempotent.
+# Self-hosted only (prints UI guidance in cloud mode). Non-fatal.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; cd "$SCRIPT_DIR/.."
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+ok(){ echo -e "  ${GREEN}✓${NC} $1"; }; warn(){ echo -e "  ${YELLOW}⚠${NC} $1"; }; fail(){ echo -e "  ${RED}✗${NC} $1"; exit 1; }
+[ -f .env ] && set -a && source .env && set +a
+
+PG="${LANGFUSE_POSTGRES_CONTAINER:-langfuse-postgres}"
+REDIS="${LANGFUSE_REDIS_CONTAINER:-langfuse-redis}"
+EVAL_MODEL="${LANGFUSE_EVAL_MODEL:-claude-haiku-4-5-20251001}"
+
+echo ""
+echo "Provisioning goal-drift LLM-as-a-Judge for slow-query-tuner..."
+
+if [ "${DEPLOY_MODE:-self-hosted}" = "cloud" ]; then
+  warn "DEPLOY_MODE=cloud — create this judge in the Langfuse UI:"
+  echo "     Evaluators > New evaluator > Custom, target Observations, filter"
+  echo "       type=AGENT, name any-of [tune-clickhouse-query], tags any-of [slow-query-tuner]:"
+  echo "       vars original_sql<-output.original_sql, final_sql<-output.final_sql,"
+  echo "            summary<-output.summary ; score 'goal_drift' (0-1)."
+  echo "     Prompt: 'Does the final query still answer the SAME business question the"
+  echo "             original did? 1 = same question, 0 = drifted.'"
+  exit 0
+fi
+
+docker ps --format '{{.Names}}' | grep -q "^${PG}$" || fail "Postgres ${PG} not running (run ./setup.sh first)"
+pg(){ docker exec -i "$PG" sh -c 'psql -v ON_ERROR_STOP=1 -q -t -A -U "$POSTGRES_USER" -d "$POSTGRES_DB"'; }
+
+PID=$(echo "SELECT project_id FROM api_keys WHERE public_key='${LANGFUSE_PUBLIC_KEY:-pk-lf-1234567890}' LIMIT 1;" | pg)
+PID="${PID:-demo-project}"; ok "Project: ${PID}"
+
+# ── Default eval model (reuse the Anthropic connection setup.sh provisions) ──
+if [ "$(echo "SELECT count(*) FROM default_llm_models WHERE project_id='${PID}';" | pg)" = "0" ]; then
+  LLM_KEY_ID=$(echo "SELECT id FROM llm_api_keys WHERE project_id='${PID}' AND adapter='anthropic' LIMIT 1;" | pg)
+  if [ -n "$LLM_KEY_ID" ]; then
+    echo "INSERT INTO default_llm_models (id, project_id, llm_api_key_id, provider, adapter, model, model_params, created_at, updated_at)
+          SELECT 'default-eval-model-${PID}','${PID}','${LLM_KEY_ID}',provider,adapter,'${EVAL_MODEL}','{}'::jsonb,now(),now()
+          FROM llm_api_keys WHERE id='${LLM_KEY_ID}' ON CONFLICT (project_id) DO NOTHING;" | pg >/dev/null
+    ok "Default eval model set (${EVAL_MODEL})"
+  else
+    warn "No Anthropic LLM connection — run ./setup.sh first; the judge stays blocked until a default eval model exists"
+  fi
+else
+  ok "Default eval model already configured"
+fi
+
+TMPL_ID="qtuner-goal-drift-tmpl"
+JOB_ID="qtuner-goal-drift"
+PROMPT='You audit an automated SQL query optimizer for GOAL DRIFT. Given the ORIGINAL query, the FINAL query the agent submitted, and the agent'"'"'s SUMMARY, decide whether the FINAL query still answers the SAME business question as the ORIGINAL. Optimizing latency is fine; silently changing which question is answered (different columns, filters, grouping, semantics) is goal drift. Score 1.0 if the business question is unchanged, 0.0 if it drifted.
+
+ORIGINAL:
+{{original_sql}}
+
+FINAL:
+{{final_sql}}
+
+AGENT SUMMARY:
+{{summary}}'
+OUTPUT_SCHEMA='{"score":"Float 0-1. 1 = final answers the same business question as the original; 0 = goal drift (different question).","reasoning":"One sentence citing the specific difference, or confirming equivalence."}'
+
+# Create the custom template + config. Degrade to UI guidance if the langfuse:3
+# schema differs (non-fatal — setup.sh calls this with `|| true`).
+create_template() {
+  cat <<SQL | pg >/dev/null 2>&1
+INSERT INTO eval_templates (id, project_id, name, version, prompt, model, provider, model_params, vars, output_schema, type, created_at, updated_at)
+VALUES ('${TMPL_ID}', '${PID}', 'query-tuner-goal-drift', 1,
+        \$QTGD\$${PROMPT}\$QTGD\$,
+        '${EVAL_MODEL}', 'anthropic', '{}'::jsonb,
+        ARRAY['original_sql','final_sql','summary'],
+        \$QTGDS\$${OUTPUT_SCHEMA}\$QTGDS\$::jsonb, 'LLM_AS_JUDGE', now(), now())
+ON CONFLICT (project_id, name, version) DO UPDATE SET prompt=EXCLUDED.prompt, model=EXCLUDED.model, provider=EXCLUDED.provider, vars=EXCLUDED.vars, output_schema=EXCLUDED.output_schema, updated_at=now();
+SQL
+}
+
+FILTER='[{"type":"stringOptions","value":["AGENT"],"column":"type","operator":"any of"},{"type":"stringOptions","value":["tune-clickhouse-query"],"column":"name","operator":"any of"},{"type":"arrayOptions","value":["slow-query-tuner"],"column":"tags","operator":"any of"}]'
+MAPPING='[{"templateVariable":"original_sql","langfuseObject":"event","selectedColumnId":"output","jsonSelector":"original_sql"},{"templateVariable":"final_sql","langfuseObject":"event","selectedColumnId":"output","jsonSelector":"final_sql"},{"templateVariable":"summary","langfuseObject":"event","selectedColumnId":"output","jsonSelector":"summary"}]'
+
+create_config() {
+  cat <<SQL | pg >/dev/null 2>&1
+INSERT INTO job_configurations (id, project_id, job_type, eval_template_id, score_name, filter, target_object, variable_mapping, sampling, delay, status, time_scope, created_at, updated_at)
+VALUES ('${JOB_ID}','${PID}','EVAL','${TMPL_ID}','goal_drift','${FILTER}'::jsonb,'event','${MAPPING}'::jsonb,1.0,0,'ACTIVE',ARRAY['NEW'],now(),now())
+ON CONFLICT (id) DO UPDATE SET eval_template_id=EXCLUDED.eval_template_id, score_name=EXCLUDED.score_name, filter=EXCLUDED.filter, variable_mapping=EXCLUDED.variable_mapping, status='ACTIVE', blocked_at=NULL, block_reason=NULL, block_message=NULL, updated_at=now();
+SQL
+}
+
+if create_template && create_config; then
+  ok "goal_drift → observation-level judge on the tune-clickhouse-query root (time_scope=NEW)"
+  if docker ps --format '{{.Names}}' | grep -q "^${REDIS}$"; then
+    docker exec "$REDIS" redis-cli del \
+      "langfuse:eval:no-event-and-experiment-job-configs:${PID}" \
+      "langfuse:eval:no-trace-and-dataset-job-configs:${PID}" >/dev/null 2>&1 || true
+    ok "Cleared evaluator config cache"
+  fi
+  echo ""
+  ok "Goal-drift judge seeded. Regenerate slow-query-tuner traffic to see it score."
+  echo "  View: ${LANGFUSE_BASE_URL:-http://localhost:3001}/project/${PID}/evals"
+else
+  warn "Could not seed via Postgres (langfuse:3 schema mismatch?). Create it in the UI:"
+  echo "     Evaluators > New evaluator > Custom, target Observations,"
+  echo "       filter type=AGENT name=[tune-clickhouse-query] tags=[slow-query-tuner],"
+  echo "       vars original_sql/final_sql/summary <- output.*, score 'goal_drift' (0-1)."
+fi
+echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -580,6 +580,22 @@ ensure_librechat_agents() {
 }
 
 #######################################
+# Seed the slow-query-tuner demo (Pattern #7): managed prompts, root-level
+# dataset, cost/turn Monitors, and the independent goal-drift judge. Guarded,
+# idempotent, non-fatal (the loop runs with local fallbacks if this is skipped).
+#######################################
+ensure_slow_query_tuner() {
+    if [ ! -d "$SCRIPT_DIR/demos/slow-query-tuner" ]; then
+        return 0
+    fi
+    header "Seeding Slow Query Tuner (prompts, dataset, monitors)"
+
+    docker compose --profile demo run --rm slow-query-tuner \
+        python scripts/seed_all.py || warn "slow-query-tuner seeding skipped"
+    "$SCRIPT_DIR/scripts/seed-query-tuner-evaluators.sh" || true
+}
+
+#######################################
 # Wait for critical services to be healthy
 #######################################
 wait_for_services() {
@@ -852,6 +868,7 @@ main() {
     ensure_llm_judge_evaluators
     ensure_project_name_dict
     ensure_librechat_agents
+    ensure_slow_query_tuner
 
     if [ "$run_seed" = true ]; then
         header "Seeding Demo Data"


### PR DESCRIPTION
## Summary

A new container demo — `demos/slow-query-tuner/` — fills the **Pattern #7 (Autonomous Agent Loop)** gap. An open-ended plan-act-observe agent is handed a ClickHouse SA's task: *"Here is a slow query. Make it at least 5× faster without changing what it returns. You decide how."* It runs a genuinely variable-length loop against a **live ClickHouse tuning lab** — `EXPLAIN`s, rewrites, **executes each candidate for real and reads back measured `elapsed_ms`/`read_rows`/`read_bytes` as ground truth**, verifies result-set equivalence with a deterministic signature, and keeps iterating until *it* decides it's done, hits a structural blocker (→ HITL DDL gate), or a backstop trips.

Contrast demo to the repo's bounded loops: `real-estate` is `MAX_ITERS=5` single-turn Q&A; `agentic-rag` is a predefined graph. Here **the agent decides when it's done**, and the caps are a backstop, not the design. Same engine on both sides of the loop: the environment the agent acts on is ClickHouse, and Langfuse (judging the agent) is on ClickHouse.

## File tree

```
demos/slow-query-tuner/
├── README.md · DEMO_SCRIPT.md (Frame/Show/Land/Ask) · Dockerfile · requirements{,-dev}.txt · pytest.ini
├── main.py            # CLI: --query/--sql/--runaway/--resume/--interactive/--auto-{approve,deny}-ddl/cap overrides
├── agent_loop.py      # THE PATTERN: controller, finish-claim verification, HITL gate, compaction, finalize+scores
├── tools.py           # 6 tool schemas + dispatcher (run_query, explain_query, get_schema, check_equivalence, propose_ddl, finish)
├── ch_env.py          # tuner_agent (RO) + tuner_admin (DDL gate) clients, SQL-shape allow-list, timing, signatures
├── budget.py          # turn/cost/wall-clock caps + kill sentinel; Anthropic price table
├── checkpoint.py      # LoopState + per-turn JSON state (save every turn; --resume reuses session_id)
├── queries.py         # bad-query catalog q1/q2/q3 + expected-turn bands
├── prompts.py         # managed prompts (query-tuner-system v1/v2, query-tuner-goal) + local fallbacks
├── langfuse_config.py # v3 wiring (typed observe(), trace_context(), scores, get_prompt(), flush())
├── sql/init/          # 01 schema (pessimal 30M-row table) · 02 seed (numbers(30e6), deterministic) · 03 users/grants
├── scripts/           # seed_prompts · seed_dataset · seed_monitors · seed_all · run_experiment · run_live_demo
└── tests/             # LLM-free + DB-free: test_budget · test_termination · test_checkpoint · test_ch_env

# Root companions:
evaluators/runaway-loop-guard.ts          # deterministic code evaluator (cap_terminated / termination_class)
scripts/seed-query-tuner-evaluators.sh    # managed goal_drift LLM judge on the trace root

# Shared-file edits (additive):
docker-compose.yaml   # clickhouse-tuning + slow-query-tuner services (demo profile) + clickhouse-tuning-data volume
.env.example          # CLICKHOUSE_TUNING_HTTP_PORT + TUNER_MAX_TURNS/MAX_BUDGET_USD/WATCHDOG_S/COMPACT_AFTER
setup.sh              # ensure_slow_query_tuner() seeding block (guarded, idempotent, non-fatal)
demos/README.md       # demo row; AI_ENGINEERING_LOOP.md: app row + loop mapping
scripts/seed-code-evaluators.sh  # wires runaway-loop-guard.ts onto the tune-clickhouse-query AGENT root
```

## How the pattern is visible in Langfuse

- **Variable-length loop** — one stable trace name `tune-clickhouse-query`; typed observations per turn (`plan-next-action` generation → `run-query`/`explain-query`/… tool → `assess-progress` evaluator). q1 unrolls to ~3 nodes, q2 to ~9 under the *same* name → **Agent Graph Expanded** looks different per run; **Aggregated** collapses to `plan → {tool} → assess ↺`. Low-cardinality names, turn # in metadata.
- **Runaway-cost Monitor** — `--runaway` (naive v1 prompt + impossible 50 ms target + raised caps + `fault:runaway` tag) churns until `error_max_budget_usd`. A `max(totalCost)` Monitor per trace crosses its alert threshold; a second Monitor on the `turns_used` score catches "self-assessment failed, backstop stopped it".
- **Pause/resume** — per-turn checkpoint; SIGINT/kill-sentinel → `killed` + a loadable checkpoint. `--resume <run_id>` restores in a fresh process **reusing the same `session_id`** → Langfuse Sessions stitches both traces into one investigation.
- **Termination reason / turn count / verified speedup are first-class trace scores** (`turns_used`, `run_cost_usd`, `verified_speedup`, `task_completed`, `trajectory_efficiency`), plus span scores `semantics_preserved` + `improvement_delta`.

## Notable decisions / caveats

- **Monitors are a Langfuse v4+ feature; this stack pins v3.** `seed_monitors.py` probes the API and otherwise **prints the exact UI field values** to paste into Monitors → New Monitor (spec-anticipated fallback). Everything else is native on v3.
- **Runaway cost thresholds are spec defaults** ($0.40 warn / $1.00 alert; caps raised to $2.50) — flagged for one calibration pass against real Sonnet pricing (§11 of the spec). Whether budget or turns trips first depends on real per-turn cost; either way the run is cap-terminated and both Monitors/scores fire.
- **No LibreChat agent** — deliberate, documented omission (an unbounded loop with a spend cap shouldn't sit behind a chat box).

## Test plan

Run without the shared stack (LLM-free + DB-free; env is mocked, Anthropic never called):

```bash
cd demos/slow-query-tuner
python -m py_compile *.py scripts/*.py tests/*.py     # all compile
pip install -r requirements-dev.txt && pytest          # 28 passed
```

What ran here and passed:
- `py_compile` on all 13 modules + 5 scripts + 5 test files — OK.
- `pytest` — **28 passed** (caps trip at exact boundaries + kill/SIGINT precedence + cost_of; finish-claim verification accepts true / rejects slow + non-equivalent + bad-SQL claims, gave_up accepted; checkpoint save→load round-trip + JSON-serialisability + atomic write + compaction + progress/plateau bookkeeping; SQL-shape allow-list blocks INSERT/ALTER/CREATE/DROP/TRUNCATE/DELETE/KILL/OPTIMIZE + multi-statement, order-independent signatures).
- Import smoke (no services, no Langfuse keys): all demo modules and all 6 scripts import with `anthropic` absent (lazy-imported), confirming graceful no-service/no-key degradation.
- `main.py --help`, `docker-compose.yaml` YAML parse (new services + volume), `bash -n` on both shell scripts — all OK.

`docker build` of the image was skipped (network-heavy pip install; Dockerfile mirrors the proven agentic-rag pattern). Live end-to-end runs (real Anthropic + live tuning lab) were not executed per the "do not run the shared stack" constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
