### PR TITLE
text-to-sql: fix trace fragmentation in langfuse_trace() root-span gap

### DIFF
--- a/demos/text-to-sql/langfuse_config.py
+++ b/demos/text-to-sql/langfuse_config.py
@@ -110,15 +110,30 @@ def langfuse_session(session_id: Optional[str] = None):
 
 @contextmanager
 def langfuse_trace(trace_name="text-to-sql", tags=None):
-    """Context manager that sets trace name and tags for all Langfuse traces within."""
+    """Context manager that sets trace name and tags for all Langfuse traces within.
+
+    ``propagate_attributes`` only stamps *attributes* (name/tags) onto whatever
+    span is active when a new observation starts — it does not itself keep one
+    trace_id alive across sequential, independent top-level calls. The pipeline
+    makes several such calls in a row (``analysis_chain.invoke`` ->
+    ``retrieve_context`` -> ``response_chain.invoke``); with no span already
+    open at each call site, every one of them minted its own ROOT span (and
+    therefore its own trace_id) — same trace name/tags, three separate traces
+    in Langfuse instead of one. Opening one root span here (mirroring
+    ``langfuse_session()`` below) keeps a parent active for the whole block, so
+    every LangChain-driven and manually-instrumented step nests under it as a
+    single trace.
+    """
     if not LANGFUSE_ENABLED:
         yield
         return
 
     try:
-        from langfuse import propagate_attributes
-        with propagate_attributes(trace_name=trace_name, tags=tags or ["text-to-sql", "demo"]):
-            yield
+        from langfuse import get_client, propagate_attributes
+        client = get_client()
+        with client.start_as_current_observation(as_type="span", name=trace_name):
+            with propagate_attributes(trace_name=trace_name, tags=tags or ["text-to-sql", "demo"]):
+                yield
     except Exception as e:
         print(f"Failed to set Langfuse trace context: {e}")
         yield


### PR DESCRIPTION
## Summary
- Every text-to-sql query on `main` currently fragments into 3 disconnected Langfuse traces (analysis / retrieve-context / response) instead of one, because `langfuse_trace()` only calls `propagate_attributes(...)`, which stamps attributes onto whatever span is already active but never opens one itself.
- Found while live-testing 6 unrelated pattern-demo PRs (#54-59) against the real running stack — two of them (#54, #59) independently hit and fixed this exact pre-existing function with a functionally identical patch, confirming it predates all of them.
- Fix: `langfuse_trace()` now opens one root span before entering `propagate_attributes`, mirroring the already-correct `langfuse_session()` helper in the same file.

## Test plan
- [x] Rebuilt `text-to-sql` from this branch, ran `python main.py --interactive` with a real question against the live stack.
- [x] Queried `langfuse-clickhouse` directly (`traces`/`observations` tables) and confirmed one `trace_id` with the full pipeline correctly nested via `parent_observation_id`: root `text-to-sql` span → analysis `RunnableSequence` → `retrieve-context` → response `RunnableSequence`.
- [x] `pytest demos/text-to-sql/tests/` unaffected (these mock Langfuse entirely, which is why this never surfaced before).

🤖 Generated with [Claude Code](https://claude.ai/code)