### PR TITLE
Fix stale comments claiming Cloud managed judges are UI-only

### DIFF
--- a/demos/real-estate/scripts/seed_managed_evaluators.sh
+++ b/demos/real-estate/scripts/seed_managed_evaluators.sh
@@ -4,15 +4,29 @@
 # AUTOMATICALLY on live traffic (visible under Evaluators).
 #
 # These are Langfuse-native evaluators (not the client-side judges the demo also
-# ships): the Langfuse worker runs them on new traces tagged 'real-estate' using
-# the Anthropic LLM connection you configured, and writes scores back.
+# ships): the Langfuse worker runs them using the Anthropic LLM connection and
+# writes scores back, with no evaluator code in our app.
 #
-# Two modes:
-#   self-hosted (localhost) — managed evaluators have no public REST API, so
-#     like this repo's other evaluator seeders we insert directly into the
-#     Langfuse Postgres. Idempotent.
-#   remote / Langfuse Cloud — no DB access: upsert the LLM connection via the
-#     public API and print the short UI recipe for the judges.
+# BOTH modes provision the judges automatically — there is no manual UI step in
+# either. They differ in mechanism, and in two consequences worth knowing:
+#
+#   self-hosted (localhost)
+#     The stable REST API does not expose `job_configurations`, so — like this
+#     repo's other evaluator seeders — we INSERT into the Langfuse Postgres
+#     directly (also needs a `default_llm_models` row). Trace-level, filtered by
+#     tag `real-estate`. Scores NEW *and* EXISTING matching traces.
+#
+#   remote / Langfuse Cloud
+#     No DB access, so we upsert the Anthropic LLM connection and then create the
+#     two judges via the UNSTABLE evaluation-rules API
+#     (POST /api/public/unstable/evaluation-rules), referencing the
+#     Langfuse-managed evaluator families. Observation-level, filtered to the root
+#     span `handle-concierge-chat-message`. Scores NEW traffic only — a trace
+#     ingested before the rules existed gets nothing, so backfill it from the UI:
+#     Traces -> select -> Actions -> Evaluate.
+#     The printed UI recipe is a FALLBACK, shown only if that API call fails.
+#
+# Both are idempotent: existing rules/configs are detected and left alone.
 #
 # Usage:  ./scripts/seed_managed_evaluators.sh
 set -euo pipefail
@@ -29,9 +43,10 @@ warn(){  printf '  \033[1;33m⚠\033[0m %s\n' "$1"; }
 EXPECTED_PROJECT="${LANGFUSE_PROJECT_NAME:-real-estate}"
 
 # ---- Langfuse Cloud / remote host: no direct DB access ----------------------
-# job_configurations have no public API, so on Cloud the two judges are set up
-# in the UI. We still provision what the API allows (the Anthropic LLM
-# connection) and print the exact remaining steps. Exit 0 so run_demo.sh flows.
+# There is no DB to write, so we do it all over HTTP: upsert the Anthropic LLM
+# connection, then create both judges via the UNSTABLE evaluation-rules API. The
+# UI recipe printed at the end is a FALLBACK for when that API is unavailable —
+# not the normal path. Exit 0 either way so run_demo.sh keeps flowing.
 case "${LANGFUSE_HOST:-http://localhost:3001}" in
   http://localhost*|https://localhost*|http://127.0.0.1*|https://127.0.0.1*)
     ;;  # self-hosted: fall through to DB seeding

--- a/docs/LANGFUSE_INTEGRATION.md
+++ b/docs/LANGFUSE_INTEGRATION.md
@@ -192,7 +192,9 @@ The auto-provisioned judges already filter on these tags (each judge watches its
 | Maintenance | You maintain code | Langfuse maintains |
 | Cost | Your API credits | Langfuse credits (or BYO key) |
 
-**Note**: Langfuse still has no public API for creating evaluators ([GitHub Discussion #8241](https://github.com/orgs/langfuse/discussions/8241)). In self-hosted mode this demo provisions them headlessly anyway (`scripts/seed-llm-judge-evaluators.sh` and `scripts/seed-code-evaluators.sh` seed the same database rows the UI creates); in cloud mode use the UI.
+**Note**: there is no *stable* public API for creating evaluators ([GitHub Discussion #8241](https://github.com/orgs/langfuse/discussions/8241)). In self-hosted mode this demo provisions them headlessly anyway (`scripts/seed-llm-judge-evaluators.sh` and `scripts/seed-code-evaluators.sh` seed the same database rows the UI creates); these main-stack seeders are self-hosted-only and print UI guidance when `DEPLOY_MODE=cloud`.
+
+There *is* an **unstable** evaluation-rules API (`POST /api/public/unstable/evaluation-rules`), and `demos/real-estate/scripts/seed_managed_evaluators.sh` uses it to provision its judges on Langfuse Cloud with no UI steps — see that script's header for the trace-level-vs-observation-level and new-vs-existing-traffic differences between the two mechanisms. So "cloud means clicking in the UI" is true of the main-stack seeders only, not of Langfuse Cloud in general.
 
 ---
 


### PR DESCRIPTION
## Why

`seed_managed_evaluators.sh` described its own pre-#45 behaviour in two places — the file header and an inline comment in the cloud branch:

> remote / Langfuse Cloud — no DB access: upsert the LLM connection via the public API and **print the short UI recipe for the judges**.

> job_configurations have no public API, so **on Cloud the two judges are set up in the UI**.

Both have been wrong since #45. The cloud branch upserts the Anthropic LLM connection and then creates *both judges* via `POST /api/public/unstable/evaluation-rules`. The UI recipe is a **fallback** for when that API is unavailable, not the normal path.

This isn't harmless drift. Reading the header — the natural thing to do — is enough to conclude Cloud needs manual setup, which is the wrong answer to give anyone standing this demo up on Cloud. It caused exactly that mistake in a working session earlier today.

## What the header says now

Both modes provision automatically; they differ in mechanism, and in two consequences worth knowing:

| | self-hosted | Langfuse Cloud |
|---|---|---|
| Mechanism | Postgres `job_configurations` (+ a `default_llm_models` row) | unstable evaluation-rules API |
| Scope | **trace**-level | **observation**-level |
| Filter | tag `real-estate` | root span `handle-concierge-chat-message` |
| Scores | NEW **and** EXISTING traces | **NEW traffic only** |

That last row is the one people trip over: on Cloud the judges look "broken" when the traces simply predate the rules. The fix is the UI backfill — **Traces → select → Actions → Evaluate** — and the header now says so.

## Verification

Re-ran it against Cloud. Output matches the header exactly:

```
Remote Langfuse host detected (https://us.cloud.langfuse.com) — managed evaluators can't be DB-seeded.
  ✓ Project verified: real-estate @ https://us.cloud.langfuse.com
  ✓ Anthropic LLM connection upserted via API
  ✓ Helpfulness rule already present
  ✓ Relevance rule already present
```

`bash -n` clean. Comment-only change — no executable lines touched.

## Also: scoping a related claim in `docs/LANGFUSE_INTEGRATION.md`

It said *"in cloud mode use the UI."* That is **accurate for the main-stack seeders** — `seed-llm-judge-evaluators.sh` gates on `DEPLOY_MODE=cloud` and prints guidance — but it reads as a claim about Langfuse Cloud in general. Now scoped to those seeders, with a pointer to the unstable API the real-estate seeder uses. The `#8241` caveat is retained, narrowed to the *stable* API.

Swept the tracked tree afterwards; no other copies of the claim remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)