### PR TITLE
docs: add the prompt-CI quality gate to the use case catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Lifecycle tasks have project skills in `.agents/skills/` (auto-discovered via
 
 For presenter-facing material, see [docs/SA_FIELD_GUIDE.md](docs/SA_FIELD_GUIDE.md)
 (demo selection, talk track, objections) and [docs/USE_CASES.md](docs/USE_CASES.md)
-(10 use cases with 2-minute demo paths). [docs/README.md](docs/README.md) indexes all
+(11 use cases with 2-minute demo paths). [docs/README.md](docs/README.md) indexes all
 docs by persona.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ See [`.env.example`](.env.example) for the full configuration reference.
 │
 ├── docs/                       # Documentation (docs/README.md = persona-based index)
 │   ├── SA_FIELD_GUIDE.md           # Presenter field guide (demo selection, talk track, Q&A)
-│   ├── USE_CASES.md                # 10 use cases with 2-minute demo paths
+│   ├── USE_CASES.md                # 11 use cases with 2-minute demo paths
 │   ├── QUICKSTART_GUIDE.md
 │   ├── USER_JOURNEY.md
 │   ├── LANGFUSE_DEMO_RUNBOOK.md    # Screen-by-screen demo script (45 min)
@@ -606,7 +606,7 @@ See [`.env.example`](.env.example) for the full configuration reference.
 | Document | Description |
 |----------|-------------|
 | [SA Field Guide](docs/SA_FIELD_GUIDE.md) | **For presenters** — demo selection, talk track, prep checklist, objection handling |
-| [Use Case Catalog](docs/USE_CASES.md) | 10 observability use cases, each with a 2-minute demo path |
+| [Use Case Catalog](docs/USE_CASES.md) | 11 observability use cases, each with a 2-minute demo path |
 | [Demo Runbook](docs/LANGFUSE_DEMO_RUNBOOK.md) | Screen-by-screen 45-min demo script with full talk tracks |
 | [Agentic RAG Demo Runbook](docs/AGENTIC_RAG_DEMO_RUNBOOK.md) | Screen-by-screen Agentic RAG demo script (25 min) |
 | [User Journey](docs/USER_JOURNEY.md) | Hands-on walkthrough of the complete demo |

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Pick your path by what you're trying to do.
 | [Vector RAG Demo Script](../demos/vector-rag/DEMO_SCRIPT.md) | Consultative script for the naive-RAG baseline — tracing, managed prompts, free guardrails, and the designed hand-off to agentic-rag |
 | [Brand-Promo Demo Script](../demos/brand-promo-multi-agent/DEMO_SCRIPT.md) | Consultative script for the multi-agent (LangGraph + CrewAI) fleet demo — 50k-trace scale, persona dashboards, certification gate |
 | [LiteLLM Gateway Demo Script](../demos/litellm-gateway/DEMO_SCRIPT.md) | Short (~5 min) script for the gateway-instrumentation pattern — centralized Langfuse tracing at a LiteLLM proxy, no client SDK, same Frame→Show→Land→Ask flow |
-| [Use Case Catalog](USE_CASES.md) | 10 capabilities, each with a 2-minute demo path; quick-tour combos |
+| [Use Case Catalog](USE_CASES.md) | 11 capabilities, each with a 2-minute demo path; quick-tour combos |
 | [Langfuse Demo Runbook](LANGFUSE_DEMO_RUNBOOK.md) | 45-min screen-by-screen platform demo script with full talk tracks |
 | [Lifecycle Feedback Runbook](LIFECYCLE_FEEDBACK_RUNBOOK.md) | 20-min SA-enablement narrative: one user 👎 → test case → proven prompt fix → CI gate → deploy (pairs with the [Property Concierge script](../demos/real-estate/DEMO_SCRIPT.md)) |
 | [Agentic RAG Demo Runbook](AGENTIC_RAG_DEMO_RUNBOOK.md) | Deep screen-by-screen reference + fallbacks (pairs with the co-located [demo script](../demos/agentic-rag/DEMO_SCRIPT.md)) |

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -95,6 +95,10 @@ labels. Then Playground → load a prompt, run the same input against two models
 side-by-side, tweak the system prompt, re-run. Close the loop: "promote the winner"
 by setting its label — apps fetch by label, so rollout is instant, no deploy.
 
+> Asked "so anyone can promote a prompt straight to production?" — that's
+> [use case 11](#11-cicd-quality-gate-on-prompt-deploys), which puts an eval suite
+> and an exit code in front of the promotion.
+
 ## 7. Agentic RAG observability
 
 **What:** A corrective-RAG (CRAG) agent — retrieve → grade → rewrite/web-fallback →
@@ -166,6 +170,44 @@ SOURCE_LANGFUSE_PUBLIC_KEY=<pk> SOURCE_LANGFUSE_SECRET_KEY=<sk> \
 In the demo: filter traces by `claude-code-demo` → "these are real traces from the AI
 agent that maintains this repo."
 
+## 11. CI/CD quality gate on prompt deploys
+
+**What:** Promoting a prompt version in Langfuse fires a `repository_dispatch`; a
+GitHub Actions workflow re-runs the eval dataset against that version and **fails the
+build** — blocking the deploy job — if any score misses a threshold checked into git.
+**Why customers care:** It answers "what stops a bad prompt reaching our users?" with
+an exit code instead of a process document. Prompts get the same gate as code, and the
+quality bar becomes a reviewable, diffable file.
+
+> **Different prerequisites from every other use case here.** This one lives in the
+> standalone [real-estate demo](../demos/real-estate/) (own `.venv` and `.env`), and it
+> requires **Langfuse Cloud** — a GitHub runner cannot reach a `localhost:3001` stack.
+> It also needs three one-time setup steps (repo secrets, a GitHub PAT, and the
+> Langfuse **Prompts → Automations → GitHub Repository Dispatch** automation), all
+> walked through in [`demos/real-estate/cicd/README.md`](../demos/real-estate/cicd/README.md).
+
+**Demo path:** Open [`cicd/thresholds.json`](../demos/real-estate/cicd/thresholds.json) —
+"the quality bar as code: deterministic checks gated hard (1.0 / 0.95), LLM judges gated
+loose at 0.80 on purpose, because a tight judge threshold gives you flaky builds." Then GitHub
+→ **Actions** → *Langfuse Prompt CI* → a run on the **`first-draft`** label: it's **red**,
+the job summary names the failing check, and the **deploy job never ran**. Re-run on
+`candidate` → green, but deploy is *still* skipped, because that version isn't labelled
+`production` — validated ≠ deployed.
+
+The eval is 18 items of real LLM calls, so start the run before the session (**Run
+workflow** → pick a label) and show the completed one, or rehearse the identical gate
+locally:
+```bash
+cd demos/real-estate && ./.venv/bin/python scripts/prompt_gate.py --prompt-label first-draft   # exits 1
+```
+
+Expect the follow-up "so the gate stops anything bad from shipping?" — no, and
+`thresholds.json` documents why: `tone` is judged on live traffic but is categorical, so
+it can't be averaged into a run-level threshold, and a persona regression structurally
+cannot fail this gate. A gate enforces the dimensions you chose. The 4-minute presenter
+version of this beat, with that counter-argument scripted, is Movement 4 of the
+[Lifecycle Feedback Runbook](LIFECYCLE_FEEDBACK_RUNBOOK.md).
+
 ---
 
 ## Suggested quick-tour combos
@@ -174,3 +216,4 @@ agent that maintains this repo."
 - **Platform team, 15 min:** 1 → 3 → 4 → 5.
 - **Agent-curious, 15 min:** 1 → 7 → 8.
 - **Data team, 15 min:** 1 → 2 → 9.
+- **"How do we ship changes safely?", 15 min:** 5 → 6 → 11 (needs the Cloud-backed real-estate demo).


### PR DESCRIPTION
## Why

The CI/CD half of the Deploy node is documented thoroughly already — [`demos/real-estate/cicd/README.md`](demos/real-estate/cicd/README.md), the [workflow file](.github/workflows/langfuse-prompt-ci.yml), [`thresholds.json`](demos/real-estate/cicd/thresholds.json), the real-estate demo script, and Movement 4 of the [Lifecycle Feedback Runbook](docs/LIFECYCLE_FEEDBACK_RUNBOOK.md).

The one place it was missing is [`docs/USE_CASES.md`](docs/USE_CASES.md) — the doc an SA browses for a self-contained 2-minute beat. Use case 6 (Prompt management) stopped at *"promote the winner by setting its label — apps fetch by label, so rollout is instant, no deploy"* and never mentioned that anything gates the promotion. So the CI/CD story was undiscoverable from the customer-facing catalog.

## What

- **New use case 11 — CI/CD quality gate on prompt deploys.** Same What / Why / Demo path shape as the other ten. The path is `thresholds.json` → red `first-draft` run → skipped deploy job → green-`candidate`-but-still-skipped (validated ≠ deployed), plus the local `prompt_gate.py` rehearsal command.
- **A prerequisites callout**, because this one breaks the file's opening assumption that every path runs on `./setup.sh --seed`: it lives in the standalone real-estate demo (own venv/`.env`) and needs Langfuse **Cloud** — a GitHub runner can't reach `localhost:3001` — plus the three one-time setup steps.
- **The honest caveat**: `tone` is judged on live traffic but is categorical, so it isn't gated and a persona regression structurally cannot fail this gate. Points at Movement 4 of the runbook for the scripted 4-minute version.
- **Cross-reference from use case 6**, and a new `5 → 6 → 11` quick-tour combo flagged as needing the Cloud-backed demo.
- Bumped the "10 use cases" counts in `README.md` (×2), `docs/README.md`, and `CLAUDE.md`.

## Notes for review

- **Appended as 11 rather than inserted after 6** on purpose: [`docs/DASHBOARD.md:32`](docs/DASHBOARD.md#L32) deep-links `USE_CASES.md#9-sql-analytics-directly-on-trace-data`, so renumbering would break that anchor.
- Two deliberate imprecisions, both to match `thresholds.json`'s own demo note: the text says "the job summary names the failing check" rather than naming `avg-language-match` (which was the blocker in 4/4 runs, but the note warns against promising a room which rows will flag), and the code-eval bar is written "1.0 / 0.95" rather than a flat 1.0 — `avg-budget-adherence` and `avg-location-match` sit at 0.95.
- Docs only; no code paths touched. All five new link targets verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)